### PR TITLE
Adding Hebrew to Focus

### DIFF
--- a/mozilla-mobile/focus-android/l10n.toml
+++ b/mozilla-mobile/focus-android/l10n.toml
@@ -37,6 +37,7 @@ locales = [
   "ga-IE",
   "gl",
   "gu-IN",
+  "he",
   "hi-IN",
   "hr",
   "hsb",

--- a/mozilla-mobile/focus-android/l10n.toml
+++ b/mozilla-mobile/focus-android/l10n.toml
@@ -45,7 +45,7 @@ locales = [
   "hus",
   "hy-AM",
   "ia",
-  "in",
+  "id",
   "it",
   "iw",
   "ixl",


### PR DESCRIPTION
Hebrew already in a-c .TOML file, so only adding to the specific Focus l10n.toml file
CC @ItielMaN . Once this lands I can add Hebrew to Focus for Android