### PR TITLE
Update fenix and a-c branch names in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,12 +1,12 @@
 [[repo]]
     org = "mozilla-mobile"
     name = "android-components"
-    branch = "master"
+    branch = "main"
 
 [[repo]]
     org = "mozilla-mobile"
     name = "fenix"
-    branch = "master"
+    branch = "main"
 
 [[repo]]
     org = "mozilla-lockwise"


### PR DESCRIPTION
This is a config file we missed for the branch rename it updates both the `android-components` and `fenix` branch name.

cc @escapewindow
