### PR TITLE
Fix printf errors

### DIFF
--- a/MozillaReality/FirefoxReality/app/src/main/res/values-fr/strings.xml
+++ b/MozillaReality/FirefoxReality/app/src/main/res/values-fr/strings.xml
@@ -488,7 +488,7 @@
 
     <!-- This string is a label above the group of switches that indicates that the switches below
          relate to Firefox data collection and use. -->
-    <string name="security_options_speech_data_collection_title">Collecte et utilisation de données par $1$s</string>
+    <string name="security_options_speech_data_collection_title">Collecte et utilisation de données par %1$s</string>
 
     <!-- This string labels an Allow/Don't Allow switch in the Privacy and Security settings dialog
      and is used to enable or disable permission to collect speech data. -->

--- a/mozilla-lockwise/lockwise-android/app/src/main/res/values-es/strings.xml
+++ b/mozilla-lockwise/lockwise-android/app/src/main/res/values-es/strings.xml
@@ -262,7 +262,7 @@
     <!-- This is the confirmation message title seen when attempting to delete a login. -->
     <string name="delete_this_login">¿Eliminar este inicio de sesión?</string>
     <!-- This is the description for the deletion dialog. -->
-    <string name="delete_description">Se eliminará el inicio de sesión tanto de %$s como de Firefox.</string>
+    <string name="delete_description">Se eliminará el inicio de sesión tanto de %1$s como de Firefox.</string>
     <!-- This is the text on an item in the item detail toolbar menu to edit an entry. -->
     <string name="edit">Editar</string>
     <!-- This is the hint in the edit entry view for the entry name. -->

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-in/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-in/strings.xml
@@ -283,6 +283,6 @@
     <string name="mozac_browser_errorpages_safe_phishing_uri_title">Masalah situs tipuan</string>
     <!-- The %1$s will be replaced by the malicious website URL-->
     <string name="mozac_browser_errorpages_safe_phishing_uri_message"><![CDATA[
-      <p>Laman web di %1$ telah dilaporkan sebagai situs tipuan dan telah diblokir sesuai dengan pengaturan keamanan Anda.</p>
+      <p>Laman web di %1$s telah dilaporkan sebagai situs tipuan dan telah diblokir sesuai dengan pengaturan keamanan Anda.</p>
     ]]></string>
 </resources>

--- a/mozilla-mobile/android-components/components/lib/crash/src/main/res/values-es/strings.xml
+++ b/mozilla-mobile/android-components/components/lib/crash/src/main/res/values-es/strings.xml
@@ -19,5 +19,5 @@
     <string name="mozac_lib_crash_notification_action_report">Informe</string>
 
     <!-- Label of notification showing that the crash report service is running. %1$s will be replaced with the name of the organization (e.g. Mozilla). -->
-    <string name="mozac_lib_send_crash_report_in_progress">Enviar informe de fallos a %$s</string>
+    <string name="mozac_lib_send_crash_report_in_progress">Enviar informe de fallos a %1$s</string>
 </resources>

--- a/mozilla-mobile/fenix/app/src/main/res/values-es/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-es/strings.xml
@@ -25,7 +25,7 @@
     <string name="private_browsing_title">Estás en una sesión privada</string>
     <!-- Explanation for private browsing displayed to users on home view when they first enable private mode
         The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="private_browsing_placeholder">%$s limpia tu historial de búsqueda y navegación cuando cierras una sesión privada
+    <string name="private_browsing_placeholder">%1$s limpia tu historial de búsqueda y navegación cuando cierras una sesión privada
         Aunque no te hace anónimo para los sitios web o proveedor de servicios de Internet, 
         te ayuda a mantener en privado lo que haces en línea frente a cualquier otra persona que use este dispositivo. \n\nMitos comunes sobre la navegación privada
         
@@ -210,7 +210,7 @@
     <!-- Text for displaying the default device name.
         The first parameter is the application name, the second is the device manufacturer name
         and the third is the device model. -->
-    <string name="default_device_name">%s en % s%s</string>
+    <string name="default_device_name">%s en %s %s</string>
 
     <!-- Send Tab -->
     <!-- Name of the "receive tabs" notification channel. Displayed in the "App notifications" system settings for the app -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-sk/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-sk/strings.xml
@@ -650,7 +650,7 @@
     <string name="preferences_delete_browsing_data_browsing_history_title">História</string>
     <!-- Subtitle for the history items in delete browsing data, parameter will be replaced with the
         number of history pages the user has -->
-    <string name="preferences_delete_browsing_data_browsing_history_subtitle">Počet stránok:</string>
+    <string name="preferences_delete_browsing_data_browsing_history_subtitle">Počet stránok: %d</string>
     <!-- Title for the collections item in Delete browsing data -->
     <string name="preferences_delete_browsing_data_collections_title">Kolekcie</string>
     <!-- Subtitle for the collections item in Delete browsing data, parameter will be replaced with the


### PR DESCRIPTION
So, we had a number of bad printfs, hidden because we allow for missing params.

There's exactly one proper use in `android-l10n` right now, https://github.com/mozilla-l10n/android-l10n/blob/9d1b7bd05845a74b120e3a08e73e482cc7787952/mozilla-mobile/fenix/app/src/main/res/values-cs/strings.xml#L547-L549, which translates to "One selected tab".

That makes me wonder if we should enforce full params reference. Sadly, we can't do the zero-width hack we used in the mozilla printf formatter to hide a param.