### PR TITLE
Bug 1854662 - Remove some unused AC strings

### DIFF
--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-az/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-az/strings.xml
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- The default document title of an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_page_title">Səhifə yüklənmə xətası</string>
-
     <!-- The button that appears at the bottom of an error page. -->
     <string name="mozac_browser_errorpages_page_refresh">Təkrar Yoxla</string>
-
-    <!-- The button that appears at the bottom of an error page. -->
-    <string name="mozac_browser_errorpages_page_go_back">Geri Get</string>
 
     <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_title">İstək yerinə yetirilə bilmir</string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-be/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-be/strings.xml
@@ -57,10 +57,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Дадаткова…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> мае палітыку бяспекі, што называецца HTTP Strict Transport Security (HSTS), і гэта азначае, што <b>%2$s</b> можа звязвацца з ім толькі абароненым злучэннем. Вы не можаце дадаць выключэнне для наведвання гэтага сайта.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> мае палітыку бяспекі, што называецца HTTP Strict Transport Security (HSTS), і гэта азначае, што <b>%2$s</b> можа звязвацца з ім толькі абароненым злучэннем. Вы не можаце дадаць выключэнне для наведвання гэтага сайта. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-bg/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-bg/strings.xml
@@ -46,8 +46,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Разширени…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[<label> <b>%1$s</b> използва политика за сигурност наречена HTTP Strict Transport Security (HSTS), което означава, че <b>%2$s</b> може да използва само сигурни връзки. Не може да добавяте изключение при посещение на тази страница.]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[<label> <b>%1$s</b> използва политика за сигурност наречена HTTP Strict Transport Security (HSTS), което означава, че <b>%2$s</b> може да използва само сигурни връзки. Не може да добавяте изключение при посещение на тази страница.</label>]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_back">Назад</string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-br/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-br/strings.xml
@@ -60,10 +60,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Kempleshoc’h…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> a zo gantañ ur politikerezh surentez anvet HTTP Strict Transport Security (HSTS), pezh a dalv ne c’hall <b>%2$s</b> kevreañ outañ nemet en un doare sur. Ne c’hallit ket ouzhpennañ un nemedenn evit gweladenniñ al lec’hienn-mañ.
-        ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> a zo gantañ ur politikerezh surentez anvet HTTP Strict Transport Security (HSTS), pezh a dalv ne c’hall <b>%2$s</b> kevreañ outañ nemet en un doare sur. Ne c’hallit ket ouzhpennañ un nemedenn evit gweladenniñ al lec’hienn-mañ. </label>
         ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-bs/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-bs/strings.xml
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- The default document title of an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_page_title">Greška pri učitavanju stranice</string>
-
     <!-- The button that appears at the bottom of an error page. -->
     <string name="mozac_browser_errorpages_page_refresh">Pokušaj ponovo</string>
-
-    <!-- The button that appears at the bottom of an error page. -->
-    <string name="mozac_browser_errorpages_page_go_back">Idi nazad</string>
 
     <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_title">Nije moguće dovršiti zahtjev</string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-ca/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-ca/strings.xml
@@ -58,9 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avançat…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[<label><b>%1$s</b> té una política de seguretat anomenada «HTTP Strict Transport Security» (Seguretat estricta de transport HTTP, o HSTS), que vol dir que el <b>%2$s</b> només pot connectar-s’hi de forma segura. No podeu afegir cap excepció per visitar aquest lloc.
-]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[<label><b>%1$s</b> té una política de seguretat anomenada «HTTP Strict Transport Security» (Seguretat estricta de transport HTTP, o HSTS), que vol dir que el <b>%2$s</b> només pot connectar-s’hi de forma segura. No podeu afegir cap excepció per visitar aquest lloc.</label>
 
 ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-cak/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-cak/strings.xml
@@ -54,11 +54,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Q\'axinäq…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
- <label> <b>%1$s</b>k\'o jun runa\'ojil jikomal b\'ina\'am HTTP Jikïl Ruk\'waxik Jikomal (HSTS), ri nuq\'ajuj chi ri <b>%2$s</b> xa xe nitikïr nok pa ütz jikomal. Man yatikïr ta natz\'aqatisaj jun man relik ta richin natz\'ët re ruxaq re\'.
-
-]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
  <label> <b>%1$s</b>k\'o jun runa\'ojil jikomal b\'ina\'am HTTP Jikïl Ruk\'waxik Jikomal (HSTS), ri nuq\'ajuj chi ri <b>%2$s</b> xa xe nitikïr nok pa ütz jikomal. Man yatikïr ta natz\'aqatisaj jun man relik ta richin natz\'ët re ruxaq re\'. </label>
 

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-co/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-co/strings.xml
@@ -58,10 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Espertu…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> impiega una strategia di sicurità chjamata HTTP Strict Transport Security (HSTS), vole si dì chì <b>%2$s</b> pò solu ci cunnettesi di manera assicurizata. Ùn pudete micca aghjunghje un’eccezzione per visità stu situ.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> impiega una strategia di sicurità chjamata HTTP Strict Transport Security (HSTS), vole si dì chì <b>%2$s</b> pò solu ci cunnettesi di manera assicurizata. Ùn pudete micca aghjunghje un’eccezzione per visità stu situ. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-cy/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-cy/strings.xml
@@ -59,10 +59,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Uwch…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        Mae gan <label> <b>%1$s</b> bolisi diogelwch o’r enw HTTP Strict Transport Security (HSTS), sy’n golygu mai dim ond yn ddiogel y gall <b>%2$s</b> gysylltu ag ef. Ni allwch ychwanegu eithriad i ymweld â’r wefan hon.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
  Mae gan <label> <b>%1$s</b> bolisi diogelwch o’r enw HTTP Strict Transport Security (HSTS), sy’n golygu mai dim ond yn ddiogel y gall <b>%2$s</b> gysylltu ag ef. Ni allwch ychwanegu eithriad i ymweld â’r wefan hon. </label>
 ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-da/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-da/strings.xml
@@ -62,10 +62,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avanceret…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> bruger en sikkerhedspolitik kaldet HTTP Strict Transport Security (HSTS), hvilket betyder at <b>%2$s</b> kun kan oprette en sikker forbindelse til webstedet. Du kan ikke tilføje en undtagelse for at besøge webstedet.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> bruger en sikkerhedspolitik kaldet HTTP Strict Transport Security (HSTS), hvilket betyder, at <b>%2$s</b> kun kan oprette en sikker forbindelse til webstedet. Du kan ikke tilføje en undtagelse for at besøge webstedet. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-de/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-de/strings.xml
@@ -57,10 +57,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Erweitert…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> hat eine Sicherheitsrichtlinie namens HTTP Strict Transport Security (HSTS), was bedeutet, dass sich <b>%2$s</b> nur über eine sichere Verbindung mit der Website verbinden kann. Daher kann keine Ausnahme für die Website hinzugefügt werden.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> hat eine Sicherheitsrichtlinie namens HTTP Strict Transport Security (HSTS), was bedeutet, dass sich <b>%2$s</b> nur über eine sichere Verbindung mit der Website verbinden kann. Daher kann keine Ausnahme für die Website hinzugefügt werden.</label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-dsb/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-dsb/strings.xml
@@ -60,10 +60,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Rozšyrjony…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> ma wěstotne pšawidło z mjenim HTTP Strict Transport Security (HSTS), kótarež wóznamjenijo, až <b>%2$s</b> móžo se jano wěsće zwězaś. Njamóžśo wuwześe pśidaś, aby se k toś tomu sedłoju woglědał.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> ma wěstotne pšawidło z mjenim HTTP Strict Transport Security (HSTS), kótarež wóznamjenijo, až <b>%2$s</b> móžo se jano wěsće zwězaś. Njamóžśo wuwześe pśidaś, aby se k toś tomu sedłoju woglědał. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-el/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-el/strings.xml
@@ -58,10 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Σύνθετα…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> Το <b>%1$s</b> διαθέτει μια πολιτική ασφαλείας, η οποία ονομάζεται «HTTP Strict Transport Security» (HSTS), που σημαίνει ότι το <b>%2$s</b> μπορεί να συνδεθεί μόνο με ασφάλεια σε αυτό. Δεν μπορείτε να προσθέσετε εξαίρεση για να επισκεφθείτε τον ιστότοπο αυτό.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> Το <b>%1$s</b> διαθέτει μια πολιτική ασφαλείας, η οποία ονομάζεται «HTTP Strict Transport Security (HSTS)», που σημαίνει ότι το <b>%2$s</b> μπορεί να συνδεθεί μόνο με ασφάλεια σε αυτό. Δεν μπορείτε να προσθέσετε εξαίρεση για να επισκεφθείτε τον ιστότοπο αυτό. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-en-rCA/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-en-rCA/strings.xml
@@ -60,10 +60,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Advanced…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> has a security policy called HTTP Strict Transport Security (HSTS), which means that <b>%2$s</b> can only connect to it securely. You can’t add an exception to visit this site.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label><b>%1$s</b> has a security policy called HTTP Strict Transport Security (HSTS), which means that <b>%2$s</b> can only connect to it securely. You can’t add an exception to visit this site.</label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-en-rGB/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-en-rGB/strings.xml
@@ -59,10 +59,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Advanced…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> has a security policy called HTTP Strict Transport Security (HSTS), which means that <b>%2$s</b> can only connect to it securely. You can’t add an exception to visit this site.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> has a security policy called HTTP Strict Transport Security (HSTS), which means that <b>%2$s</b> can only connect to it securely. You can’t add an exception to visit this site. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-eo/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-eo/strings.xml
@@ -55,10 +55,6 @@ la eraro povas esti tempa kaj vi povos klopodi denove poste.</li>
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Spertula…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> havas sekurecan politikon, kiun oni nomas HTTP Strict Transport Security (HSTS), kiu signifas ke <b>%2$s</b> nur povas konektiĝi per sekura konekto. Vi ne povas aldoni escepton por viziti la retejon.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> havas sekurecan politikon, kiun oni nomas HTTP Strict Transport Security (HSTS), kiu signifas ke <b>%2$s</b> nur povas konektiĝi per sekura konekto. Vi ne povas aldoni escepton por viziti la retejon.</label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-es-rAR/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-es-rAR/strings.xml
@@ -58,10 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avanzadas…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> tiene una política de seguridad llamada HTTP Strict Transport Security (HSTS), lo que se traduce en que <b>%2$s</b> solo puede conectarse de forma segura. No podés añadir una excepción para visitar este sitio.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> tiene una política de seguridad llamada HTTP Strict Transport Security (HSTS), lo que significa que <b>%2$s</b> solo puede conectarse de forma segura. No podés añadir una excepción para visitar este sitio.</label>]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-es-rCL/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-es-rCL/strings.xml
@@ -61,10 +61,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avanzado…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> tiene una política de seguridad llamada HTTP Strict Transport Security (HSTS), lo que se traduce en que <b>%2$s</b> solo puede conectarse de forma segura. No puedes añadir una excepción para visitar este sitio.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> tiene una política de seguridad llamada HTTP Strict Transport Security (HSTS), lo que se traduce en que <b>%2$s</b> solo puede conectarse de forma segura. No puedes añadir una excepción para visitar este sitio.</label>]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-es-rES/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-es-rES/strings.xml
@@ -58,10 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avanzadas…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-<label><b>%1$s</b> tiene una política de seguridad llamada HTTP Strict Transport Security (HSTS), que significa que <b>%2$s</b> solo puede conectarse a él de forma segura. No puedes añadir una excepción para visitar este sitio.
-]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
  <label><b>%1$s</b> tiene una política de seguridad llamada HTTP Strict Transport Security (HSTS), que significa que <b>%2$s</b> solo puede conectarse a él de forma segura. No puedes añadir una excepción para visitar este sitio.</label>
  ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-es-rMX/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-es-rMX/strings.xml
@@ -51,10 +51,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Opciones avanzadas…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> tiene una política de segurdad llamada HTTP Strict Transport Security (HSTS), lo que significa que <b>%2$s</b> solo puede conectarse de forma segura. No puedes agregar una excepción para visitar este sitio.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> tiene una política de seguridad llamada HTTP Strict Transport Security (HSTS), lo que significa que <b>%2$s</b> solo puede conectarse de forma segura. No puedes agregar una excepción para visitar este sitio. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-es/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-es/strings.xml
@@ -58,10 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avanzadas…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-<label><b>%1$s</b> tiene una política de seguridad llamada HTTP Strict Transport Security (HSTS), que significa que <b>%2$s</b> solo puede conectarse a él de forma segura. No puedes añadir una excepción para visitar este sitio.
-]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
  <label><b>%1$s</b> tiene una política de seguridad llamada HTTP Strict Transport Security (HSTS), que significa que <b>%2$s</b> solo puede conectarse a él de forma segura. No puedes añadir una excepción para visitar este sitio.</label>
  ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-et/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-et/strings.xml
@@ -53,10 +53,6 @@ ja sa võid hiljem uuesti proovida.</li>
 
     <!-- The text shown inside the advanced button used to expand the advanced options. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Edasijõudnuile…</string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo"><![CDATA[
-        <label>Sait <b>%1$s</b> kasutab HTTP Strict Transport Security (HSTS) turvaprotokolli, mis tähendab, et <b>%2$s</b> saab sellega ühenduda ainult turvaliselt. Selle saidi külastamiseks pole võimalik erandit lisada.
-    ]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_back">Mine tagasi</string>
 

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-eu/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-eu/strings.xml
@@ -61,10 +61,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Aurreratua…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> webguneak HTTP Strict Transport Security (HSTS) izeneko segurtasun-politika dauka eta beraz <b>%2$s</b> aplikazioa modu seguruan konekta daiteke soilik. Ezin duzu gune hau bisitatzeko salbuespenik gehitu.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> webguneak HTTP Strict Transport Security (HSTS) izeneko segurtasun-politika dauka eta beraz <b>%2$s</b> aplikazioa modu seguruan konekta daiteke soilik. Ezin duzu gune hau bisitatzeko salbuespenik gehitu. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-fi/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-fi/strings.xml
@@ -59,10 +59,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Lisäasetukset…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> noudattaa tietoturvakäytäntöä nimeltä HTTP Strict Transport Security (HSTS), mikä tarkoittaa, että <b>%2$s</b> voi muodostaa siihen vain suojatun yhteyden. Tälle sivustolle siirtymistä varten ei voi lisätä poikkeusta.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> noudattaa tietoturvakäytäntöä nimeltä HTTP Strict Transport Security (HSTS), mikä tarkoittaa, että <b>%2$s</b> voi muodostaa vain suojatun yhteyden. Tälle sivustolle siirtymistä varten ei voi lisätä poikkeusta. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-fr/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-fr/strings.xml
@@ -57,8 +57,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avancé…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[<label> <b>%1$s</b> a recours à une stratégie de sécurité HTTP Strict Transport Security (HSTS), ce qui signifie que <b>%2$s</b> doit impérativement établir une connexion sécurisée pour y accéder. Vous ne pouvez pas ajouter d’exception pour accéder à ce site.]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[<label> <b>%1$s</b> a recours à une stratégie de sécurité HTTP Strict Transport Security (HSTS), ce qui signifie que <b>%2$s</b> doit impérativement établir une connexion sécurisée pour y accéder. Vous ne pouvez pas ajouter d’exception pour accéder à ce site.</label>]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_back">Retour</string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-fy-rNL/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-fy-rNL/strings.xml
@@ -74,11 +74,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avansearre…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> hat in befeiligingsbelied mei de namme HTTP Strict Transport Security (HSTS), wat betsjut dat <b>%2$s</b> allinnich in befeilige ferbining dêrmei meitsje kin. Jo kinne gjin útsûndering tafoegje om dizze website te besykjen.
-
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> hat in befeiligingsbelied mei de namme HTTP Strict Transport Security (HSTS), wat betsjut dat <b>%2$s</b> allinnich in befeilige ferbining dêrmei meitsje kin. Jo kinne gjin útsûndering tafoegje om dizze website te besykjen. </label>
 

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-ga-rIE/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-ga-rIE/strings.xml
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- The default document title of an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_page_title">Fadhb i rith lódáil an leathanaigh</string>
-
     <!-- The button that appears at the bottom of an error page. -->
     <string name="mozac_browser_errorpages_page_refresh">Bain Triail Eile As</string>
-
-    <!-- The button that appears at the bottom of an error page. -->
-    <string name="mozac_browser_errorpages_page_go_back">Ar Ais</string>
 
     <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_title">Ní féidir an t-iarratas a chríochnú</string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-gd/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-gd/strings.xml
@@ -51,11 +51,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Adhartach…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> Tha poileasaidh tèarainteachd aig <b>%1$s</b> air a bheil HTTP Strict Transport Security (HSTS), agus is ciall dha sin nach urrainn dha <b>%2$s</b> ach ceangal tèarainte a dhèanamh. Chan urrainn dhut eisgeachd a chur ris a thadhal air an làrach seo.
-    ]]></string>
-
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> Tha poileasaidh tèarainteachd aig <b>%1$s</b> air a bheil HTTP Strict Transport Security (HSTS), agus is ciall dha sin nach urrainn dha <b>%2$s</b> ach ceangal tèarainte a dhèanamh. Chan urrainn dhut eisgeachd a chur ris a thadhal air an làrach seo.</label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-gu-rIN/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-gu-rIN/strings.xml
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- The default document title of an error page (i.e., the contents of the `<title>` tag). -->
-    <string name="mozac_browser_errorpages_page_title">પાનું લોડ કરવામાં સમસ્યા</string>
-
     <!-- The button that appears at the bottom of an error page. -->
     <string name="mozac_browser_errorpages_page_refresh">ફરીથી પ્રયત્ન કરો</string>
-
-    <!-- The button that appears at the bottom of an error page. -->
-    <string name="mozac_browser_errorpages_page_go_back">પાછા જાવ</string>
 
     <!-- The document title and heading of an error page shown when a website cannot be loaded for an unknown reason. -->
     <string name="mozac_browser_errorpages_generic_title">વિનંતી પૂર્ણ કરી શકાતી નથી</string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-hr/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-hr/strings.xml
@@ -52,10 +52,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Napredno…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> provodi sigurnosnu politiku pod nazivom HTTP Strict Transport Security (HSTS), koja znači da se <b>%2$s</b> može na istu povezati samo sigurno. Ne možete dodati iznimku za posjete ovoj web stranici.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> provodi sigurnosnu politiku pod nazivom HTTP Strict Transport Security (HSTS), koja znači da se <b>%2$s</b> može na istu povezati samo sigurno. Ne možete dodati iznimku za posjete ovoj web stranici. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-hsb/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-hsb/strings.xml
@@ -58,10 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Rozšěrjeny…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> ma wěstotne prawidło z mjenom HTTP Strict Transport Security (HSTS), kotrež woznamjenja, zo <b>%2$s</b> móže so jenož wěsće zwjazać. Njemóžeće wuwzaće přidać, zo byšće tute sydło wopytał.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> ma wěstotne prawidło z mjenom HTTP Strict Transport Security (HSTS), kotrež woznamjenja, zo <b>%2$s</b> móže so jenož wěsće zwjazać. Njemóžeće wuwzaće přidać, zo byšće tute sydło wopytał. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-hu/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-hu/strings.xml
@@ -47,10 +47,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Speciális…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label>A(z) <b>%1$s</b> oldal a HTTP Strict Transport Security (HSTS) nevű biztonsági házirendet használja, amely azt jelenti, hogy a(z) <b>%2$s</b> csak biztonságosan kapcsolódhat hozzá. Nem adhat hozzá kivételt, hogy felkeresse ezt az oldalt.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label>A(z) <b>%1$s</b> oldal a HTTP Strict Transport Security (HSTS) nevű biztonsági házirendet használja, amely azt jelenti, hogy a(z) <b>%2$s</b> csak biztonságosan kapcsolódhat hozzá. Nem adhat hozzá kivételt, hogy felkeresse ezt az oldalt. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-hy-rAM/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-hy-rAM/strings.xml
@@ -53,9 +53,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Լրացուցիչ…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b>-ը ունի անվտանգության քաղաքականություն, որը կոչվում է HTTP Strict Transport Security (HSTS): Այն նշանակում է, որ <b>%2$s</b>-ը կարող է միայն անվտանգ կապակցում անել: Տվյալ կայքը այցելելու համար դուք չեք կարող բացառություն սահմանել:]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b>-ը ունի անվտանգության քաղաքականություն, որը կոչվում է HTTP Strict Transport Security (HSTS), ինչը նշանակում է, որ <b>%2$s</b>-ը կարող է դրան միմիայն անվտանգ կապակցվել: Դուք չեք կարող բացառություն ավելացնել տվյալ էջն այցելելու համար: </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-in/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-in/strings.xml
@@ -60,10 +60,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Tingkat lanjut…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> memiliki kebijakan keamanan yang disebut HTTP Strict Transport Security (HSTS), yang berarti <b>%2$s</b> hanya dapat terhubung dengan aman. Anda tidak dapat menambahkan pengecualian untuk mengunjungi situs ini.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> memiliki kebijakan keaman yang disebut HTTP Strict Transport Security (HSTS), yang berarti <b>%2$s</b> hanya dapat terhubung dengan aman. Anda tidak dapat menambahkan pengecualian untuk mengunjungi situs ini. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-is/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-is/strings.xml
@@ -55,9 +55,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Ítarlegt…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-         · <label> <b>%1$s</b> er með öryggisstefnu sem kallast HTTP Strict Transport Security (HSTS), sem þýðir að <b>%2$s</b> getur aðeins tengst því á öruggan hátt. Þú getur ekki bætt við undantekningu til að heimsækja þetta vefsvæði.]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
          · <label> <b>%1$s</b> er með öryggisstefnu sem kallast HTTP Strict Transport Security (HSTS), sem þýðir að <b>%2$s</b> getur aðeins tengst því á öruggan hátt. Þú getur ekki bætt við undantekningu til að heimsækja þetta vefsvæði.</label>]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-it/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-it/strings.xml
@@ -58,8 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avanzate…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[<label><b>%1$s</b> utilizza un criterio di sicurezza chiamato HTTP Strict Transport Security (HSTS). Questo significa che <b>%2$s</b> può connettersi solo in modo sicuro e non è possibile aggiungere un’eccezione per visitare questo sito.]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[<label><b>%1$s</b> utilizza un criterio di sicurezza chiamato HTTP Strict Transport Security (HSTS). Questo significa che <b>%2$s</b> può connettersi solo in modo sicuro e non è possibile aggiungere un’eccezione per visitare questo sito.</label>]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_back">Torna indietro</string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-iw/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-iw/strings.xml
@@ -58,8 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">מתקדם…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[<label> ל־<b>%1$s</b> יש מדיניות אבטחה בשם אבטחת תעבורה מחמירה של HTTP ‏(HSTS), כלומר <b>%2$s</b> יכול להתחבר לאתר באופן מאובטח בלבד. לא ניתן להוסיף חריגה כדי לבקר באתר זה.]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[<label> ל־<b>%1$s</b> יש מדיניות אבטחה בשם אבטחת תעבורה מחמירה של HTTP ‏(HSTS), כלומר <b>%2$s</b> יכול להתחבר לאתר באופן מאובטח בלבד. לא ניתן להוסיף חריגה כדי לבקר באתר זה.</label>]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_back">חזרה אחורה</string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-ja/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-ja/strings.xml
@@ -56,10 +56,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">詳細情報...</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-  <label> <b>%1$s</b> には HTTP Strict Transport Security (HSTS) と呼ばれるセキュリティポリシーが設定されており、<b>%2$s</b> は安全な接続でしか通信できません。そのため、このサイトを例外に追加することはできません。
-]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
   <label> <b>%1$s</b> には HTTP Strict Transport Security (HSTS) と呼ばれるセキュリティポリシーが設定されており、<b>%2$s</b> は安全な接続でしか通信できません。そのため、このサイトを例外に追加することはできません。</label>
 ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-kaa/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-kaa/strings.xml
@@ -61,10 +61,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Qosımsha…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> HTTP qatań transport qáwipsizligi (HSTS) dep atalǵan qáwipsizlik siyasatına iye, yaǵnıy <b>%2$s</b> oǵan tek ǵana qáwipsiz jalǵanıwı múmkin. Bul saytqa kiriw ushın esaptan tısqarılardı qosa almaysız.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> HTTP qatań transport qáwipsizligi (HSTS) dep atalǵan qáwipsizlik siyasatına iye, yaǵnıy <b>%2$s</b> oǵan tek ǵana qáwipsiz jalǵanıwı múmkin. Bul saytqa kiriw ushın esaptan tısqarılardı qosa almaysız.</label>]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-kab/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-kab/strings.xml
@@ -57,10 +57,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Talqayt…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> ɣur-s tasertit n tɣellist HTTP Strict Transport Security (HSTS), ay-agi yemmal-d d akken <b>%2$s</b> izmer kan ad iqqen ɣur-s s tɣellist. Ur tezmireḍ ara ad ternuḍ tasureft akken ad twaliḍ asmel-agi.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> ɣur-s tasertit n tɣellist HTTP Strict Transport Security (HSTS), ay-agi yemmal-d d akken <b>%2$s</b> izmer kan ad iqqen ɣur-s s tɣellist. Ur tezmireḍ ara ad ternuḍ tasureft akken ad twaliḍ asmel-agi.</label>]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-kk/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-kk/strings.xml
@@ -53,10 +53,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Қосымша…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> сайтының HTTP Strict Transport Security (HSTS) деп аталатын қауіпсіздік саясаты бар, бұл дегеніміз, <b>%2$s</b> оған тек қауіпсіз түрде байланыса алады. Бұл веб-сайт үшін ережеден тыс жағдайды қоса алмайсыз.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> сайтының HTTP Strict Transport Security (HSTS) деп аталатын қауіпсіздік саясаты бар, бұл дегеніміз, <b>%2$s</b> оған тек қауіпсіз түрде байланыса алады. Бұл веб-сайт үшін ережеден тыс жағдайды қоса алмайсыз.</label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-kmr/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-kmr/strings.xml
@@ -61,11 +61,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Pêşketî…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> polîtîkayeke ewlekariyê heye ku navê wê HTTP Strict Transport Security (HSTS) ango Ewlekariya Transporta Guvaştî ye, loma <b>%2$s</b> dikare tenê gava ewle be peywendiyê çêke. Tu nikarî ji bo vekirina vê malperê îstisnayan lê zêde bikî.
-    ]]></string>
-
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> rêgezeke ewlekariyê ya bi navê Ewlekariya Jidandî ya Guheztinê ya HTTPê (HSTS) heye û loma <b>%2$s</b> dikare tenê di rewşeke ewle de bi malperê re têkiliyê dayne. Tu nikarî zêdekariyan bidiyê û têkeviyê.</label>
      ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-ko/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-ko/strings.xml
@@ -57,10 +57,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">고급…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> 사이트는 HTTP Strict Transport Security (HSTS)라는 보안 정책을 가지고 있어서 <b>%2$s</b>가 보안 연결만 할 수 있습니다. 이 사이트를 방문하기 위해 예외를 추가 할 수 없습니다.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> 사이트는 HTTP Strict Transport Security (HSTS)라는 보안 정책을 가지고 있어서 <b>%2$s</b>가 보안 연결만 할 수 있습니다. 이 사이트를 방문하기 위해 예외를 추가 할 수 없습니다. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-lo/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-lo/strings.xml
@@ -63,10 +63,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">ຂັ້ນສູງ…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> ມີນະໂຍບາຍຄວາມປອດໄພທີ່ເອີ້ນວ່າ HTTP Strict Transport Security (HSTS), ຊຶ່ງຫມາຍຄວາມວ່າ <b>%2$s</b> ສາມາດເຊື່ອມຕໍ່ກັບມັນໄດ້ຢ່າງປອດໄພເທົ່ານັ້ນ. ທ່ານບໍ່ສາມາດເພີ່ມຂໍ້ຍົກເວັ້ນເພື່ອເຂົ້າເບິ່ງເວັບໄຊນີ້ໄດ້.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> ມີນະໂຍບາຍຄວາມປອດໄພທີ່ເອີ້ນວ່າ HTTP Strict Transport Security (HSTS), ຊຶ່ງຫມາຍຄວາມວ່າ <b>%2$s</b> ສາມາດເຊື່ອມຕໍ່ກັບມັນໄດ້ຢ່າງປອດໄພເທົ່ານັ້ນ. ທ່ານບໍ່ສາມາດເພີ່ມຂໍ້ຍົກເວັ້ນເພື່ອເຂົ້າເບິ່ງເວັບໄຊນີ້ໄດ້.</label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-nb-rNO/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-nb-rNO/strings.xml
@@ -60,10 +60,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avansert …</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> har en sikkerhetspolicy kalt HTTP Strict Transport Security (HSTS), som betyr at <b>%2$s</b> bare kan koble til den sikkert. Du kan ikke legge til et unntak for å besøke dette nettstedet.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> har en sikkerhetspolicy kalt HTTP Strict Transport Security (HSTS), som betyr at <b>%2$s</b> bare kan koble til den sikkert. Du kan ikke legge til et unntak for å besøke dette nettstedet. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-nl/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-nl/strings.xml
@@ -63,10 +63,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Geavanceerd…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> heeft een beveiligingsbeleid genaamd HTTP Strict Transport Security (HSTS), wat betekent dat <b>%2$s</b> er alleen beveiligd mee kan verbinden. U kunt geen uitzondering toevoegen om deze website te bezoeken.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> heeft een beveiligingsbeleid genaamd HTTP Strict Transport Security (HSTS), wat betekent dat <b>%2$s</b> er alleen beveiligd mee kan verbinden. U kunt geen uitzondering toevoegen om deze website te bezoeken. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-nn-rNO/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-nn-rNO/strings.xml
@@ -63,10 +63,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avansert…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> har ein sikkerheitspolicy kalla HTTP Strict Transport Security (HSTS), som tyder at <b>%2$s</b> berre kan kople til den sikkert. Du kan ikkje legge til eit unntak for å besøkje denne nettstaden.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> har ein sikkerheitspolicy kalt HTTP Strict Transport Security (HSTS), som tyder at <b>%2$s</b> berre kan kople til den sikkert. Du kan ikkje leggje til eit unntak for å besøkje dette nenne nettstaden. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-oc/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-oc/strings.xml
@@ -55,10 +55,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avançat…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-<label> <b>%1$s</b> a una estrategia de seguretat HTTP Strict Transport Security (HSTS), valent a dire que <b>%2$s</b> pòt sonque s’i connectar amb una connexion securizada. Podètz pas apondre d’excepcion per consultar aqueste site.
-]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
 <label> <b>%1$s</b> a una estrategia de seguretat HTTP Strict Transport Security (HSTS), valent a dire que <b>%2$s</b> pòt sonque s’i connectar amb una connexion securizada. Podètz pas apondre d’excepcion per consultar aqueste site. </label>
 ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-pa-rIN/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-pa-rIN/strings.xml
@@ -62,10 +62,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">…ਤਕਨੀਕੀ</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> ਕੋਲ HTTP Strict Transport Security (HSTS) ਨਾਂ ਦੀ ਸੁਰੱਖਿਆ ਨੀਤੀ ਹੈ, ਜਿਸ ਦਾ ਅਰਥ ਹੈ ਕਿ <b>%2$s</b> ਇਸ ਨਾਲ ਸਿਰਫ਼ ਸੁਰੱਖਿਅਤ ਢੰਗ ਨਾਲ ਹੀ ਕਨੈਕਟ ਹੋ ਸਕਦਾ ਹੈ। ਤੁਸੀਂ ਇਸ ਵੈੱਬਸਾਈਟ ਲਈ ਛੋਟ ਦੇ ਸਕਦੇ ਹੋ।
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> ਦੀ ਸੁਰੱਖਿਆ ਪਾਲਸੀ ਹੈ, ਜਿਸ ਨੂੰ HTTP ਸਟਰਿਕ ਟਰਾਂਸਪੋਰਟ ਸਕਿਉਰਟੀ (HSTS) ਕਹਿੰਦੇ ਹਨ, ਜਿਸ ਦਾ ਅਰਥ ਹੈ ਕਿ <b>%2$s</b> ਨੂੰ ਸਿਰਫ਼ ਸੁਰੱਖਿਅਤ ਢੰਗ ਨਾਲ ਹੀ ਕਨੈਕਟ ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ। ਤੁਸੀਂ ਇਸ ਸਾਈਟ ਨੂੰ ਛੋਟ ਨਹੀਂ ਦਿੱਤੀ ਜਾ ਸਕਦੀ ਹੈ।</label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-pl/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-pl/strings.xml
@@ -60,10 +60,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Zaawansowane…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> Witryna „<b>%1$s</b>” określa poprzez HSTS (HTTP Strict Transport Security), że <b>%2$s</b> ma się z nią łączyć jedynie w sposób zabezpieczony. Dodanie wyjątku w celu odwiedzenia tej witryny jest niemożliwe.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> Witryna „<b>%1$s</b>” określa poprzez HSTS (HTTP Strict Transport Security), że <b>%2$s</b> ma się z nią łączyć jedynie w sposób zabezpieczony. Dodanie wyjątku w celu odwiedzenia tej witryny jest niemożliwe. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-pt-rBR/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-pt-rBR/strings.xml
@@ -62,10 +62,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avançado…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> tem uma diretiva de segurança chamada HTTP Strict Transport Security (HSTS), que significa que o <b>%2$s</b> só pode se conectar a ele com segurança. Você não pode adicionar uma exceção para visitar este site.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> tem uma diretiva de segurança chamada HTTP Strict Transport Security (HSTS), que significa que o <b>%2$s</b> só pode se conectar a ele com segurança. Você não pode adicionar uma exceção para visitar este site. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-pt-rPT/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-pt-rPT/strings.xml
@@ -60,10 +60,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avançado…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> tem uma política de segurança chamada HTTP Strict Transport Security (HSTS), que significa que o <b>%2$s</b> apenas pode ligar-se em segurança. Não pode adicionar uma exceção para visitar este site.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[<label> <b>%1$s</b> tem uma política de segurança chamada HTTP Strict Transport Security (HSTS), que significa que o <b>%2$s</b> apenas pode ligar-se com este protocolo. Não é possível adicionar uma exceção para este site.</label>
     ]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-rm/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-rm/strings.xml
@@ -52,10 +52,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avanzà…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> ha ina directiva da segirezza che sa numna HTTP Strict Transport Security (HSTS). Quai munta che <b>%2$s</b> po mo connectar a moda segirada. I n\'è betg pussaivel dad agiuntar ina excepziun per visitar questa website.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> ha ina directiva da segirezza che sa numna HTTP Strict Transport Security (HSTS). Quai munta che <b>%2$s</b> po mo connectar a moda segirada cun la website. I n\'è betg pussaivel dad agiuntar ina excepziun per visitar questa website. </label>
 ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-ru/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-ru/strings.xml
@@ -58,10 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Дополнительно…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> использует политику безопасности под названием Форсированное безопасное соединение HTTP (HSTS), согласно которой <b>%2$s</b> может соединяться с ним только с помощью безопасного соединения. Вы не можете добавить исключение для посещения этого сайта.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> использует политику безопасности под названием Форсированное безопасное соединение HTTP (HSTS), согласно которой <b>%2$s</b> может соединяться с ним только с помощью безопасного соединения. Вы не можете добавить исключение для посещения этого сайта. </label>
 

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-sk/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-sk/strings.xml
@@ -60,10 +60,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Pokročilé…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> má bezpečnostnú politiku s názvom HTTP Strict Transport Security (HSTS), čo znamená, že <b>%2$s</b> sa k nemu môže pripojiť iba zabezpečene. Na návštevu tohto webu nemôžete pridať výnimku.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> má bezpečnostnú politiku s názvom HTTP Strict Transport Security (HSTS), čo znamená, že <b>%2$s</b> sa k nemu môže pripojiť iba zabezpečene. Na návštevu tohto webu nemôžete pridať výnimku.</label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-skr/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-skr/strings.xml
@@ -58,10 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">ودھایا۔۔۔</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> دی ہک حفاظتی پالیسی ہے جیکوں ایچ ٹی ٹی پی سخت ٹرانسپورٹ حفاظت(HSTS) آہدے ہن، جیندے مطلب ایہ ہے جو  <b>%2$s</b> صرف ایندے نال حفاظت نال کنکٹ کر سڳدے۔ تساں ایں سائٹ تے ون٘ڄݨ کیتے کوئی استثناء شامل نہوے کر سڳدے۔
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> دی ہک حفاظتی پالیسی ہے جیکوں ایچ ٹی ٹی پی سخت ٹرانسپورٹ حفاظت(HSTS) آہدے ہن، جیندے مطلب ایہ ہے جو  <b>%2$s</b> صرف ایندے نال حفاظت نال کنکٹ کر سڳدے۔ تساں ایں سائٹ تے ون٘ڄݨ کیتے کوئی استثناء شامل نہوے کر سڳدے۔</label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-sl/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-sl/strings.xml
@@ -63,10 +63,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Napredno …</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> uporablja varnostni pravilnik, imenovan HTTP Strict Transport Security (HSTS), kar pomeni, da se lahko <b>%2$s</b> nanj poveže zgolj varno. Za obisk tega spletnega mesta ne morete dodati izjeme.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> uporablja varnostni pravilnik, imenovan HTTP Strict Transport Security (HSTS), kar pomeni, da se lahko <b>%2$s</b> nanj poveže zgolj varno. Za obisk tega spletnega mesta ne morete dodati izjeme. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-sr/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-sr/strings.xml
@@ -55,10 +55,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Напредно…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> проводи сигурносну политику под називом HTTP Strict Transport Security (HSTS), што значи да <b>%2$s</b> може на исту повезати само сигурно. Не можете да додате изузетак за посете овој страници.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> проводи сигурносну политику под називом HTTP Strict Transport Security (HSTS), што значи да <b>%2$s</b> може на исту повезати само сигурно. Не можете да додате изузетак за посете овој страници. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-su/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-su/strings.xml
@@ -58,10 +58,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Leuwih lengkep…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> miboga kawijakan kaamanan anu katelah HTTP Strict Transport Security (HSTS), anu hartina <b>%2$s</b> ngan bisa nyambung ka dinya ku cara anu aman. Anjeun teu bisa ngiwalkeun pikeun muka ieu loka.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> miboga kawijakan kaamanan anu katelah HTTP Strict Transport Security (HSTS), anu hartina <b>%2$s</b> ngan bisa nyambung ka dinya ku cara anu aman. Anjeun teu bisa ngiwalkeun pikeun muka ieu loka. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-sv-rSE/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-sv-rSE/strings.xml
@@ -62,10 +62,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Avancerat…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> har en säkerhetspolicy som kallas HTTP Strict Transport Security (HSTS), vilket innebär att <b>%2$s</b> bara kan ansluta till den på ett säkert sätt. Du kan inte lägga till ett undantag för att besöka den här webbplatsen.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
     <label> <b>%1$s</b> har en säkerhetspolicy som kallas HTTP Strict Transport Security (HSTS), vilket innebär att <b>%2$s</b> bara kan ansluta till den på ett säkert sätt. Du kan inte lägga till ett undantag för att besöka den här webbplatsen.</label>]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-th/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-th/strings.xml
@@ -54,10 +54,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">ขั้นสูง…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> มีนโยบายการรักษาความปลอดภัยที่เรียกว่า HTTP Strict Transport Security (HSTS) ซึ่งหมายความว่า <b>%2$s</b> สามารถทำการเชื่อมต่อได้อย่างปลอดภัยเท่านั้น คุณไม่สามารถเพิ่มข้อยกเว้นเพื่อเยี่ยมชมไซต์นี้ได้
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> มีนโยบายการรักษาความปลอดภัยที่เรียกว่า HTTP Strict Transport Security (HSTS) ซึ่งหมายความว่า <b>%2$s</b> สามารถทำการเชื่อมต่อได้อย่างปลอดภัยเท่านั้น คุณไม่สามารถเพิ่มข้อยกเว้นเพื่อเยี่ยมชมไซต์นี้ได้ </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-uk/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-uk/strings.xml
@@ -60,10 +60,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Додатково…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> має політику безпеки під назвою HTTP Strict Transport Security (HSTS), що означає, що <b>%2$s</b> може підключитися до нього лише безпечно. Ви не можете додати виняток для відвідування цього сайту.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> має політику безпеки під назвою HTTP Strict Transport Security (HSTS), що означає, що <b>%2$s</b> може підключитися до нього лише безпечно. Ви не можете додати виняток для відвідування цього сайту. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-uz/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-uz/strings.xml
@@ -61,10 +61,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Qoʻshimcha…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> HTTP Strict Transport Security (HSTS) deb nomlangan xavfsizlik siyosatiga ega, yaʼni <b>%2$s</b> unga faqat xavfsiz ulanishi mumkin. Bu saytga tashrif buyurish uchun istisno qoʻsha olmaysiz.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> HTTP Strict Transport Security (HSTS) deb nomlangan xavfsizlik siyosatiga ega, yaʼni <b>%2$s</b> unga faqat xavfsiz ulanishi mumkin. Bu saytga tashrif buyurish uchun istisno qoʻsha olmaysiz.</label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-vec/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-vec/strings.xml
@@ -56,10 +56,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Vansà…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-   <label> <b>%1$s</b> el gà na połìtega de seguresa ciamà HTTP Strict Transport Security (HSTS), che vołe dire che <b>%2$s</b> el połe conétarse soło in magnera segura. No se połe zontare na ecesion par vardare ’sto sito.
-]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> el gà na połìtega de seguresa ciamada HTTP Strict Transport Security (HSTS), che vołe dir che <b>%2$s</b> el połe conétarse soło en magnera segura. No te połi zontar nissuna ecesion par vardar ’sto sito. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-vi/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-vi/strings.xml
@@ -56,10 +56,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Nâng cao…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[
-        <label> <b>%1$s</b> có một chính sách bảo mật được gọi là Bảo mật truyền tải nghiêm ngặt HTTP (HSTS), có nghĩa là <b>%2$s</b> chỉ có thể kết nối với nó một cách an toàn. Bạn không thể thêm một ngoại lệ để truy cập trang web này.
-    ]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[
         <label> <b>%1$s</b> có chính sách bảo mật được gọi là Bảo mật truyền tải nghiêm ngặt HTTP (HSTS), có nghĩa là <b>%2$s</b> chỉ có thể kết nối với nó một cách an toàn. Bạn không thể thêm ngoại lệ để truy cập trang web này. </label>
     ]]></string>

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-yo/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-yo/strings.xml
@@ -57,9 +57,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">Ní ìlọsíwájú…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[<label> <b>%1$s</b> gẹ́gẹ́ bíi ètò ààbò tí a pè ní HTTP Strict Transport Security (HSTS), tó túmọ̀ si ́pé <b>%2$s</b> ó lè ṣiṣẹ́ nínu pẹ̀lú. O kò lè ṣe àfikún ohun ọ̀tọ̀ mí ì lórí ìkànnì yìí.
-]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[<label> <b>%1$s</b> gẹ́gẹ́ bíi ètò ààbò tí a pè ní HTTP ààbò ìlọmabọ̀ tó le (HSTS), tó túmọ̀ sí pé <b>%2$s</b> ó lè ní ìbátan pẹ̀lú rẹ̀ nígbà tí ààbò bá wà. O kò lè fi ìyàsọ́tọ̀ kún-un láti ṣàbẹ̀wò sí sáìtì yìí. </label>
 ]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->

--- a/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-zh-rTW/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/errorpages/src/main/res/values-zh-rTW/strings.xml
@@ -55,8 +55,6 @@
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_advanced">進階…</string>
 
     <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
-    <string moz:removedIn="104" name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo" tools:ignore="UnusedResources"><![CDATA[<label><b>%1$s</b> 有一條稱為 HTTP Strict Transport Security (HSTS) 的安全性政策，讓 <b>%2$s</b> 僅能與其進行安全連線。您無法加入例外，手動排除此政策。]]></string>
-    <!-- The advanced certificate information shown when a website uses HSTS. The %1$s will be replaced by the website URL and %2$s will be replaced by the app name. It's only shown when a website uses HSTS. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_techInfo2"><![CDATA[<label><b>%1$s</b> 有一條稱為 HTTP Strict Transport Security (HSTS) 的安全性政策，讓 <b>%2$s</b> 僅能與其進行安全連線。您無法加入例外，手動排除此政策。</label>]]></string>
     <!-- The text shown inside the advanced options button used to go back. It's only shown if the user has expanded the advanced options. -->
     <string name="mozac_browser_errorpages_security_bad_hsts_cert_back">回上一頁</string>

--- a/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-az/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-az/strings.xml
@@ -102,8 +102,6 @@
     <string name="mozac_feature_addons_install_addon_content_description">Əlavəni quraşdır</string>
     <!-- This is the label of a button to cancel an ongoing add-on installation. -->
     <string name="mozac_feature_addons_install_addon_dialog_cancel">Ləğv et</string>
-    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of users -->
-    <string name="mozac_feature_addons_user_rating_count">İstifadəçilər: %1$s</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->

--- a/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-ga-rIE/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-ga-rIE/strings.xml
@@ -94,8 +94,6 @@
     <string name="mozac_feature_addons_permissions_dialog_cancel">Cealaigh</string>
     <!-- Accessibility content description to install add-on button. -->
     <string name="mozac_feature_addons_install_addon_content_description">Suiteáil an Breiseán</string>
-    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of users -->
-    <string name="mozac_feature_addons_user_rating_count">Úsáideoirí: %1$s</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->

--- a/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-kn/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-kn/strings.xml
@@ -102,8 +102,6 @@
     <string name="mozac_feature_addons_install_addon_content_description">ಆಡ್-ಆನ್ ಅನ್ನು ಅನುಸ್ಥಾಪಿಸು</string>
     <!-- This is the label of a button to cancel an ongoing add-on installation. -->
     <string name="mozac_feature_addons_install_addon_dialog_cancel">ರದ್ದು ಮಾಡು</string>
-    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of users -->
-    <string name="mozac_feature_addons_user_rating_count">ಬಳಕೆದಾರರು: %1$s</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->

--- a/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-lij/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-lij/strings.xml
@@ -102,8 +102,6 @@
     <string name="mozac_feature_addons_install_addon_content_description">Installa conponente azonto</string>
     <!-- This is the label of a button to cancel an ongoing add-on installation. -->
     <string name="mozac_feature_addons_install_addon_dialog_cancel">Anulla</string>
-    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of users -->
-    <string name="mozac_feature_addons_user_rating_count">Utenti: %1$s</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->

--- a/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-ml/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-ml/strings.xml
@@ -102,8 +102,6 @@
     <string name="mozac_feature_addons_install_addon_content_description">ആഡ്-ഓണ്‍ ഇന്‍സ്റ്റോള്‍ ചെയ്യുക</string>
     <!-- This is the label of a button to cancel an ongoing add-on installation. -->
     <string name="mozac_feature_addons_install_addon_dialog_cancel">റദ്ദാക്കുക</string>
-    <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of users -->
-    <string name="mozac_feature_addons_user_rating_count">ഉപയോക്താക്കൾ: %1$s</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
     <string name="mozac_feature_addons_rating_content_description">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->

--- a/mozilla-mobile/android-components/components/feature/contextmenu/src/main/res/values-ga-rIE/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/contextmenu/src/main/res/values-ga-rIE/strings.xml
@@ -23,8 +23,4 @@
     <!-- Action shown in a "snacbkar" after opening a new/private tab. Clicking this action will switch to the newly opened tab. -->
     <string name="mozac_feature_contextmenu_snackbar_action_switch">Malartaigh</string>
     <string name="mozac_feature_contextmenu_open_link_in_external_app">Oscail an nasc in aip eile</string>
-    <!-- Action shown in a text selection context menu. This will prompt a search using the selected text. The first parameter is the name of the application (For example: Fenix)-->
-    <string name="mozac_selection_context_menu_search">Cuardach %s</string>
-    <!-- Action shown in a text selection context menu. This will prompt a search in a private tab using the selected text The first parameter is the name of the application (For example: Fenix) -->
-    <string name="mozac_selection_context_menu_search_privately">Cuardach Príobháideach %s</string>
 </resources>

--- a/mozilla-mobile/android-components/components/feature/contextmenu/src/main/res/values-lij/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/contextmenu/src/main/res/values-lij/strings.xml
@@ -30,10 +30,6 @@
     <string name="mozac_feature_contextmenu_snackbar_action_switch">Passa a</string>
     <!-- Text for context menu item to open the link in an external app. -->
     <string name="mozac_feature_contextmenu_open_link_in_external_app">Arvi link in app esterna</string>
-    <!-- Action shown in a text selection context menu. This will prompt a search using the selected text. The first parameter is the name of the application (For example: Fenix)-->
-    <string name="mozac_selection_context_menu_search">Çerca con %s</string>
-    <!-- Action shown in a text selection context menu. This will prompt a search in a private tab using the selected text The first parameter is the name of the application (For example: Fenix) -->
-    <string name="mozac_selection_context_menu_search_privately">Çerca con %s (privou)</string>
     <!-- Action shown in a text selection context menu. This will prompt a share of the selected text. -->
     <string name="mozac_selection_context_menu_share">Condividdi</string>
 </resources>

--- a/mozilla-mobile/android-components/components/feature/contextmenu/src/main/res/values-ml/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/contextmenu/src/main/res/values-ml/strings.xml
@@ -30,10 +30,6 @@
     <string name="mozac_feature_contextmenu_snackbar_action_switch">മാറുക</string>
     <!-- Text for context menu item to open the link in an external app. -->
     <string name="mozac_feature_contextmenu_open_link_in_external_app">ബാഹ്യ ആപ്പിൽ കണ്ണി തുറക്കുക</string>
-    <!-- Action shown in a text selection context menu. This will prompt a search using the selected text. The first parameter is the name of the application (For example: Fenix)-->
-    <string name="mozac_selection_context_menu_search">%s തിരയൽ</string>
-    <!-- Action shown in a text selection context menu. This will prompt a search in a private tab using the selected text The first parameter is the name of the application (For example: Fenix) -->
-    <string name="mozac_selection_context_menu_search_privately">%s സ്വകാര്യ തിരയൽ</string>
     <!-- Action shown in a text selection context menu. This will prompt a share of the selected text. -->
     <string name="mozac_selection_context_menu_share">പങ്കിടുക</string>
 </resources>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ast/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ast/strings.xml
@@ -117,8 +117,6 @@
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
-    <string moz:removedIn="104" name="mozac_feature_prompts_select_address" tools:ignore="UnusedResources">Seleiciona unes señes</string>
-    <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seleición d\'unes señes</string>
     <!-- Content description for expanding the select addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description">Espander les señes suxeríes</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-bg/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-bg/strings.xml
@@ -119,8 +119,6 @@
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
-    <string name="mozac_feature_prompts_select_address" moz:removedIn="104" tools:ignore="UnusedResources">Изберете адреси</string>
-    <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Изберете адрес</string>
     <!-- Content description for expanding the select addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description">Разгъване на предложени адреси</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-cak/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-cak/strings.xml
@@ -120,8 +120,6 @@
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
-    <string name="mozac_feature_prompts_select_address" moz:removedIn="104" tools:ignore="UnusedResources">Kecha\' ochochib\'äl</string>
-    <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Ticha\' ochochib\'äl</string>
     <!-- Content description for expanding the select addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description">Kerik\' ri chilab\'en ochochib\'äl</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es-rMX/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es-rMX/strings.xml
@@ -118,8 +118,6 @@
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
-    <string moz:removedIn="104" name="mozac_feature_prompts_select_address" tools:ignore="UnusedResources">Seleccionar direcciones</string>
-    <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seleccionar dirección</string>
     <!-- Content description for expanding the select addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description">Expandir direcciones sugeridas</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-et/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-et/strings.xml
@@ -116,8 +116,6 @@
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
-    <string moz:removedIn="104" name="mozac_feature_prompts_select_address" tools:ignore="UnusedResources">Vali aadressid</string>
-    <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Vali aadress</string>
     <!-- Content description for expanding the select addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description">Laienda soovitatud aadressid</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ga-rIE/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ga-rIE/strings.xml
@@ -26,8 +26,6 @@
     <string name="mozac_feature_prompt_error_empty_password">Ní cheadaítear focal faire folamh</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause">Níorbh fhéidir an focal faire a shábháil</string>
-    <!-- Prompt message displayed when app detects a user has entered a password and user decides if app should save it. The first parameter is the name of the application (For example: Fenix)  -->
-    <string name="mozac_feature_prompt_logins_save_message">An bhfuil tú ag iarraidh go sábhálfadh %s an focal faire seo?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
     <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
     <string name="mozac_feature_prompts_content_description_input_label">Lipéad do réimse ionchurtha téacs</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-kaa/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-kaa/strings.xml
@@ -123,8 +123,6 @@
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
-    <string name="mozac_feature_prompts_select_address" moz:removedIn="104" tools:ignore="UnusedResources">Mánzillerdi tańlań</string>
-    <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Mánzildi tańlań</string>
     <!-- Content description for expanding the select addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description">Usınıs etilgen mánzillerdi keńeytiriw</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pa-rPK/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pa-rPK/strings.xml
@@ -123,8 +123,6 @@
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
-    <string moz:removedIn="104" name="mozac_feature_prompts_select_address" tools:ignore="UnusedResources">پتے چݨو</string>
-    <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">پتہ چݨو</string>
     <!-- Content description for expanding the select addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description">ہور پتے ویکھو</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sq/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sq/strings.xml
@@ -119,8 +119,6 @@
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
-    <string moz:removedIn="104" name="mozac_feature_prompts_select_address" tools:ignore="UnusedResources">Përzgjidhni adresa</string>
-    <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Përzgjidhni adresë</string>
     <!-- Content description for expanding the select addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description">Zgjeroji adresat e sugjeruara</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-uz/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-uz/strings.xml
@@ -118,8 +118,6 @@
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
-    <string moz:removedIn="104" name="mozac_feature_prompts_select_address" tools:ignore="UnusedResources">Manzillarni tanlang</string>
-    <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Manzilni tanlang</string>
     <!-- Content description for expanding the select addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description">Tavsiya etilgan manzillarni kengaytirish</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-vec/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-vec/strings.xml
@@ -26,8 +26,6 @@
     <string name="mozac_feature_prompt_error_empty_password">Bixogna meter rento na password</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause">No xe mìa posibiƚe salvare ƚa password</string>
-    <!-- Prompt message displayed when app detects a user has entered a password and user decides if app should save it. The first parameter is the name of the application (For example: Fenix)  -->
-    <string name="mozac_feature_prompt_logins_save_message">Salvare ste credensiali so %s?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
     <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
     <string name="mozac_feature_prompts_content_description_input_label">Eticheta par meter rento el testo en on canpo</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-yo/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-yo/strings.xml
@@ -118,8 +118,6 @@
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
-    <string moz:removedIn="104" name="mozac_feature_prompts_select_address" tools:ignore="UnusedResources">Yan àwọn àdírẹ́sì</string>
-    <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Yan àdírẹ́ẹ̀sì</string>
     <!-- Content description for expanding the select addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description">Fẹ àwọn adírẹ́sì tí a dábàá</string>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-am/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-am/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">ኢሜይል በ…</string>
     <string name="mozac_support_ktx_menu_share_with">ያጋሩ ከ…</string>
     <string name="mozac_support_ktx_share_dialog_title">በ በኩል አጋራ</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">ምስል ወደ ቅንጥብ ሰሌዳ ተቀድቷል</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-be/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-be/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Адправіць электроннай поштай праз…</string>
     <string name="mozac_support_ktx_menu_share_with">Падзяліцца з…</string>
     <string name="mozac_support_ktx_share_dialog_title">Падзяліцца праз</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Відарыс скапіяваны ў буфер абмену</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-bg/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-bg/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Имейл чрез…</string>
     <string name="mozac_support_ktx_menu_share_with">Споделяне с …</string>
     <string name="mozac_support_ktx_share_dialog_title">Споделяне чрез</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Изображението е копирано</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ca/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ca/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Envia un correu electrònic amb…</string>
     <string name="mozac_support_ktx_menu_share_with">Comparteix amb…</string>
     <string name="mozac_support_ktx_share_dialog_title">Comparteix mitjançant</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">S’ha copiat la imatge al porta-retalls</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-cak/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-cak/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Titaq rik\'in…</string>
     <string name="mozac_support_ktx_menu_share_with">Tikomonïx rik\'in…</string>
     <string name="mozac_support_ktx_share_dialog_title">Tikomonïx rik\'in</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Xwachib\'ëx ri wachib\'äl pa molwuj</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-co/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-co/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Mandà un messaghju cù…</string>
     <string name="mozac_support_ktx_menu_share_with">Sparte cù…</string>
     <string name="mozac_support_ktx_share_dialog_title">Sparte via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Fiura cupiata in u preme’papei</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-cs/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-cs/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Poslat e-mail pomocí…</string>
     <string name="mozac_support_ktx_menu_share_with">Sdílet pomocí…</string>
     <string name="mozac_support_ktx_share_dialog_title">Sdílet pomocí</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Obrázek zkopírován do schránky</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-cy/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-cy/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">E-bostio gyda…</string>
     <string name="mozac_support_ktx_menu_share_with">Rhannu gyda…</string>
     <string name="mozac_support_ktx_share_dialog_title">Rhannu drwy</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Copïwyd arallenw i’r clipfwrdd</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-da/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-da/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Send mail med…</string>
     <string name="mozac_support_ktx_menu_share_with">Del med…</string>
     <string name="mozac_support_ktx_share_dialog_title">Del via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Billede kopieret til udklipsholder</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-de/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-de/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Per E-Mail versenden mit…</string>
     <string name="mozac_support_ktx_menu_share_with">Teilen mit…</string>
     <string name="mozac_support_ktx_share_dialog_title">Teilen über</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Grafik in Zwischenablage kopiert</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-dsb/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-dsb/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Mejlki słaś z …</string>
     <string name="mozac_support_ktx_menu_share_with">Źěliś z…</string>
     <string name="mozac_support_ktx_share_dialog_title">Źěliś pśez</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Wobraz jo se kopěrował do mjazywótkłada</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-el/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-el/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Email με…</string>
     <string name="mozac_support_ktx_menu_share_with">Κοινή χρήση με…</string>
     <string name="mozac_support_ktx_share_dialog_title">Κοινή χρήση μέσω</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Η εικόνα αντιγράφτηκε στο πρόχειρο</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-en-rCA/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-en-rCA/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Email with…</string>
     <string name="mozac_support_ktx_menu_share_with">Share with…</string>
     <string name="mozac_support_ktx_share_dialog_title">Share via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Image copied to clipboard</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-en-rGB/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-en-rGB/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Email with…</string>
     <string name="mozac_support_ktx_menu_share_with">Share with…</string>
     <string name="mozac_support_ktx_share_dialog_title">Share via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Image copied to clipboard</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-eo/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-eo/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Sendi retpoŝton per…</string>
     <string name="mozac_support_ktx_menu_share_with">Dividi kun…</string>
     <string name="mozac_support_ktx_share_dialog_title">Dividi per</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Bildo kopiita al la tondujo</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-es-rAR/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-es-rAR/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Enviar por correo electrónico…</string>
     <string name="mozac_support_ktx_menu_share_with">Compartir con…</string>
     <string name="mozac_support_ktx_share_dialog_title">Compartir vía</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Imagen copiada al portapapeles</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-es-rCL/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-es-rCL/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Enviar correo con…</string>
     <string name="mozac_support_ktx_menu_share_with">Compartir con…</string>
     <string name="mozac_support_ktx_share_dialog_title">Compartir mediante</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Imagen copiada al portapapeles</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-es-rES/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-es-rES/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Enviar correo con…</string>
     <string name="mozac_support_ktx_menu_share_with">Compartir con…</string>
     <string name="mozac_support_ktx_share_dialog_title">Compartir a través de</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Imagen copiada al portapapeles</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-es-rMX/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-es-rMX/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Enviar correo con…</string>
     <string name="mozac_support_ktx_menu_share_with">Compartir con…</string>
     <string name="mozac_support_ktx_share_dialog_title">Compartir vía</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Imagen copiada al portapapeles</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-es/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-es/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Enviar correo con…</string>
     <string name="mozac_support_ktx_menu_share_with">Compartir con…</string>
     <string name="mozac_support_ktx_share_dialog_title">Compartir a través de</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Imagen copiada al portapapeles</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-et/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-et/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Saada e-kiri äpiga…</string>
     <string name="mozac_support_ktx_menu_share_with">Jaga…</string>
     <string name="mozac_support_ktx_share_dialog_title">Jagamine kasutades</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Pilt kopeeriti vahemällu</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-eu/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-eu/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Bidali mezu elektronikoa honekin…</string>
     <string name="mozac_support_ktx_menu_share_with">Partekatu honekin…</string>
     <string name="mozac_support_ktx_share_dialog_title">Partekatu honen bidez</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Irudia arbelean kopiatu da</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-fa/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-fa/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">رایانامه کردن با…</string>
     <string name="mozac_support_ktx_menu_share_with">هم‌رسانی با…</string>
     <string name="mozac_support_ktx_share_dialog_title">همرسانی از طریق</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">تصویر به تخته‌گیره رونوشت شد</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-fi/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-fi/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Sähköposti…</string>
     <string name="mozac_support_ktx_menu_share_with">Jaa…</string>
     <string name="mozac_support_ktx_share_dialog_title">Jaa</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Kuva kopioitu leikepöydälle</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-fr/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-fr/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Envoyer un e-mail avec…</string>
     <string name="mozac_support_ktx_menu_share_with">Partager avec…</string>
     <string name="mozac_support_ktx_share_dialog_title">Partager à l’aide de</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Image copiée dans le presse-papiers</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-fur/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-fur/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Mande e-mail cun…</string>
     <string name="mozac_support_ktx_menu_share_with">Condivît cun…</string>
     <string name="mozac_support_ktx_share_dialog_title">Condivît vie</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Imagjin copiade intes notis</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-fy-rNL/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-fy-rNL/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">E-maile mei…</string>
     <string name="mozac_support_ktx_menu_share_with">Diele mei…</string>
     <string name="mozac_support_ktx_share_dialog_title">Diele fia</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Ofbylding nei klamboerd kopiearre</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-gd/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-gd/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Cuir air a‘ phost-d le…</string>
     <string name="mozac_support_ktx_menu_share_with">Co-roinn le…</string>
     <string name="mozac_support_ktx_share_dialog_title">Co-roinn slighe</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Chaidh lethbhreac dhen dealbh a chur air an stòr-bhòrd</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-gl/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-gl/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Enviar por correo con…</string>
     <string name="mozac_support_ktx_menu_share_with">Compartir con…</string>
     <string name="mozac_support_ktx_share_dialog_title">Compartir mediante</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Copiouse a imaxe ao portapapeis</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-gn/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-gn/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Emondo ñanduti veve… ndive</string>
     <string name="mozac_support_ktx_menu_share_with">Emoherakuã…</string>
     <string name="mozac_support_ktx_share_dialog_title">Emoherakuã amóva rupi</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Embohasa ta’ãnga kuatiajokohápe</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-hsb/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-hsb/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Mejlki słać z …</string>
     <string name="mozac_support_ktx_menu_share_with">Dźělić z…</string>
     <string name="mozac_support_ktx_share_dialog_title">Dźělić přez</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Wobraz je so do mjezyskłada kopěrował</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-hu/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-hu/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">E-mail ezzel…</string>
     <string name="mozac_support_ktx_menu_share_with">Megosztás…</string>
     <string name="mozac_support_ktx_share_dialog_title">Megosztás ezzel</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Kép vágólapra másolva</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-hy-rAM/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-hy-rAM/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Էլ. նամակ ուղարկել՝</string>
     <string name="mozac_support_ktx_menu_share_with">Կիսվել հետևյալի հետ՝</string>
     <string name="mozac_support_ktx_share_dialog_title">Համօգտագործել հետևյալի միջոցով՝</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Պատկերը պատճենվել է սեղմատախտակին</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ia/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ia/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Inviar email con…</string>
     <string name="mozac_support_ktx_menu_share_with">Compartir con…</string>
     <string name="mozac_support_ktx_share_dialog_title">Compartir per</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Imagine copiate al area de transferentia</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-in/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-in/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Surelkan dengan…</string>
     <string name="mozac_support_ktx_menu_share_with">Bagikan dengan…</string>
     <string name="mozac_support_ktx_share_dialog_title">Bagikan lewat</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Gambar disalin ke papan klip</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-is/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-is/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Senda tölvupóst með…</string>
     <string name="mozac_support_ktx_menu_share_with">Deila með…</string>
     <string name="mozac_support_ktx_share_dialog_title">Deila með</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Mynd afrituð á klippispjald</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-it/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-it/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Invia email con…</string>
     <string name="mozac_support_ktx_menu_share_with">Condividi con…</string>
     <string name="mozac_support_ktx_share_dialog_title">Condividi con</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Immagine copiata negli appunti</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-iw/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-iw/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">שליחה בדוא״ל באמצעות…</string>
     <string name="mozac_support_ktx_menu_share_with">שיתוף עם…</string>
     <string name="mozac_support_ktx_share_dialog_title">שיתוף באמצעות</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">התמונה הועתקה ללוח</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ja/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ja/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">メール送信…</string>
     <string name="mozac_support_ktx_menu_share_with">共有先…</string>
     <string name="mozac_support_ktx_share_dialog_title">共有方法</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">画像をクリップボードにコピーしました</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ka/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ka/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">ელფოსტის გაგზავნა…</string>
     <string name="mozac_support_ktx_menu_share_with">გაზიარება…</string>
     <string name="mozac_support_ktx_share_dialog_title">გაზიარება პროგრამით</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">სურათის ასლი აღებულია</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-kaa/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-kaa/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Elektron pochta járdeminde…</string>
     <string name="mozac_support_ktx_menu_share_with">…járdeminde bólisiw</string>
     <string name="mozac_support_ktx_share_dialog_title">Arqalı bólisiw</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Súwret almasıw buferine kóshirip alındı</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-kab/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-kab/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Azen imayl s…</string>
     <string name="mozac_support_ktx_menu_share_with">Bḍu d…</string>
     <string name="mozac_support_ktx_share_dialog_title">Bḍu s</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Tugna tettwanɣel ɣef wafus</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-kk/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-kk/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Көмегімен эл. пошта хатын жіберу…</string>
     <string name="mozac_support_ktx_menu_share_with">Көмегімен бөлісу…</string>
     <string name="mozac_support_ktx_share_dialog_title">Арқылы бөлісу</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Сурет алмасу буферіне көшірілді</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-kmr/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-kmr/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Emaîl bi…</string>
     <string name="mozac_support_ktx_menu_share_with">Parve bike bi…</string>
     <string name="mozac_support_ktx_share_dialog_title">Parve bike bi rêya</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Wêne li panoyê hate kopîkirin</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ko/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ko/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">이메일 앱…</string>
     <string name="mozac_support_ktx_menu_share_with">공유…</string>
     <string name="mozac_support_ktx_share_dialog_title">다음으로 공유</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">클립보드에 이미지 복사됨</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-lo/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-lo/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">ອີເມລດ້ວຍ…</string>
     <string name="mozac_support_ktx_menu_share_with">ແບ່ງປັນກັບ…</string>
     <string name="mozac_support_ktx_share_dialog_title">ແບ່ງປັນຜ່ານທາງ</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">ສຳເນົາຮູບໃສ່ຄລິບບອດແລ້ວ</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-nb-rNO/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-nb-rNO/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Send e-post med…</string>
     <string name="mozac_support_ktx_menu_share_with">Del med…</string>
     <string name="mozac_support_ktx_share_dialog_title">Del via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Bilde kopiert til utklippstavlen</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-nl/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-nl/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">E-mailen met…</string>
     <string name="mozac_support_ktx_menu_share_with">Delen met…</string>
     <string name="mozac_support_ktx_share_dialog_title">Delen via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Afbeelding naar klembord gekopieerd</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-nn-rNO/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-nn-rNO/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Send e-post med…</string>
     <string name="mozac_support_ktx_menu_share_with">Del med…</string>
     <string name="mozac_support_ktx_share_dialog_title">Del via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Bilde kopiert til utklippstavla</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-oc/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-oc/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Enviar un corrièl amb…</string>
     <string name="mozac_support_ktx_menu_share_with">Partejar amb…</string>
     <string name="mozac_support_ktx_share_dialog_title">Partejar via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Imatge copiat al quichapapièrs</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-pa-rIN/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-pa-rIN/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">…ਨਾਲ ਈਮੇਲ ਭੇਜੋ</string>
     <string name="mozac_support_ktx_menu_share_with">…ਨਾਲ ਸਾਂਝਾ ਕਰੋ</string>
     <string name="mozac_support_ktx_share_dialog_title">ਇਸ ਰਾਹੀਂ ਸਾਂਝਾ ਕਰੋ</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">ਚਿੱਤਰ ਨੂੰ ਕਲਿੱਪਬੋਰਡ ਲਈ ਕਾਪੀ ਕੀਤਾ</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-pa-rPK/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-pa-rPK/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">کیہتھوں ای‌میل بھیجو…</string>
     <string name="mozac_support_ktx_menu_share_with">کیہنوں سانجھا کرو…</string>
     <string name="mozac_support_ktx_share_dialog_title">کیہتھوں سانجھا کرو</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">کاپی کیتی گئی</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-pl/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-pl/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Wyślij e-mail za pomocą…</string>
     <string name="mozac_support_ktx_menu_share_with">Udostępnij za pomocą…</string>
     <string name="mozac_support_ktx_share_dialog_title">Udostępnij przez</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Skopiowano obraz do schowka</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-pt-rBR/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-pt-rBR/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Enviar email com…</string>
     <string name="mozac_support_ktx_menu_share_with">Compartilhar com…</string>
     <string name="mozac_support_ktx_share_dialog_title">Compartilhar via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Imagem copiada para área de transferência</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-pt-rPT/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-pt-rPT/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Enviar e-mail com…</string>
     <string name="mozac_support_ktx_menu_share_with">Partilhar com…</string>
     <string name="mozac_support_ktx_share_dialog_title">Partilhar via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Imagem copiada para a área de transferência</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-rm/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-rm/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Trametter l\'e-mail cun…</string>
     <string name="mozac_support_ktx_menu_share_with">Cundivider cun…</string>
     <string name="mozac_support_ktx_share_dialog_title">Cundivider via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Copià il maletg en l\'archiv provisoric</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ru/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-ru/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Отправить по почте через…</string>
     <string name="mozac_support_ktx_menu_share_with">Поделиться с помощью…</string>
     <string name="mozac_support_ktx_share_dialog_title">Поделиться через</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Изображение скопировано в буфер обмена</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sat/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sat/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">ᱱᱚᱶᱟ ᱛᱮ ᱤᱢᱮᱞ ᱢᱮ …</string>
     <string name="mozac_support_ktx_menu_share_with">ᱱᱚᱶᱟ ᱛᱮ ᱦᱟᱹᱴᱤᱧ ᱢᱮ…</string>
     <string name="mozac_support_ktx_share_dialog_title">ᱫᱟᱨᱟᱭ ᱛᱮ ᱦᱟᱹᱴᱤᱧ</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">ᱨᱮᱴᱚᱯᱵᱚᱰ ᱨᱮ ᱪᱤᱛᱟᱹᱨ ᱱᱚᱠᱚᱞ ᱮᱱᱟ</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-si/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-si/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">මගින් තැපෑලට…</string>
     <string name="mozac_support_ktx_menu_share_with">සමඟ බෙදාගන්න…</string>
     <string name="mozac_support_ktx_share_dialog_title">හරහා බෙදාගන්න</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">රූපය පසුරුපුවරුවට පිටපත් විය</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sk/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sk/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Poslať e-mail pomocou…</string>
     <string name="mozac_support_ktx_menu_share_with">Zdieľať pomocou…</string>
     <string name="mozac_support_ktx_share_dialog_title">Zdieľať cez</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Obrázok bol skopírovaný do schránky</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-skr/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-skr/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">این٘دے نال ای میل کرو۔۔۔</string>
     <string name="mozac_support_ktx_menu_share_with">این٘دے نال شیئر کرو۔۔۔</string>
     <string name="mozac_support_ktx_share_dialog_title">شیئر بذریعہ</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">تصویر کلپ بورڈ تے نقل تھی ڳئی</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sl/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sl/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Pošlji po e-pošti z …</string>
     <string name="mozac_support_ktx_menu_share_with">Deli z …</string>
     <string name="mozac_support_ktx_share_dialog_title">Deli preko</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Slika kopirana v odložišče</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sq/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sq/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Dërgoni Email me…</string>
     <string name="mozac_support_ktx_menu_share_with">Ndajeni me të tjerët përmes…</string>
     <string name="mozac_support_ktx_share_dialog_title">Ndajeni përmes</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Figura u kopjua në të papastër</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sr/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sr/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Пошаљи мејл са…</string>
     <string name="mozac_support_ktx_menu_share_with">Дели са…</string>
     <string name="mozac_support_ktx_share_dialog_title">Дели преко</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Слика је копирана у привремену меморију</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-su/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-su/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Surélékan maké…</string>
     <string name="mozac_support_ktx_menu_share_with">Bagikeun sareng…</string>
     <string name="mozac_support_ktx_share_dialog_title">Bagikeun kana</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Gambar ditiron kana papan klip</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sv-rSE/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-sv-rSE/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Skicka e-post med…</string>
     <string name="mozac_support_ktx_menu_share_with">Dela med…</string>
     <string name="mozac_support_ktx_share_dialog_title">Dela via</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Bilden har kopierats till urklipp</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-tg/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-tg/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Ирсоли паёми эл. тавассути…</string>
     <string name="mozac_support_ktx_menu_share_with">Мубодила кардан тавассути…</string>
     <string name="mozac_support_ktx_share_dialog_title">Мубодила тавассути</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Тасвир ба ҳофизаи муваққатӣ нусха бардошта шуд</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-th/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-th/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">อีเมลด้วย…</string>
     <string name="mozac_support_ktx_menu_share_with">แบ่งปันด้วย…</string>
     <string name="mozac_support_ktx_share_dialog_title">แบ่งปันผ่าน</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">คัดลอกภาพไปยังคลิปบอร์ดแล้ว</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-tl/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-tl/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">i-Email kasama…</string>
     <string name="mozac_support_ktx_menu_share_with">Ibahagi sa…</string>
     <string name="mozac_support_ktx_share_dialog_title">Ibahagi sa pamamagitan ng</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Kinopya sa clipboard</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-tr/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-tr/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Bununla e-posta…</string>
     <string name="mozac_support_ktx_menu_share_with">Paylaş…</string>
     <string name="mozac_support_ktx_share_dialog_title">Paylaş</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Resim panoya kopyalandı</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-trs/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-trs/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Gā\'nïnj gān\'ānj korrêo ngà…</string>
     <string name="mozac_support_ktx_menu_share_with">Dūyingô\' ngà…</string>
     <string name="mozac_support_ktx_share_dialog_title">Dūyingô\' riña</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Ñadū’hua ngà nanun riña portapapel</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-tt/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-tt/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">… ярдәмендә эл. почта җибәрү</string>
     <string name="mozac_support_ktx_menu_share_with">Уртаклашу…</string>
     <string name="mozac_support_ktx_share_dialog_title">Аша уртаклашу</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied" moz:removedIn="114" tools:ignore="UnusedResources">Рәсем алмашу буферына копияләнде</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-uk/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-uk/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Надіслати електронним листом через…</string>
     <string name="mozac_support_ktx_menu_share_with">Поділитися з…</string>
     <string name="mozac_support_ktx_share_dialog_title">Поділитись через</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Зображення скопійовано в буфер обміну</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-vi/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-vi/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">Email với…</string>
     <string name="mozac_support_ktx_menu_share_with">Chia sẽ với…</string>
     <string name="mozac_support_ktx_share_dialog_title">Chia sẻ qua</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">Đã sao chép hình ảnh vào khay nhớ tạm</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-zh-rCN/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-zh-rCN/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">使用下列程序发送邮件…</string>
     <string name="mozac_support_ktx_menu_share_with">使用下列方式分享…</string>
     <string name="mozac_support_ktx_share_dialog_title">分享到</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">图像已复制到剪贴板</string>
 </resources>

--- a/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-zh-rTW/strings.xml
+++ b/mozilla-mobile/android-components/components/support/ktx/src/main/res/values-zh-rTW/strings.xml
@@ -6,6 +6,4 @@
     <string name="mozac_support_ktx_menu_email_with">使用下列程式發送郵件…</string>
     <string name="mozac_support_ktx_menu_share_with">使用下列方式分享…</string>
     <string name="mozac_support_ktx_share_dialog_title">分享到</string>
-    <!-- Text for confirmation "snackbar" shown after copying an image to the clipboard. -->
-    <string name="mozac_support_ktx_snackbar_delegate_image_copied">已將圖片複製至剪貼簿</string>
 </resources>


### PR DESCRIPTION
Per bug 1854662, these are causing some logspam in projects which use AC.