### PR TITLE
Change the android-components branch name to main

### DIFF
--- a/mozilla-mobile/android-components/l10n.toml
+++ b/mozilla-mobile/android-components/l10n.toml
@@ -113,7 +113,7 @@ locales = [
 # Expose the following branches to localization
 # Changes to this list should be announced to the l10n team ahead of time.
 branches = [
-    "master",
+    "main",
 ]
 
 [env]


### PR DESCRIPTION
This patch changes the branch for `android-components` to `main`.