### PR TITLE
Added kaa locale to Firefox Android

### DIFF
--- a/mozilla-mobile/android-components/l10n.toml
+++ b/mozilla-mobile/android-components/l10n.toml
@@ -59,6 +59,7 @@ locales = [
     "it",
     "ja",
     "ka",
+    "kaa",
     "kab",
     "kk",
     "kmr",

--- a/mozilla-mobile/fenix/l10n.toml
+++ b/mozilla-mobile/fenix/l10n.toml
@@ -59,6 +59,7 @@ locales = [
   "it",
   "ja",
   "ka",
+  "kaa",
   "kab",
   "kk",
   "kmr",


### PR DESCRIPTION
Adds [Karakalpak](https://pontoon.mozilla.org/kaa/) locale to fenix and a-c