### PR TITLE
Change the fenix branch name to main

### DIFF
--- a/mozilla-mobile/fenix/l10n.toml
+++ b/mozilla-mobile/fenix/l10n.toml
@@ -113,7 +113,7 @@ locales = [
 # Expose the following branches to localization
 # Changes to this list should be announced to the l10n team ahead of time.
 branches = [
-    "master",
+    "main",
 ]
 
 [env]


### PR DESCRIPTION
This patch changes the `mozilla-mobile/fenix` branch from `master` to `main`. It should land the day when we do the branch rename in Fenix. This is coordinated by @st3fan - once we've settled on a date we'll let everyone know.