### PR TITLE
Focus: Switch from 'master' to 'main' branch.

### DIFF
--- a/_meta/mozilla-mobile-focus-android.json
+++ b/_meta/mozilla-mobile-focus-android.json
@@ -1,6 +1,6 @@
 {
   "name": "mozilla-mobile/focus-android",
   "revs": {
-    "master": "62e101a4caa9cac8be4bc71660217bce1c12fc43"
+    "main": "62e101a4caa9cac8be4bc71660217bce1c12fc43"
   }
 }

--- a/config.toml
+++ b/config.toml
@@ -16,5 +16,5 @@
 [[repo]]
     org = "mozilla-mobile"
     name = "focus-android"
-    branch = "master"
+    branch = "main"
 

--- a/mozilla-mobile/focus-android/l10n.toml
+++ b/mozilla-mobile/focus-android/l10n.toml
@@ -106,7 +106,7 @@ locales = [
 # Expose the following branches to localization
 # Changes to this list should be announced to the l10n team ahead of time.
 branches = [
-    "master",
+    "main",
 ]
 
 [env]


### PR DESCRIPTION
Focus switched the default branch from `master` to `main` this week and I forgot that this will need changes here too. :)

CC @Delphine @mathjazz 