### PR TITLE
Remove _meta directory

### DIFF
--- a/_meta/mozilla-mobile-android-components.json
+++ b/_meta/mozilla-mobile-android-components.json
@@ -1,6 +1,0 @@
-{
-  "name": "mozilla-mobile/android-components",
-  "revs": {
-    "main": "96444ddbd36acf0987ca531574187647bc74b5f3"
-  }
-}

--- a/_meta/mozilla-mobile-fenix.json
+++ b/_meta/mozilla-mobile-fenix.json
@@ -1,6 +1,0 @@
-{
-  "name": "mozilla-mobile/fenix",
-  "revs": {
-    "main": "982f26b026c2621d4d23d306b0aff949ff407f06"
-  }
-}

--- a/_meta/mozilla-mobile-firefox-android-android-components.json
+++ b/_meta/mozilla-mobile-firefox-android-android-components.json
@@ -1,6 +1,0 @@
-{
-  "name": "mozilla-mobile/firefox-android/android-components",
-  "revs": {
-    "main": "4a45842d38fd47c4e7ff77e53825f7eb8a94a179"
-  }
-}

--- a/_meta/mozilla-mobile-firefox-android-focus-android.json
+++ b/_meta/mozilla-mobile-firefox-android-focus-android.json
@@ -1,6 +1,0 @@
-{
-  "name": "mozilla-mobile/firefox-android/focus-android",
-  "revs": {
-    "main": "05da0304685bf0a1949ae04b5914594512e6848f"
-  }
-}

--- a/_meta/mozilla-mobile-firefox-android.json
+++ b/_meta/mozilla-mobile-firefox-android.json
@@ -1,6 +1,0 @@
-{
-  "name": "mozilla-mobile/firefox-android",
-  "revs": {
-    "main": "6405a457bad3ceebc02065d3c1eb81ce3a920b48"
-  }
-}

--- a/_meta/mozilla-mobile-focus-android.json
+++ b/_meta/mozilla-mobile-focus-android.json
@@ -1,6 +1,0 @@
-{
-  "name": "mozilla-mobile/focus-android",
-  "revs": {
-    "main": "a9a09b171665081b4e5f4d426f0e30f22f84ae49"
-  }
-}


### PR DESCRIPTION
The _meta directory is no longer necessary since the android-l10n-tooling is now deprecated.