### PR TITLE
Bug 1786793 - part 1: Add firefox-android repository and link it to t…

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,3 +13,7 @@
     name = "focus-android"
     branch = "main"
 
+[[repo]]
+    org = "mozilla-mobile"
+    name = "firefox-android"
+    branch = "ac-prep"


### PR DESCRIPTION
…he ac-prep branch

Blocks https://github.com/mozilla-l10n/android-l10n-tooling/pull/48. This is another attempt in order to avoid disrupting the link between Pontoon and the android-l10n repo (https://github.com/mozilla-l10n/android-l10n/pull/513). I tested the changes on my fork at https://github.com/JohanLorenzo/android-l10n/commit/2e29f4bda793238185735a12dc9af32cac60385a. It enabled me to run `create-l10n-branch` locally. I'm now trying to make it work on Taskcluster.