### PR TITLE
Bug 1786793 - part 2: Link firefox-android to the `main` branch

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,4 +16,4 @@
 [[repo]]
     org = "mozilla-mobile"
     name = "firefox-android"
-    branch = "ac-prep"
+    branch = "main"


### PR DESCRIPTION
Depends on https://github.com/mozilla-l10n/android-l10n/pull/515. Blocks https://github.com/mozilla-l10n/android-l10n-tooling/pull/49