### PR TITLE
Bug 1928411 - Remove unused strings for v132

### DIFF
--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-am/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-am/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">ምናሌ</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">የተተኮረበት</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">ተጨማሪዎች</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">ቅጥያዎች</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">ተጨማሪዎች አስተዳዳሪ</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">የቅጥያዎች ማስተዳደሪያ</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">ወደ ላይ አስስ</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">ተጨማሪዎች፣ ወደ ላይ ዳስስ</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">ቅጥያዎች፣ ወደ ላይ ዳስስ</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-azb/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-azb/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">منو</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">هایلایت اولدو</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">تاخیلان</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">اوزانتی‌لار</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">تاخیلان مودیریتی</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">اوزانتی مودیری</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">یوخاریا گئت</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">تاخیلان‌لار، یوخاری گئت</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">اوزانتی‌ْلار، یوخاریْ گئت</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-be/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-be/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Меню</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Вылучаны(я)</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Дадаткі</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Пашырэнні</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Менеджар дадаткаў</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Менеджар пашырэнняў</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Перайсці ўверх</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Дадаткі, перайсці ўніз</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Пашырэнні, перайсці ўверх</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-br/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-br/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Lañser</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Usskedet</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Askouezhioù</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Askouezhioù</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Ardoer an askouezhioù</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Merañ an askouezhioù</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Adpignat</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Enlugelladoù, pignat</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Askouezhioù, pignat</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-bs/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-bs/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Meni</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Istaknuto</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Add-oni</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Ekstenzije</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Upravnik add-onima</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Menadžer ekstenzija</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Idi prema gore</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Dodaci, idite gore</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Ekstenzije, idi gore</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-cak/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-cak/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">K\'utsamaj</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Ya\'on ruq\'ij</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Taq tz\'aqat</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Taq k\'amal</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Kinuk\'samajel taq Tz\'aqat</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Runuk\'samajel taq K\'amal</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Tib\'an okem ajsik</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Taq tz\'aqat, tijote\' chi rokem</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Taq k\'amal, tok q\'anij</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-co/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-co/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Listinu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Sopralineatu</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Moduli addiziunali</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Estensioni</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Ghjestiunariu di moduli addiziunali</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Ghjestiunariu d’estensioni</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navigà insù</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Moduli addiziunali, ricullà</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Estensioni, ricullà</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-cs/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-cs/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Nabídka</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Zvýrazněné</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Doplňky</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Rozšíření</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Správce doplňků</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Správce rozšíření</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Přejít nahoru</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Doplňky, přejít nahoru</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Rozšíření, přejít nahoru</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-cy/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-cy/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Dewislen</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Amlygwyd</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Ychwanegion</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Estyniadau</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Rheolwr Ychwanegion</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Rheolwr Estyniadau</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Llywio i fyny</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Ychwanegion, symud i fyny</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Estyniadau, llywio i fyny</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-da/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-da/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Fremhævet</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Tilføjelser</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Udvidelser</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Håndtering af tilføjelser</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Håndtering af udvidelser</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Naviger op</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Tilføjelser, naviger op</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Udvidelser, naviger op</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-de/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-de/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menü</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Hervorgehoben</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Erweiterungen</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons-Verwaltung</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Erweiterungs-Manager</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Nach oben navigieren</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons, nach oben navigieren</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Erweiterungen, nach oben navigieren</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-dsb/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-dsb/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Meni</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Wuzwignjony</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Dodanki</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Rozšyrjenja</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Zastojnik dodankow</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Zastojnik rozšyrjenjow</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Górjej</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Dodanki, górjej nawigěrowaś</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Rozšyrjenja, górjej nawigěrowaś</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-el/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-el/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Μενού</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Επισημασμένο</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Πρόσθετα</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Επεκτάσεις</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Διαχείριση προσθέτων</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Διαχείριση επεκτάσεων</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Πλοήγηση προς τα πάνω</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Πρόσθετα, πλοήγηση προς τα πάνω</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Επεκτάσεις, πλοήγηση προς τα πάνω</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-en-rCA/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-en-rCA/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Highlighted</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensions</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons Manager</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Extensions Manager</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navigate up</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons, navigate up</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensions, navigate up</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-en-rGB/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-en-rGB/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Highlighted</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensions</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons Manager</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Extensions Manager</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navigate up</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons, navigate up</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensions, navigate up</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-eo/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-eo/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menuo</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Elstarigitaj</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Aldonaĵoj</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Etendaĵoj</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Administrilo de aldonaĵoj</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Administranto de etendaĵoj</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Iri supren</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Aldonaĵoj, supren</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Etendaĵoj, supren</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-es-rAR/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-es-rAR/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menú</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Resaltado</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Complementos</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Complementos</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Administrador de complementos</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Administrador de complementos</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navegar hacia arriba</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Complementos, navegar hacia arriba</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Complementos, navegar hacia arriba</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-es-rCL/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-es-rCL/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menú</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Destacado</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Complementos</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensiones</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Administrador de complementos</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Administrador de extensiones</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navegar hacia arriba</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Complementos, navegar hacia arriba</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensiones, navegar hacia arriba</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-es-rES/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-es-rES/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menú</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Resaltado</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Complementos</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensiones</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Administrador de complementos</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Administrador de extensiones</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navegar hacia arriba</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Complementos, navega hacia arriba</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensiones, navega hacia arriba</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-es/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-es/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menú</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Resaltado</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Complementos</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensiones</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Administrador de complementos</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Administrador de extensiones</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navegar hacia arriba</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Complementos, navega hacia arriba</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensiones, navega hacia arriba</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-eu/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-eu/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menua</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Nabarmendua</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Gehigarriak</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Hedapenak</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Gehigarrien kudeatzailea</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Hedapenen kudeatzailea</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Nabigatu gora</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Gehigarriak, nabigatu gora</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Hedapenak, nabigatu gora</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-fi/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-fi/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Valikko</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Korostettu</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Lisäosat</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Laajennukset</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Lisäosien hallinta</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Laajennusten hallinta</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Liiku ylöspäin</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Lisäosat, liiku ylös</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Laajennukset, liiku ylös</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-fr/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-fr/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Sélectionné</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Modules complémentaires</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensions</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Gestionnaire de modules</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Gestionnaire d’extensions</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Remonter</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Modules complémentaires, remonter</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensions, remonter</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-fur/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-fur/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menù</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Evidenziât</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Components adizionâi</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Estensions</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Gjestôr comp. adizionâi</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Gjestôr estensions</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navighe in sù</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Components adizionâi, torne indaûr</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Estensions, torne indaûr</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-fy-rNL/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-fy-rNL/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Markearre</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Utwreidingen</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Add-onbehearder</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Utwreidingsbehearder</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Omheech</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons, omheech navigearje</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Utwreidingen, omheech navigearje</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-gn/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-gn/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Poravorã</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Hechaukaveha</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Moĩmbaha</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Jepysokue</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Moĩmbaha ñangarekohára</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Jepysokue ñangarekoha</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Eikundaha yvate gotyo</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Moĩmbaha, eikundaha yvate gotyo</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Jepysokue, eikundaha yvate gotyo</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-hsb/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-hsb/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Meni</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Wuzběhnjeny</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Přidatki</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Rozšěrjenja</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Zrjadowak přidatkow</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Zrjadowak rozšěrjenjow</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Horje</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Přidatki, horje nawigěrować</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Rozšěrjenja, horje nawigěrować</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-hu/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-hu/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menü</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Kiemelt</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Kiegészítők</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Kiegészítők</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Kiegészítőkezelő</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Kiegészítőkezelő</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navigálás fel</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Kiegészítők, navigáció felfelé</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Kiegészítők, navigáció felfelé</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-hy-rAM/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-hy-rAM/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Ցանկ</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Գունանշված</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Հավելումներ</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Ընդլայնումներ</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Հավելումների կառավարիչ</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Ընդլայնումների կառավարիչ</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Նավարկել վերև</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Հավելումներ, նավարկեք վերև</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Ընդլայնումներ, նավարկեք վերև</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-ia/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-ia/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Evidentiate</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Additivos</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensiones</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Gestor de additivos</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Gestor de extensiones</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navigar</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Additivos, navigar retro</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensiones, remontar</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-in/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-in/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Tersorot</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Pengaya</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Ekstensi</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Pengelola Pengaya</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Pengelola Ekstensi</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Arahkan ke atas</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Pengaya, navigasikan ke atas</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Ekstensi, navigasikan ke atas</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-is/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-is/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Valmynd</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Undirstrikað</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Viðbætur</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Forritsaukar</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Viðbótastjóri</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Umsýsla forritsauka</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Flakka upp</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Viðbætur, fara upp</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Forritsaukar, fara upp</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-it/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-it/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Evidenziato</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Componenti aggiuntivi</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Estensioni</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Gestore comp. aggiuntivi</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Gestione estensioni</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Passa a livello superiore</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Componenti aggiuntivi, torna indietro</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Estensioni, torna indietro</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-iw/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-iw/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">תפריט</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">מודגש</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">תוספות</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">הרחבות</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">מנהל התוספות</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">מנהל ההרחבות</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">ניווט למעלה</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">תוספות, ניווט למעלה</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">הרחבות, ניווט למעלה</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-ja/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-ja/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">メニュー</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">強調</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">アドオン</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">拡張機能</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">アドオンマネージャー</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">拡張機能マネージャー</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">上へ移動します</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">アドオン、上へ移動します</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">拡張機能、上へ移動します</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-kab/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-kab/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Umuɣ</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">ittwag deg uqerru</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Izegrar</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Isiɣzaf</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Amsefrak n izegrar</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Amsefrak n yisiɣzaf</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Inig d asawen</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Izegrar niḍen, ulin-d</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Isiɣzaf niḍen, ulin-d</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-kk/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-kk/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Мәзір</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Ерекшеленген</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Қосымшалар</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Кеңейтулер</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Қосымшалар басқарушысы</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Кеңейтулер басқарушысы</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Жоғары жылжу</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Қосымшалар, жоғары өту</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Кеңейтулер, жоғары өту</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-ko/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-ko/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">메뉴</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">강조 표시됨</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">부가 기능</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">확장 기능</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">부가 기능 관리자</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">확장 기능 관리자</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">위로 이동</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">부가 기능, 위로 이동</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">확장 기능, 위로 이동</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-meh/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-meh/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Kají</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">A xinañu\'u</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Ka̱a̱ chunta´an</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensiones</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Ke\'i ka̱a̱ chunta´an</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Nu ke\'i da extensiones</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Kaka íchi sikɨ</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Daa ka̱a̱ chunta\'an, kaka íchi sikɨ</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensiones, kaka íchi sikɨ</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-nb-rNO/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-nb-rNO/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Meny</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Uthevet</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Tillegg</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Utvidelser</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Tilleggsbehandler</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Behandling av utvidelser</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Naviger opp</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Tillegg, naviger opp</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Utvidelser, naviger opp</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-nl/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-nl/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Gemarkeerd</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensies</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Add-onbeheerder</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Extensiebeheerder</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Omhoog</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Add-ons, omhoog navigeren</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensies, omhoog navigeren</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-nn-rNO/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-nn-rNO/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Meny</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Utheva</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Tillegg</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Utvidingar</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Tilleggshandsamar</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Utvidingshandsamar</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Naviger opp</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Tillegg, naviger opp</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Utvidingar, naviger opp</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-oc/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-oc/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menú</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Notables</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Moduls complementaris</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensions</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Gestionari de moduls complementaris</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Gestionari d’extensions</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Remontar</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Moduls complementaris, montar</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extension, montar</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-pa-rIN/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-pa-rIN/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">ਮੀਨੂ</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">ਉਘਾੜੇ</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">ਐਡ-ਆਨ</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">ਇਕਸਟੈਨਸ਼ਨਾਂ</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">ਐਡ-ਆਨ ਮੈਨੇਜਰ</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">ਇਕਸਟੈਨਸ਼ਨ ਮੈਨੇਜਰ</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">ਉੱਤੇ ਜਾਓ</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">ਐਡ-ਆਨ, ਉੱਤੇ</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">ਇਕਸਟੈਨਸ਼ਨਾਂ, ਉੱਤੇ ਵੱਲ</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-pl/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-pl/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Wyróżnione</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Dodatki</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Rozszerzenia</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Zarządzaj dodatkami</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Zarządzaj rozszerzeniami</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Przejdź w górę</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Dodatki, przejdź w górę</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Rozszerzenia, przejdź w górę</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-pt-rBR/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-pt-rBR/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Destacado</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Extensões</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensões</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Gerenciador de extensões</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Gerenciador de extensões</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Ir para o topo</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Extensões, voltar</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensões, voltar</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-pt-rPT/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-pt-rPT/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Destacado</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Extras</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensões</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Gestor de extras</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Gestor de Extensões</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navegar para cima</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Extras, navegar para cima</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensões, navegar para cima</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-rm/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-rm/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Cun emfasa</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Supplements</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Extensiuns</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Administraziun da supplements</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Administraziun dad extensiuns</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navigar ensi</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Supplements, returnar ensi</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Extensiuns, turnar ensi</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-ru/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-ru/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Меню</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Выделено</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Дополнения</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Расширения</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Менеджер дополнений</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Менеджер расширений</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Перейти наверх</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Дополнения, перейти вверх</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Расширения, перейти вверх</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sat/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sat/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">ᱢᱤᱱᱭᱩ</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">ᱩᱪᱷᱟᱹᱱᱟᱜ</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">ᱮᱰᱼᱚᱱᱥ</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">ᱮᱠᱥᱴᱮᱱᱥᱚᱱᱠᱚ</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">ᱮᱰᱼᱚᱱᱥ ᱵᱮᱵᱚᱥᱛᱟ</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">ᱮᱠᱥᱴᱮᱱᱥᱚᱱ ᱢᱮᱱᱮᱡᱚᱨ</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">ᱪᱮᱛᱟᱱ ᱥᱮᱱ ᱱᱮᱣᱤᱜᱮᱴ ᱢᱮ</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">ᱮᱰ-ᱚᱱᱥ, ᱪᱮᱛᱟᱱ ᱥᱮᱫ</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">ᱮᱠᱥᱴᱮᱱᱥᱚᱱ, ᱪᱮᱛᱟᱱ ᱛᱮ ᱥᱮᱱᱚᱜ ᱢᱮ</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sc/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sc/strings.xml
@@ -4,12 +4,8 @@
     <string name="mozac_browser_menu_button">Menù</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">In evidèntzia</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Cumplementos</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Estensiones</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Gestore de cumplementos</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Gestore de estensiones</string>
     <!-- Content description for the action bar "up" button -->

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sk/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sk/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Ponuka</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Zvýraznené</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Doplnky</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Rozšírenia</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Správca doplnkov</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Správca rozšírení</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Prejsť nahor</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Doplnky, prejsť nahor</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Rozšírenia, prejsť nahor</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-skr/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-skr/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">مینیو</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">نمایاں کیتا ڳیا</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">ایڈ ــ آن</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">ایکسٹینشنز</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">ایڈ ــ آن منیجر</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">ایکسٹنشنز منیجر</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">اُتے ون٘ڄو</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">ایڈ آن, اُتے نیویگیٹ کرو</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">ایکسٹنشناں, اُتے نیویگیٹ کرو</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sl/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sl/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Meni</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Označeno</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Dodatki</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Razširitve</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Upravitelj dodatkov</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Upravitelj razširitev</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Pojdi gor</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Dodatki, pomakni se gor</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Razširitve, pomakni se gor</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sq/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sq/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">E theksuar</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Shtesa</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Zgjerime</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Përgjegjës Shtesash</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Përgjegjës Zgjerimesh</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Lëvizni për sipër</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Shtesa, shkoni sipër</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Zgjerime, shkoni sipër</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-su/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-su/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Disorot</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Émboh</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Éksténsi</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Manajer Émboh</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Pangatur éksténsi</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Pindah ka luhur</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Add-ins, tuduhkeun ka luhur</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Éksténsi, tuduhkeun ka luhur</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sv-rSE/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-sv-rSE/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Meny</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Markerad</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Tillägg</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Tillägg</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Tilläggshanterare</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Tilläggshanterare</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navigera uppåt</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Tillägg, navigera uppåt</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Tillägg, navigera upp</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-te/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-te/strings.xml
@@ -4,12 +4,8 @@
     <string name="mozac_browser_menu_button">మెనూ</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">హైలైట్ చేసినవి</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">పొడగింతలు</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">పొడగింతలు</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">పొడగింతల నిర్వాహకి</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">పొడగింతల నిర్వాహకి</string>
     </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-tg/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-tg/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Меню</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Таъкид</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Ҷузъи иловагӣ</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Васеъшавиҳо</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Мудири ҷузъи иловагӣ</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Мудири васеъшавиҳо</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Ба боло гузаред</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Ҷузъҳои иловагӣ, гузариш ба боло</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Васеъшавиҳо, гузариш ба боло</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-th/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-th/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">เมนู</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">เน้น</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">ส่วนเสริม</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">ส่วนขยาย</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">ตัวจัดการส่วนเสริม</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">ตัวจัดการส่วนขยาย</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">นำทางขึ้นไปด้านบน</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">ส่วนเสริม, นำทางไปด้านบน</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">ส่วนขยาย, นำทางไปด้านบน</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-tr/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-tr/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menü</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Vurgulu</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Eklentiler</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Uzantılar</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Eklenti yöneticisi</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Uzantı yöneticisi</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Yukarı git</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Eklentiler, yukarı git</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Uzantılar, yukarı git</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-ug/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-ug/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">تىزىملىك</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">ئالاھىدە</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">قىستۇرما</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">كېڭەيتمە</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">قىستۇرما باشقۇرغۇچ</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">كېڭەيتمە باشقۇرۇش</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">ئۈستىگە يول باشلا</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">قوشۇلما، ئۈستىگە يول باشلا</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">كېڭەيتمە، ئۈستىگە يول باشلا</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-uk/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-uk/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Меню</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Виділено</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Додатки</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Розширення</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Керувати додатками</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Менеджер розширень</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Вгору</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Додатки, перейти вгору</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Розширення, перейти вгору</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-vi/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-vi/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">Menu</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">Đã tô sáng</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">Tiện ích</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">Tiện ích</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">Quản lí tiện ích</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">Quản lý tiện ích</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Điều hướng lên</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">Tiện ích, điều hướng lên</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">Tiện ích, điều hướng lên</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-zh-rCN/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-zh-rCN/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">菜单</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">高亮</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">附加组件</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">扩展</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">附加组件管理器</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">扩展管理器</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">向上导航</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">附加组件，向上导航</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">扩展，向上导航</string>
 </resources>

--- a/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-zh-rTW/strings.xml
+++ b/mozilla-mobile/android-components/components/browser/menu/src/main/res/values-zh-rTW/strings.xml
@@ -4,18 +4,12 @@
     <string name="mozac_browser_menu_button">選單</string>
     <!-- Content description (not visible, for screen readers etc.): Indicates the overflow menu has a highlight -->
     <string name="mozac_browser_menu_highlighted">強調</string>
-    <!-- Label for add-ons submenu section -->
-    <string name="mozac_browser_menu_addons" moz:removedIn="126" tools:ignore="UnusedResources">附加元件</string>
     <!-- Label for extensions submenu section -->
     <string name="mozac_browser_menu_extensions">擴充套件</string>
-    <!-- Label for add-ons sub menu item for add-ons manager -->
-    <string name="mozac_browser_menu_addons_manager" moz:removedIn="126" tools:ignore="UnusedResources">附加元件管理員</string>
     <!-- Label for extensions sub menu item for extensions manager -->
     <string name="mozac_browser_menu_extensions_manager">擴充套件管理員</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">向上導航</string>
-    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
-    <string name="mozac_browser_menu_addons_description" moz:removedIn="126" tools:ignore="UnusedResources">附加元件，向上導航</string>
     <!-- Content description for the action bar "up" button of the extensions sub menu item -->
     <string name="mozac_browser_menu_extensions_content_description">擴充套件，向上導航</string>
 </resources>

--- a/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-azb/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-azb/strings.xml
@@ -76,8 +76,6 @@
     <string name="mozac_feature_addons_version">یازیم</string>
     <!-- The author of an add-on. -->
     <string name="mozac_feature_addons_author">یازیجی</string>
-    <!-- The authors of an add-on. -->
-    <string name="mozac_feature_addons_authors" moz:removedIn="123" tools:ignore="UnusedResources">یازیجی‌لار</string>
     <!-- The last date that the add-on was updated. -->
     <string name="mozac_feature_addons_last_updated">سون گونجلله‌مه</string>
     <!-- The developer website (Homepage) of the add-on. -->
@@ -86,16 +84,12 @@
     <string name="mozac_feature_addons_learn_more">ایجازه‌لر حاقیندا داها آرتیق بیلین</string>
     <!-- The rating of the add-on. -->
     <string name="mozac_feature_addons_rating">دگرلندیرمه</string>
-    <!-- A link that points to the detail page of the add-on. -->
-    <string name="mozac_feature_addons_more_info_link" moz:removedIn="126" tools:ignore="UnusedResources">بو تاخیلان حاقیندا آرتیقراق بیلگی</string>
     <!-- A link that points to the detail page of the extension. -->
     <string name="mozac_feature_addons_more_info_link_2">بو اوزانتی اوچون داها چوخ بیلگی</string>
     <!-- The settings of the add-on. -->
     <string name="mozac_feature_addons_settings">تنظیم‌‎لر</string>
     <!-- Indicates the add-on is enabled. -->
     <string name="mozac_feature_addons_settings_on">آچیق</string>
-    <!-- Indicates the add-on is disabled. -->
-    <string name="mozac_feature_addons_settings_off" moz:removedIn="125" tools:ignore="UnusedResources">باغلی</string>
     <!-- Indicates the add-on is allowed in private browsing mode. -->
     <string name="mozac_feature_addons_settings_allow_in_private_browsing">اؤزل مورورچویا ایجازه وئر</string>
     <!-- Indicates the add-on is allowed in private browsing mode. -->
@@ -104,8 +98,6 @@
     <string name="mozac_feature_addons_not_allowed_in_private_browsing">گیزلی پنجره‌لرده ایجازه وئریلمیر</string>
     <!-- Indicates the add-on is enabled. -->
     <string name="mozac_feature_addons_enabled">گوجلنمیش</string>
-    <!-- Indicates the add-on is disabled. -->
-    <string name="mozac_feature_addons_disabled" moz:removedIn="125" tools:ignore="UnusedResources">گوجدن سالینمیش</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the installed section. -->
     <string name="mozac_feature_addons_installed_section">قورولدو</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the recommended section. -->
@@ -140,30 +132,18 @@
     <string name="mozac_feature_addons_permissions_dialog_deny">رد </string>
     <!-- This is a button to cancel the add-on installation . -->
     <string name="mozac_feature_addons_permissions_dialog_cancel">لغو</string>
-    <!-- Accessibility content description to install add-on button. -->
-    <string name="mozac_feature_addons_install_addon_content_description" tools:ignore="UnusedResources" moz:removedIn="124">تاخیلانی قور</string>
     <!-- Accessibility content description to install add-on button. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_install_addon_content_description_2">%1$s ـنی قور</string>
     <!-- This is the label of a button to cancel an ongoing add-on installation. -->
     <string name="mozac_feature_addons_install_addon_dialog_cancel">لغو</string>
     <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of reviews -->
     <string name="mozac_feature_addons_user_rating_count_2">نظرلر: %1$s</string>
-    <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
-    <string name="mozac_feature_addons_rating_content_description" moz:removedIn="124" tools:ignore="UnusedResources">%1$.02f/5</string>
     <!-- This is the title of page where all the add-ons are listed-->
     <string name="mozac_feature_addons_addons">تاخیلان‌لار</string>
     <!-- Label for add-ons sub menu item for add-ons manager-->
     <string name="mozac_feature_addons_addons_manager">تاخیلان مودیریتی</string>
-    <!-- The title of the "crash" notification in the add-ons manager -->
-    <string name="mozac_feature_addons_manager_notification_title_text" moz:removedIn="126" tools:ignore="UnusedResources">تاخیلان‌لار گئچیجی اولاراق گوجدن سالینمیش.</string>
     <!-- The title of the "crash" notification in the extensions manager -->
     <string name="mozac_feature_extensions_manager_notification_title_text">اوزانتی‌لار گئچیجی اوْلاراق گوُجدن سالینمیش.</string>
-    <!-- The content of the "crash" notification in the add-ons manager -->
-    <string name="mozac_feature_addons_manager_notification_content_text" moz:removedIn="126" tools:ignore="UnusedResources">بیر ویا نئچه تاخیلان دایاندیریلدی، بودا سیستمیزی ثابیتسیز ائله‌دی.</string>
-    <!-- Button to re-enable the add-ons in the "crash" notification -->
-    <string name="mozac_feature_addons_manager_notification_restart_button" moz:removedIn="126" tools:ignore="UnusedResources">تاخیلان‌لاری یئنی‌دن باشلات</string>
-    <!-- Button in the add-ons manager that opens AMO in a tab -->
-    <string name="mozac_feature_addons_find_more_addons_button_text" moz:removedIn="126" tools:ignore="UnusedResources">داها آرتیق تاخیلان آختار</string>
     <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
     <string name="mozac_feature_addons_updater_notification_allow_button">ایجازه</string>
     <!-- The label of the deny button on a notification, this will be shown to the user when an add-on needs new permissions. Indicates the user denies the new permissions and prevents the add-on from be updated-->
@@ -174,8 +154,6 @@
     <string name="mozac_feature_addons_updater_notification_content" tools:ignore="PluralsCandidate">%1$d یئنی ایجازه‌لر لازیمدیر</string>
     <!-- The content of the notification displayed when an add-on needs a new permission-->
     <string name="mozac_feature_addons_updater_notification_content_singular">بیر یئنی ایجازه لازیمدیر</string>
-    <!-- Name of the "notification channel" used for displaying a notification for updating an add-on. See https://developer.android.com/training/notify-user/channels -->
-    <string name="mozac_feature_addons_updater_notification_channel" moz:removedIn="126" tools:ignore="UnusedResources">تاخیلان گونجلله‌مه‌لری</string>
     <!-- Name of the "notification channel" used for displaying a notification for new supported add-ons. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_feature_addons_supported_checker_notification_channel" tools:ignore="UnusedResources">آرخالانمیش تاخیلان‌لارین چک ائلیه‌نی</string>
     <!-- The tile of the notification, this will be shown to the user when one newly supported add-on is available.-->
@@ -189,27 +167,13 @@
     <!-- The content of the notification, this will be shown to the user when more than two newly supported add-ons are available. %1$s is the app name (in most cases Firefox). -->
     <string name="mozac_feature_addons_supported_checker_notification_content_more_than_two">بونلاری %1$s\'ا اکله‌ییه</string>
     <!-- This is the caption for not yet supported screen caption -->
-    <string name="mozac_feature_addons_not_yet_supported_caption" moz:removedIn="126" tools:ignore="UnusedResources">فایرفاکس‌‍ین تاخیلان تکنولوژیسی مدرنلشیر. بو تاخیلان‌لار فایرفاکس ۷۵ و سونراکی یازیملارلا توتوشمایان چرچیوه‌لردن ایستیفاده ائدیر.</string>
-    <!-- This is the caption for not yet supported screen caption -->
     <string name="mozac_feature_addons_not_yet_supported_caption2">ایندی توصیه اولونان اوزانتی‌لارین ایلک سئچیمی اوچون ساپورت وئریریق.</string>
-    <!-- This is the caption for the add-on installation progress overlay -->
-    <string name="mozac_add_on_install_progress_caption" moz:removedIn="126" tools:ignore="UnusedResources">تاخیلان یئندیریلیر و دوغرولانیر…</string>
-    <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
-    <string name="mozac_feature_addons_failed_to_query_add_ons" moz:removedIn="126" tools:ignore="UnusedResources">تاخیلان‌لاری سورغولاماق  آلینمادی.</string>
     <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
     <string name="mozac_feature_addons_failed_to_translate">یئرلی %1$s اوچون و %2$s وارساییلان دیل اوچون ترجومه تاپیلمادی. </string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_successfully_installed">باشاریلی قورولدو %1$s</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_failed_to_install">%1$s قورماسی قیریلدی</string>
-    <!-- Text shown after failing to install an add-on for which we don't have its name. -->
-    <string name="mozac_feature_addons_failed_to_install_generic" moz:removedIn="126" tools:ignore="UnusedResources">بو تاخیلانین قورماسی قیریلدی</string>
-    <!-- Text shown when attempting to install an add-on and a network error happened. -->
-    <string name="mozac_feature_addons_failed_to_install_network_error" moz:removedIn="126" tools:ignore="UnusedResources">باغلانتی خطاسی سببینه گؤره بو تاخیلان یئندیری‌لنمه‌دی.</string>
-    <!-- Text shown when attempting to install an add-on and the downloaded file is corrupted. -->
-    <string name="mozac_feature_addons_failed_to_install_corrupt_error" moz:removedIn="126" tools:ignore="UnusedResources">بو تاخیلانی قورماق مومکون اولمادی، چونکی خاراب گؤرونور.</string>
-    <!-- Text shown when attempting to install an add-on and an error occurred because the extension was not signed. -->
-    <string name="mozac_feature_addons_failed_to_install_not_signed_error" moz:removedIn="126" tools:ignore="UnusedResources">بو تاخیلانی قورماق مومکون اولمادی، چونکی دوغرولانمیب.</string>
     <!-- Text shown when attempting to install an add-on and an error occurred because the extension was incompatible. %1$s is the add-on name, %2$s is the app name and %3$s is the app version. -->
     <string name="mozac_feature_addons_failed_to_install_incompatible_error">%1$s قورولا بیلمه‌دی، چونکی او، %2$s %3$s ایله اویغون دئییل.</string>
     <!-- Text shown when attempting to install a blocklisted add-on. %1$s is the add-on name. -->
@@ -232,10 +196,6 @@
     <string name="mozac_feature_addons_failed_to_remove" tools:ignore="UnusedResources">%1$s قالدیریلماسی قیریلدی</string>
     <!-- Label shown to indicate that the add-on was migrated from a previous version of the app. %1$s is the app name most of the case it will be Firefox. -->
     <string name="mozac_feature_addons_migrated_from_a_previous_version_label" tools:ignore="UnusedResources">بو تاخیلان %1$s -ین اؤنجه‌کی بیر یازیمیندان داشیندی.</string>
-    <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter. -->
-    <string name="mozac_feature_addons_unsupported_caption" moz:removedIn="126" tools:ignore="UnusedResources">تاخیلان</string>
-    <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter - plural. %1$s is the number of unsupported add-ons -->
-    <string name="mozac_feature_addons_unsupported_caption_plural" moz:removedIn="126" tools:ignore="UnusedResources">%1$s تاخیلان</string>
     <!-- Text link to a sumo page for learning more about unsupported add-ons. -->
     <string name="mozac_feature_addons_unsupported_learn_more">آرتیق بیلین</string>
     <!-- Displayed in the "Status" field for the updater when an add-on has been correctly updated. -->
@@ -252,10 +212,6 @@
     <string name="mozac_feature_addons_updater_dialog_status">دوروم:</string>
     <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. %2$s is the app name. -->
     <string name="mozac_feature_addons_installed_dialog_title">%1$s، %2$s لیستینه اکلندی.</string>
-    <!-- Text shown in the dialog when add-on installation is completed. -->
-    <string name="mozac_feature_addons_installed_dialog_description" moz:removedIn="124" tools:ignore="UnusedResources">منودا آچین</string>
-    <!-- Confirmation button text for the dialog when add-on installation is completed. -->
-    <string name="mozac_feature_addons_installed_dialog_okay_button" moz:removedIn="124" tools:ignore="UnusedResources">تامام، باشا دوشدوم</string>
     <!-- "Learn more" link displayed below an add-on status message. -->
     <string name="mozac_feature_addons_status_learn_more">آرتیق بیلین</string>
     <!-- Status message below an add-on in the add-ons manager when this add-on has been blocklisted. %1$s is the add-on name. -->

--- a/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-be/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-be/strings.xml
@@ -76,8 +76,6 @@
     <string name="mozac_feature_addons_version">Версія</string>
     <!-- The author of an add-on. -->
     <string name="mozac_feature_addons_author">Аўтар</string>
-    <!-- The authors of an add-on. -->
-    <string name="mozac_feature_addons_authors" moz:removedIn="123" tools:ignore="UnusedResources">Аўтары</string>
     <!-- The last date that the add-on was updated. -->
     <string name="mozac_feature_addons_last_updated">Апошняе абнаўленне</string>
     <!-- The developer website (Homepage) of the add-on. -->
@@ -86,16 +84,12 @@
     <string name="mozac_feature_addons_learn_more">Даведацца больш пра дазволы</string>
     <!-- The rating of the add-on. -->
     <string name="mozac_feature_addons_rating">Ацэнка</string>
-    <!-- A link that points to the detail page of the add-on. -->
-    <string name="mozac_feature_addons_more_info_link" moz:removedIn="126" tools:ignore="UnusedResources">Падрабязней аб гэтым дадатку</string>
     <!-- A link that points to the detail page of the extension. -->
     <string name="mozac_feature_addons_more_info_link_2">Падрабязней аб гэтым пашырэнні</string>
     <!-- The settings of the add-on. -->
     <string name="mozac_feature_addons_settings">Налады</string>
     <!-- Indicates the add-on is enabled. -->
     <string name="mozac_feature_addons_settings_on">Укл.</string>
-    <!-- Indicates the add-on is disabled. -->
-    <string name="mozac_feature_addons_settings_off" moz:removedIn="125" tools:ignore="UnusedResources">Выкл.</string>
     <!-- Indicates the add-on is allowed in private browsing mode. -->
     <string name="mozac_feature_addons_settings_allow_in_private_browsing">Дазволена ў прыватным агляданні</string>
     <!-- Indicates the add-on is allowed in private browsing mode. -->
@@ -104,8 +98,6 @@
     <string name="mozac_feature_addons_not_allowed_in_private_browsing">Не дазволена ў прыватных вокнах</string>
     <!-- Indicates the add-on is enabled. -->
     <string name="mozac_feature_addons_enabled">Уключаны</string>
-    <!-- Indicates the add-on is disabled. -->
-    <string name="mozac_feature_addons_disabled" moz:removedIn="125" tools:ignore="UnusedResources">Выключаны</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the installed section. -->
     <string name="mozac_feature_addons_installed_section">Усталявана</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the recommended section. -->
@@ -140,36 +132,24 @@
     <string name="mozac_feature_addons_permissions_dialog_deny">Адмовіць</string>
     <!-- This is a button to cancel the add-on installation . -->
     <string name="mozac_feature_addons_permissions_dialog_cancel">Адмяніць</string>
-    <!-- Accessibility content description to install add-on button. -->
-    <string name="mozac_feature_addons_install_addon_content_description" tools:ignore="UnusedResources" moz:removedIn="124">Усталяваць дадатак</string>
     <!-- Accessibility content description to install add-on button. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_install_addon_content_description_2">Усталяваць %1$s</string>
     <!-- This is the label of a button to cancel an ongoing add-on installation. -->
     <string name="mozac_feature_addons_install_addon_dialog_cancel">Адмяніць</string>
     <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of reviews -->
     <string name="mozac_feature_addons_user_rating_count_2">Водгукі: %1$s</string>
-    <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
-    <string name="mozac_feature_addons_rating_content_description" moz:removedIn="124" tools:ignore="UnusedResources">%1$.02f/5</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars. -->
     <string name="mozac_feature_addons_rating_content_description_2">Ацэнка: %1$.02f з 5</string>
     <!-- This is the title of page where all the add-ons are listed-->
     <string name="mozac_feature_addons_addons">Дадаткі</string>
     <!-- Label for add-ons sub menu item for add-ons manager-->
     <string name="mozac_feature_addons_addons_manager">Менеджар дадаткаў</string>
-    <!-- The title of the "crash" notification in the add-ons manager -->
-    <string name="mozac_feature_addons_manager_notification_title_text" moz:removedIn="126" tools:ignore="UnusedResources">Дадаткі часова адключаны</string>
     <!-- The title of the "crash" notification in the extensions manager -->
     <string name="mozac_feature_extensions_manager_notification_title_text">Пашырэнні часова адключаны</string>
-    <!-- The content of the "crash" notification in the add-ons manager -->
-    <string name="mozac_feature_addons_manager_notification_content_text" moz:removedIn="126" tools:ignore="UnusedResources">Адзін або некалькі дадатковых кампанентаў перасталі працаваць, што зрабіла вашу сістэму нестабільнай.</string>
     <!-- The content of the "crash" notification in the extensions manager -->
     <string name="mozac_feature_extensions_manager_notification_content_text">Адно або некалькі пашырэнняў перасталі працаваць, што зрабіла вашу сістэму нестабільнай.</string>
-    <!-- Button to re-enable the add-ons in the "crash" notification -->
-    <string name="mozac_feature_addons_manager_notification_restart_button" moz:removedIn="126" tools:ignore="UnusedResources">Перазапусціць дадаткі</string>
     <!-- Button to re-enable the extensions in the "crash" notification -->
     <string name="mozac_feature_extensions_manager_notification_restart_button">Перазапусціць пашырэнні</string>
-    <!-- Button in the add-ons manager that opens AMO in a tab -->
-    <string name="mozac_feature_addons_find_more_addons_button_text" moz:removedIn="126" tools:ignore="UnusedResources">Знайсці больш дадаткаў</string>
     <!-- Button in the extensions manager that opens AMO in a tab -->
     <string name="mozac_feature_addons_find_more_extensions_button_text">Знайсці іншыя пашырэнні</string>
     <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
@@ -182,8 +162,6 @@
     <string name="mozac_feature_addons_updater_notification_content" tools:ignore="PluralsCandidate">%1$d патрэбныя новыя дазволы</string>
     <!-- The content of the notification displayed when an add-on needs a new permission-->
     <string name="mozac_feature_addons_updater_notification_content_singular">Патрэбен новы дазвол</string>
-    <!-- Name of the "notification channel" used for displaying a notification for updating an add-on. See https://developer.android.com/training/notify-user/channels -->
-    <string name="mozac_feature_addons_updater_notification_channel" moz:removedIn="126" tools:ignore="UnusedResources">Абнаўленні дадаткаў</string>
     <!-- Name of the "notification channel" used for displaying a notification for updating an extension. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_feature_addons_updater_notification_channel_2">Абнаўленні пашырэнняў</string>
     <!-- Name of the "notification channel" used for displaying a notification for new supported add-ons. See https://developer.android.com/training/notify-user/channels -->
@@ -199,27 +177,13 @@
     <!-- The content of the notification, this will be shown to the user when more than two newly supported add-ons are available. %1$s is the app name (in most cases Firefox). -->
     <string name="mozac_feature_addons_supported_checker_notification_content_more_than_two">Дадаць іх да %1$s</string>
     <!-- This is the caption for not yet supported screen caption -->
-    <string name="mozac_feature_addons_not_yet_supported_caption" moz:removedIn="126" tools:ignore="UnusedResources">Тэхналогія дадаткаў Firefox мадэрнізуецца. Гэтыя дадаткі выкарыстоўваюць фрэймворкі, якія не сумяшчальныя з Firefox версіі 75 і вышэй.</string>
-    <!-- This is the caption for not yet supported screen caption -->
     <string name="mozac_feature_addons_not_yet_supported_caption2">Зараз мы ствараем падтрымку для пачатковага набору рэкамендаваных пашырэнняў.</string>
-    <!-- This is the caption for the add-on installation progress overlay -->
-    <string name="mozac_add_on_install_progress_caption" moz:removedIn="126" tools:ignore="UnusedResources">Спампоўка і праверка дадатку…</string>
-    <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
-    <string name="mozac_feature_addons_failed_to_query_add_ons" moz:removedIn="126" tools:ignore="UnusedResources">Не атрымалася запытацца на дадаткі</string>
     <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
     <string name="mozac_feature_addons_failed_to_translate">Пераклад не знойдзены, ні для лакалі %1$s, ні для прадвызначанай мовы %2$s</string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_successfully_installed">%1$s паспяхова ўсталяваны</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_failed_to_install">Не атрымалася ўсталяваць %1$s</string>
-    <!-- Text shown after failing to install an add-on for which we don't have its name. -->
-    <string name="mozac_feature_addons_failed_to_install_generic" moz:removedIn="126" tools:ignore="UnusedResources">Не ўдалося ўсталяваць гэты дадатак.</string>
-    <!-- Text shown when attempting to install an add-on and a network error happened. -->
-    <string name="mozac_feature_addons_failed_to_install_network_error" moz:removedIn="126" tools:ignore="UnusedResources">Немагчыма сцягнуць гэты дадатак, бо злучэнне не ўдалося.</string>
-    <!-- Text shown when attempting to install an add-on and the downloaded file is corrupted. -->
-    <string name="mozac_feature_addons_failed_to_install_corrupt_error" moz:removedIn="126" tools:ignore="UnusedResources">Гэты дадатак не можа быць усталяваны, бо ён выглядае пашкоджаным.</string>
-    <!-- Text shown when attempting to install an add-on and an error occurred because the extension was not signed. -->
-    <string name="mozac_feature_addons_failed_to_install_not_signed_error" moz:removedIn="126" tools:ignore="UnusedResources">Гэты дадатак не можа быць усталяваны, бо ён не правераны.</string>
     <!-- Text shown when attempting to install an add-on and an error occurred because the extension was incompatible. %1$s is the add-on name, %2$s is the app name and %3$s is the app version. -->
     <string name="mozac_feature_addons_failed_to_install_incompatible_error">%1$s не можа быць усталяваны, бо ён несумяшчальны з %2$s %3$s.</string>
     <!-- Text shown when attempting to install a blocklisted add-on. %1$s is the add-on name. -->
@@ -242,12 +206,8 @@
     <string name="mozac_feature_addons_failed_to_remove" tools:ignore="UnusedResources">Не атрымалася выдаліць %1$s</string>
     <!-- Label shown to indicate that the add-on was migrated from a previous version of the app. %1$s is the app name most of the case it will be Firefox. -->
     <string name="mozac_feature_addons_migrated_from_a_previous_version_label" tools:ignore="UnusedResources">Гэты дадатак перанесены з папярэдняй версіі %1$s</string>
-    <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter. -->
-    <string name="mozac_feature_addons_unsupported_caption" moz:removedIn="126" tools:ignore="UnusedResources">1 дадатак</string>
     <!-- Text shown in not yet supported add-ons section. -->
     <string name="mozac_feature_addons_unsupported_caption_2">1 пашырэнне</string>
-    <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter - plural. %1$s is the number of unsupported add-ons -->
-    <string name="mozac_feature_addons_unsupported_caption_plural" moz:removedIn="126" tools:ignore="UnusedResources">Дадаткаў: %1$s</string>
     <!-- Text shown in not yet supported add-ons section - plural. %1$s is the number of unsupported extensions. -->
     <string name="mozac_feature_addons_unsupported_caption_plural_2">%1$s пашырэнняў</string>
     <!-- Text link to a sumo page for learning more about unsupported add-ons. -->
@@ -266,12 +226,8 @@
     <string name="mozac_feature_addons_updater_dialog_status">Статус:</string>
     <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. %2$s is the app name. -->
     <string name="mozac_feature_addons_installed_dialog_title">%1$s было дададзена ў %2$s</string>
-    <!-- Text shown in the dialog when add-on installation is completed. -->
-    <string name="mozac_feature_addons_installed_dialog_description" moz:removedIn="124" tools:ignore="UnusedResources">Адкрыць яго ў меню</string>
     <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. %2$s is the app name. -->
     <string name="mozac_feature_addons_installed_dialog_description_2">Доступ да %1$s з меню %2$s.</string>
-    <!-- Confirmation button text for the dialog when add-on installation is completed. -->
-    <string name="mozac_feature_addons_installed_dialog_okay_button" moz:removedIn="124" tools:ignore="UnusedResources">Добра, зразумела</string>
     <!-- Confirmation button text for the dialog when add-on installation is completed. -->
     <string name="mozac_feature_addons_installed_dialog_okay_button_2">OK</string>
     <!-- "Learn more" link displayed below an add-on status message. -->

--- a/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-cak/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-cak/strings.xml
@@ -76,8 +76,6 @@
     <string name="mozac_feature_addons_version">Ruwäch</string>
     <!-- The author of an add-on. -->
     <string name="mozac_feature_addons_author">B\'anel</string>
-    <!-- The authors of an add-on. -->
-    <string name="mozac_feature_addons_authors" moz:removedIn="123" tools:ignore="UnusedResources">Taq b\'anel</string>
     <!-- The last date that the add-on was updated. -->
     <string name="mozac_feature_addons_last_updated">Ruk\'isib\'äl k\'exoj</string>
     <!-- The developer website (Homepage) of the add-on. -->
@@ -86,16 +84,12 @@
     <string name="mozac_feature_addons_learn_more">Tetamäx ch\'aqa\' chik chi kij ri taq ya\'öl q\'ij</string>
     <!-- The rating of the add-on. -->
     <string name="mozac_feature_addons_rating">Kejqalem</string>
-    <!-- A link that points to the detail page of the add-on. -->
-    <string name="mozac_feature_addons_more_info_link" moz:removedIn="126" tools:ignore="UnusedResources">Ch\'aqa\' chik chi rij re tz\'aqat re\'</string>
     <!-- A link that points to the detail page of the extension. -->
     <string name="mozac_feature_addons_more_info_link_2">Ch\'aqa\' chik chi rij re k\'amal re\'</string>
     <!-- The settings of the add-on. -->
     <string name="mozac_feature_addons_settings">Taq nuk\'ulem</string>
     <!-- Indicates the add-on is enabled. -->
     <string name="mozac_feature_addons_settings_on">Tzijïl</string>
-    <!-- Indicates the add-on is disabled. -->
-    <string name="mozac_feature_addons_settings_off" moz:removedIn="125" tools:ignore="UnusedResources">Chupül</string>
     <!-- Indicates the add-on is allowed in private browsing mode. -->
     <string name="mozac_feature_addons_settings_allow_in_private_browsing">Tiya\' q\'ij chi re pa ichinan okem pa k\'amaya\'l</string>
     <!-- Indicates the add-on is allowed in private browsing mode. -->
@@ -104,8 +98,6 @@
     <string name="mozac_feature_addons_not_allowed_in_private_browsing">Man okel ta pa ichinan rutzuwäch</string>
     <!-- Indicates the add-on is enabled. -->
     <string name="mozac_feature_addons_enabled">Tzijon</string>
-    <!-- Indicates the add-on is disabled. -->
-    <string name="mozac_feature_addons_disabled" moz:removedIn="125" tools:ignore="UnusedResources">Chupun</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the installed section. -->
     <string name="mozac_feature_addons_installed_section">Xyak</string>
     <!-- This is displayed in a page where the user can see the installed and recommended(not installed yet) add-ons, this string indicates the recommended section. -->
@@ -140,36 +132,24 @@
     <string name="mozac_feature_addons_permissions_dialog_deny">Tixutüx</string>
     <!-- This is a button to cancel the add-on installation . -->
     <string name="mozac_feature_addons_permissions_dialog_cancel">Tiq\'at</string>
-    <!-- Accessibility content description to install add-on button. -->
-    <string name="mozac_feature_addons_install_addon_content_description" tools:ignore="UnusedResources" moz:removedIn="124">Tiyak ri Tz\'aqat</string>
     <!-- Accessibility content description to install add-on button. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_install_addon_content_description_2">Tiyak %1$s</string>
     <!-- This is the label of a button to cancel an ongoing add-on installation. -->
     <string name="mozac_feature_addons_install_addon_dialog_cancel">Tiq\'at</string>
     <!-- Indicates how many users have rated an add-on. %1$s will be replaced with number of reviews -->
     <string name="mozac_feature_addons_user_rating_count_2">Taq nik\'oxïk: %1$s</string>
-    <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars and / separator and 5 the maximum number of stars e.g (2/5, 4.5/5 or 5/5)  . -->
-    <string name="mozac_feature_addons_rating_content_description" moz:removedIn="124" tools:ignore="UnusedResources">%1$.02f/5</string>
     <!-- Accessibility content description for the amount of stars that add-on has, where %1$.02f will be the amount of stars. -->
     <string name="mozac_feature_addons_rating_content_description_2">Rajlab\'al: %1$.02f richin 5</string>
     <!-- This is the title of page where all the add-ons are listed-->
     <string name="mozac_feature_addons_addons">Taq tz\'aqat</string>
     <!-- Label for add-ons sub menu item for add-ons manager-->
     <string name="mozac_feature_addons_addons_manager">Kinuk\'samajel taq Tz\'aqat</string>
-    <!-- The title of the "crash" notification in the add-ons manager -->
-    <string name="mozac_feature_addons_manager_notification_title_text" moz:removedIn="126" tools:ignore="UnusedResources">Echupun jumej ri taq tz\'aqat</string>
     <!-- The title of the "crash" notification in the extensions manager -->
     <string name="mozac_feature_extensions_manager_notification_title_text">Echupun jumej ri taq k\'amal</string>
-    <!-- The content of the "crash" notification in the add-ons manager -->
-    <string name="mozac_feature_addons_manager_notification_content_text" moz:removedIn="126" tools:ignore="UnusedResources">Jun o ka\'i\' oxi\' taq tz\'aqat xkiq\'ät kisamaj, ri nub\'än chi man jikil ta ri q\'inoj.</string>
     <!-- The content of the "crash" notification in the extensions manager -->
     <string name="mozac_feature_extensions_manager_notification_content_text">Jun o ka\'i\' oxi\' taq k\'amal xkiq\'ät kisamaj, ri nub\'än chi man jikil ta ri q\'inoj.</string>
-    <!-- Button to re-enable the add-ons in the "crash" notification -->
-    <string name="mozac_feature_addons_manager_notification_restart_button" moz:removedIn="126" tools:ignore="UnusedResources">Ketzij chik ri taq tz\'aqat</string>
     <!-- Button to re-enable the extensions in the "crash" notification -->
     <string name="mozac_feature_extensions_manager_notification_restart_button">Ketzij chik k\'amal</string>
-    <!-- Button in the add-ons manager that opens AMO in a tab -->
-    <string name="mozac_feature_addons_find_more_addons_button_text" moz:removedIn="126" tools:ignore="UnusedResources">Kekanöx ch\'aqa\' chik taq tz\'aqat</string>
     <!-- Button in the extensions manager that opens AMO in a tab -->
     <string name="mozac_feature_addons_find_more_extensions_button_text">Ke\'ilitäj ch\'aqa\' chik taq k\'amal</string>
     <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
@@ -182,8 +162,6 @@
     <string name="mozac_feature_addons_updater_notification_content" tools:ignore="PluralsCandidate">Najowäx %1$d k\'ak\'a\' ya\'oj q\'ij</string>
     <!-- The content of the notification displayed when an add-on needs a new permission-->
     <string name="mozac_feature_addons_updater_notification_content_singular">Najowäx jun k\'ak\'a\' ya\'oj q\'ij</string>
-    <!-- Name of the "notification channel" used for displaying a notification for updating an add-on. See https://developer.android.com/training/notify-user/channels -->
-    <string name="mozac_feature_addons_updater_notification_channel" moz:removedIn="126" tools:ignore="UnusedResources">Kik\'exoj tz\'aqat</string>
     <!-- Name of the "notification channel" used for displaying a notification for updating an extension. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_feature_addons_updater_notification_channel_2">Kik\'exoj k\'amal</string>
     <!-- Name of the "notification channel" used for displaying a notification for new supported add-ons. See https://developer.android.com/training/notify-user/channels -->
@@ -199,15 +177,9 @@
     <!-- The content of the notification, this will be shown to the user when more than two newly supported add-ons are available. %1$s is the app name (in most cases Firefox). -->
     <string name="mozac_feature_addons_supported_checker_notification_content_more_than_two">Ketz\'aqatisäx pa %1$s</string>
     <!-- This is the caption for not yet supported screen caption -->
-    <string name="mozac_feature_addons_not_yet_supported_caption" moz:removedIn="126" tools:ignore="UnusedResources">Nib\'an k\'ak\'a\' chi re ri runa\'ob\'al rutz\'aqat Firefox. Re taq tz\'aqat re\' yekokisaj taq ruchi\' ri man kik\'amon ta ki\' rik\'in ri Firefox 75 &amp; ch\'aqa\' chik e nima\'q.</string>
-    <!-- This is the caption for not yet supported screen caption -->
     <string name="mozac_feature_addons_not_yet_supported_caption2">Wakami niqanük\' tob\'äl kichin nab\'ey cha\'oj taq K\'amal Echilab\'en.</string>
-    <!-- This is the caption for the add-on installation progress overlay -->
-    <string name="mozac_add_on_install_progress_caption" moz:removedIn="126" tools:ignore="UnusedResources">Niqasäx chuqa\' ninik\'öx tz\'aqat…</string>
     <!-- This is the caption for the extension installation progress overlay -->
     <string name="mozac_extension_install_progress_caption">Niqasäx chuqa\' ninik\'öx k\'amal…</string>
-    <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
-    <string name="mozac_feature_addons_failed_to_query_add_ons" moz:removedIn="126" tools:ignore="UnusedResources">¡Xsach toq xk\'utüx Tz\'aqat!</string>
     <!-- Error shown when something unexpected happened while trying to get the extension list from the server -->
     <string name="mozac_feature_addons_failed_to_query_extensions">¡Xsach toq xk\'utüx K\'amal!</string>
     <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
@@ -216,20 +188,12 @@
     <string name="mozac_feature_addons_successfully_installed">Ütz xyak ri %1$s</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_failed_to_install">Xsach toq xyak ri %1$s</string>
-    <!-- Text shown after failing to install an add-on for which we don't have its name. -->
-    <string name="mozac_feature_addons_failed_to_install_generic" moz:removedIn="126" tools:ignore="UnusedResources">Xsach toq niyak re tz\'aqat re\'.</string>
     <!-- Text shown after failing to install an extension for which we don't have its name. -->
     <string name="mozac_feature_addons_extension_failed_to_install">Xsach toq niyak re k\'amal re\'.</string>
-    <!-- Text shown when attempting to install an add-on and a network error happened. -->
-    <string name="mozac_feature_addons_failed_to_install_network_error" moz:removedIn="126" tools:ignore="UnusedResources">Man xqasäx ta re tz\'aqat re ruma man pa rub\'eyal taq ri rokem.</string>
     <!-- Text shown when attempting to install an extension and a network error happened. -->
     <string name="mozac_feature_addons_extension_failed_to_install_network_error">Man xqasäx ta re k\'amal re ruma man pa rub\'eyal taq ri rokem.</string>
-    <!-- Text shown when attempting to install an add-on and the downloaded file is corrupted. -->
-    <string name="mozac_feature_addons_failed_to_install_corrupt_error" moz:removedIn="126" tools:ignore="UnusedResources">Man xyak ta kan re tz\'aqat xa ke xa man ütz ta.</string>
     <!-- Text shown when attempting to install an extension and the downloaded file is corrupted. -->
     <string name="mozac_feature_addons_extension_failed_to_install_corrupt_error">Man xyak ta kan re k\'amal xa ke xa man ütz ta.</string>
-    <!-- Text shown when attempting to install an add-on and an error occurred because the extension was not signed. -->
-    <string name="mozac_feature_addons_failed_to_install_not_signed_error" moz:removedIn="126" tools:ignore="UnusedResources">Man xyak ta kan re jun rutz\'aqat re\' ruma chi man nik\'on ta.</string>
     <!-- Text shown when attempting to install an add-on and an error occurred because the extension was not signed. -->
     <string name="mozac_feature_addons_extension_failed_to_install_not_signed_error">Man xyak ta kan re jun k\'amal re\' ruma chi man nik\'on ta.</string>
     <!-- Text shown when attempting to install an add-on and an error occurred because the extension was incompatible. %1$s is the add-on name, %2$s is the app name and %3$s is the app version. -->
@@ -254,12 +218,8 @@
     <string name="mozac_feature_addons_failed_to_remove" tools:ignore="UnusedResources">Xsach toq xyuj ri %1$s</string>
     <!-- Label shown to indicate that the add-on was migrated from a previous version of the app. %1$s is the app name most of the case it will be Firefox. -->
     <string name="mozac_feature_addons_migrated_from_a_previous_version_label" tools:ignore="UnusedResources">Re tz\'aqat re\' xk\'am pe pa jun kan ruwäch %1$s</string>
-    <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter. -->
-    <string name="mozac_feature_addons_unsupported_caption" moz:removedIn="126" tools:ignore="UnusedResources">1 tz\'aqat</string>
     <!-- Text shown in not yet supported add-ons section. -->
     <string name="mozac_feature_addons_unsupported_caption_2">1 k\'amal</string>
-    <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter - plural. %1$s is the number of unsupported add-ons -->
-    <string name="mozac_feature_addons_unsupported_caption_plural" moz:removedIn="126" tools:ignore="UnusedResources">%1$s taq tz\'aqat</string>
     <!-- Text shown in not yet supported add-ons section - plural. %1$s is the number of unsupported extensions. -->
     <string name="mozac_feature_addons_unsupported_caption_plural_2">%1$s taq k\'amal</string>
     <!-- Text link to a sumo page for learning more about unsupported add-ons. -->
@@ -278,12 +238,8 @@
     <string name="mozac_feature_addons_updater_dialog_status">Rub\'anikil:</string>
     <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. %2$s is the app name. -->
     <string name="mozac_feature_addons_installed_dialog_title">%1$s xtz\'aqatisäx pa %2$s.</string>
-    <!-- Text shown in the dialog when add-on installation is completed. -->
-    <string name="mozac_feature_addons_installed_dialog_description" moz:removedIn="124" tools:ignore="UnusedResources">Tijaq pa k\'utsamaj</string>
     <!-- Text shown in the dialog when add-on installation is completed. %1$s is the add-on name. %2$s is the app name. -->
     <string name="mozac_feature_addons_installed_dialog_description_2">Tok pa %1$s chupam ri %2$s cholsamaj.</string>
-    <!-- Confirmation button text for the dialog when add-on installation is completed. -->
-    <string name="mozac_feature_addons_installed_dialog_okay_button" moz:removedIn="124" tools:ignore="UnusedResources">Ütz, Xq\'ax pa nuwi\'</string>
     <!-- Confirmation button text for the dialog when add-on installation is completed. -->
     <string name="mozac_feature_addons_installed_dialog_okay_button_2">ÜTZ</string>
     <!-- "Learn more" link displayed below an add-on status message. -->

--- a/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-ka/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-ka/strings.xml
@@ -74,8 +74,6 @@
     <string name="mozac_feature_addons_version">ვერსია</string>
     <!-- The author of an add-on. -->
     <string name="mozac_feature_addons_author">შემქმნელი</string>
-    <!-- The authors of an add-on. -->
-    <string name="mozac_feature_addons_authors" moz:removedIn="120" tools:ignore="UnusedResources">შემქმნელები</string>
     <!-- The last date that the add-on was updated. -->
     <string name="mozac_feature_addons_last_updated">ბოლო განახლება</string>
     <!-- The developer website (Homepage) of the add-on. -->

--- a/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-sr/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-sr/strings.xml
@@ -74,8 +74,6 @@
     <string name="mozac_feature_addons_version">Верзија</string>
     <!-- The author of an add-on. -->
     <string name="mozac_feature_addons_author">Аутор</string>
-    <!-- The authors of an add-on. -->
-    <string name="mozac_feature_addons_authors" moz:removedIn="120" tools:ignore="UnusedResources">Аутори</string>
     <!-- The last date that the add-on was updated. -->
     <string name="mozac_feature_addons_last_updated">Последњи пут ажурирано</string>
     <!-- The developer website (Homepage) of the add-on. -->

--- a/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-te/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/addons/src/main/res/values-te/strings.xml
@@ -132,8 +132,6 @@
     <string name="mozac_feature_addons_updater_notification_content" tools:ignore="PluralsCandidate">%1$d కొత్త అనుమతులు అవసరం</string>
     <!-- The content of the notification displayed when an add-on needs a new permission-->
     <string name="mozac_feature_addons_updater_notification_content_singular">కొత్త అనుమతి కావాలి</string>
-    <!-- Name of the "notification channel" used for displaying a notification for updating an add-on. See https://developer.android.com/training/notify-user/channels -->
-    <string name="mozac_feature_addons_updater_notification_channel" moz:removedIn="126" tools:ignore="UnusedResources">పొడగింత తాజాకరణలు</string>
     <!-- Name of the "notification channel" used for displaying a notification for new supported add-ons. See https://developer.android.com/training/notify-user/channels -->
     <string name="mozac_feature_addons_supported_checker_notification_channel" tools:ignore="UnusedResources">తోడ్పాటున్న పొడగింతల చెకర్</string>
     <!-- The tile of the notification, this will be shown to the user when one newly supported add-on is available.-->
@@ -147,13 +145,7 @@
     <!-- The content of the notification, this will be shown to the user when more than two newly supported add-ons are available. %1$s is the app name (in most cases Firefox). -->
     <string name="mozac_feature_addons_supported_checker_notification_content_more_than_two">వాటిని %1$sకు చేర్చు</string>
     <!-- This is the caption for not yet supported screen caption -->
-    <string name="mozac_feature_addons_not_yet_supported_caption" moz:removedIn="126" tools:ignore="UnusedResources">Firefox పొడగింతల సాంకేతికత ఆధునికీకరించబడుతోంది. ఈ పొడగింతలు Firefox 75 ఆ తర్వాతి వెర్షనలకు అనుగుణంగా లేని ఫ్రేమువర్కులను వాడుతున్నాయి.</string>
-    <!-- This is the caption for not yet supported screen caption -->
     <string name="mozac_feature_addons_not_yet_supported_caption2">ప్రస్తుతం మేము ముందుగా ఎంచుకున్న సిఫార్సుచేయబడ్డ పొడగింతలకు తోడ్పాటును నిర్మిస్తున్నాము.</string>
-    <!-- This is the caption for the add-on installation progress overlay -->
-    <string name="mozac_add_on_install_progress_caption" moz:removedIn="126" tools:ignore="UnusedResources">పొడగింతను దించుకుంటుంది, తనిఖీ చేస్తుంది…</string>
-    <!-- Error shown when something unexpected happened while trying to get the add-on list from the server -->
-    <string name="mozac_feature_addons_failed_to_query_add_ons" moz:removedIn="126" tools:ignore="UnusedResources">పొడగింతలను తేవడం విఫలమైంది!</string>
     <!-- Error shown when unable to find a translation for an add-on field. %1$s is the locale of the user and %2$s is the default language of the add-on -->
     <string name="mozac_feature_addons_failed_to_translate">%1$s లొకేల్, అప్రమేయ భాష %2$s లలో దేనికీ అనువాదం దొరకలేదు</string>
     <!-- Text shown after successfully installed an add-on. %1$s is the add-on name. -->
@@ -178,10 +170,6 @@
     <string name="mozac_feature_addons_failed_to_remove" tools:ignore="UnusedResources">%1$sని తొలగించడం విఫలమైంది</string>
     <!-- Label shown to indicate that the add-on was migrated from a previous version of the app. %1$s is the app name most of the case it will be Firefox. -->
     <string name="mozac_feature_addons_migrated_from_a_previous_version_label" tools:ignore="UnusedResources">ఈ పొడగింత %1$s యొక్క మునుపటి వెర్షను నుండి తేబడింది</string>
-    <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter. -->
-    <string name="mozac_feature_addons_unsupported_caption" moz:removedIn="126" tools:ignore="UnusedResources">1 పొడగింత</string>
-    <!-- Text shown in not yet supported add-ons section in AddonsManagerAdapter - plural. %1$s is the number of unsupported add-ons -->
-    <string name="mozac_feature_addons_unsupported_caption_plural" moz:removedIn="126" tools:ignore="UnusedResources">%1$s పొడగింతలు</string>
     <!-- Text link to a sumo page for learning more about unsupported add-ons. -->
     <string name="mozac_feature_addons_unsupported_learn_more">ఇంకా తెలుసుకోండి</string>
     <!-- Displayed in the "Status" field for the updater when an add-on has been correctly updated. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-an/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-an/strings.xml
@@ -16,26 +16,12 @@
     <string name="mozac_feature_prompt_username_hint">Nombre d’usuario</string>
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Clau</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">No alzar-lo</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">No alzar nunca</string>
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Alzar-lo</string>
-    <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">No actualizar-lo</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Actualizar</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Lo campo Clau no puede estar vuedo</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">No se puede alzar l’inicio de sesión</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Alzar este inicio de sesión?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Actualizar este inicio de sesión?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Anyadir nombre de usuario a la clau alzada?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
     <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
     <string name="mozac_feature_prompts_content_description_input_label">Etiqueta pa escribir un campo de dentrada de texto</string>
@@ -79,14 +65,6 @@
     <string name="mozac_feature_prompts_nov">Nov</string>
     <!-- December month of the year (short description), used on the month chooser dialog. -->
     <string name="mozac_feature_prompts_dec">Avi</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Chestiona os inicios de sesión</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expande los inicios de sesión sucherius</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Reduce los inicios de sesión sucherius</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Inicios de sesión sucherius</string>
 
     <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
     <string name="mozac_feature_prompt_repost_title">Tornar a ninviar datos a esta pachina?</string>
@@ -97,13 +75,5 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancelar</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Seleccionar tarcheta de credito</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expande las tarchetas de credito sucheridas</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Reduce las tarchetas de credito sucheridas</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Chestiona las tarchetas de credito</string>
 
     </resources>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ar/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ar/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">كلمة السر</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">لا تحفظ</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">ليس الآن</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">لا تحفظ أبدًا</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">احفظ</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">لا تُحدّث</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">ليس الآن</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">حدّث</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">لا يمكن أن يكون حقل كلمة السر فارغًا</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">أدخل كلمة سرّ</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">تعذّر حفظ جلسة الولوج</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">لا يمكن حفظ كلمة السر</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">أنحفظ هذا الولوج؟</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">حفظ كلمة السرّ؟</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">أنحدّث هذا الولوج؟</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">تحديث كلمة السرّ؟</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">أنُضيف اسم المستخدم إلى كلمة المرور المحفوظة؟</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">حدّث اسم المستخدم؟</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">ديسمبر</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">اضبط الوقت</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">أدِر جلسات الولوج</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">أدِر كلمات السر</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">وسّع جلسات الولوج المقترحة</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">وسّع كلمات المرور المحفوظة</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">اطوِ جلسات الولوج المقترحة</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">اطو كلمات المرور المحفوظة</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">جلسات الولوج المقترحة</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">كلمات السرّ المحفوظة</string>
@@ -125,8 +103,6 @@
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">استخدام كلمة سر قوية؟</string>
 
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">احمِ حساباتك باستخدام كلمة مرور قوية يتم إنشاؤها عشوائيًا. واحصل على وصول سريع إلى كلمات مرورك عن طريق حفظها في حسابك.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">احمِ حساباتك باستخدام كلمة مرور قوية يتم إنشاؤها عشوائيًا. سيتم حفظها في حسابك لاستخدامها في المستقبل.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
@@ -152,28 +128,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">ألغِ</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">اختر بطاقة ائتمان</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">استخدم بطاقة محفوظة</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">وسّع بطاقات الائتمان المقترحة</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">وسّع البطاقات المحفوظة</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">اطوِ بطاقات الائتمان المقترحة</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">اطو البطاقات المحفوظة</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">أدِر بطاقات الائتمان</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">إدارة البطاقات</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">أأحفظ هذه البطاقة بأمان؟</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">أتريد تحديث تاريخ انتهاء البطاقة؟</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">سيُعمّى رقم البطاقة. لن يُحفظ رمز الأمان.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">يشفر %s رقم بطاقتك، ولن يحفظ رمز أمانك.</string>
@@ -181,12 +147,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">اختر العنوان</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">وسِّع العناوين المقترحة</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">وسّع العناوين المحفوظة</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">اطوِ العناوين المقترحة</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">اطو العناوين المحفوظة</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-be/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-be/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Пароль</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Не захоўваць</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Не зараз</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Ніколі не захоўваць</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Захаваць</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Не абнаўляць</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Не зараз</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Абнавіць</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Поле пароля не павінна быць пустым</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Увядзіце пароль</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Немагчыма захаваць лагін</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Немагчыма захаваць пароль</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Захаваць гэты лагін?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Захаваць пароль?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Абнавіць гэты лагін?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Абнавіць пароль?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Дадаць імя карыстальніка да захаванага пароля?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Абнавіць імя карыстальніка?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Сне</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Усталяваць час</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Кіраваць лагінамі</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Кіраваць паролямі</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Разгарнуць прапанаваныя лагіны</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Разгарнуць захаваныя паролі</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Згарнуць прапанаваныя лагіны</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Згарнуць захаваныя паролі</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Прапанаваныя лагіны</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Захаваныя паролі</string>
@@ -142,28 +120,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Адмяніць</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Выберыце крэдытную карту</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Выкарыстаць захаваную карту</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Разгарнуць прапанаваныя крэдытныя карты</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Разгарнуць захаваныя карты</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Згарнуць прапанаваныя крэдытныя карты</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Згарнуць захаваныя карты</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Кіраванне крэдытнымі картамі</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Кіраваць картамі</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Захаваць надзейна гэту карту?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Абнавіць тэрмін дзеяння карты?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Нумар карты будзе зашыфраваны. Код бяспекі не будзе захаваны.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s шыфруе нумар вашай карты. Ваш код бяспекі не будзе захаваны.</string>
@@ -171,12 +139,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Выбраць адрас</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Разгарнуць прапанаваныя адрасы</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Разгарнуць захаваныя адрасы</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Згарнуць прапанаваныя адрасы</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Згарнуць захаваныя адрасы</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-bg/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-bg/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Парола</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Без запазване</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Не сега</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Без запазване</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Запазване</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Без обновяване</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Не сега</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Обновяване</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Полето за парола не трябва да е празно</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Въведете парола</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Данните за вход не могат да бъдат запазени</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Паролата не може да бъде запазена</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Запазване на регистрацията?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Запазване на паролата?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Обновяване на регистрацията?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Обновяване на паролата?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Добавяне на потребител към запазената парола?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Обновяване на потребителското име?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">дек</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Задаване на време</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Управление на регистрации</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Управление на пароли</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Разгъване на предложени регистрации</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Разгъване на запазени пароли</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Сгъване на предложени регистрации</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Сгъване на запазени пароли</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Предложени регистрации</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Запазени пароли</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Използвате силна парола?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Защитете профилите си, като използвате силна, произволна парола. Получете бърз достъп до паролите си, като ги запазите в профила си.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Защитете профилите си, като използвате силна, произволна парола. Ще бъде запазена в профила ви за бъдеща употреба.</string>
 
@@ -154,20 +130,12 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Отказ</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Изберете банкова карта</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Използване на запазена карта</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Разгъва предложения списък с банкови карти</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Разгъване на запазени карти</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Сгъва предложения списък с банкови карти</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Сгъване на запазени карти</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Управление на банкови карти</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Управление на карти</string>
     <!-- Text for the title of a save credit card dialog. -->
@@ -175,8 +143,6 @@
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Обновяване на валидността на картата?</string>
 
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Номерът на карата ще бъде шифрован. Кодът за сигурност няма да бъде запазен.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s шифрова номера на картата. Кодът за сигурност няма да бъде запазен.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Изберете адрес</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Разгъване на предложени адреси</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Разгъване на запазени адреси</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Свиване на предложени адреси</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Сгъване на запазени адреси</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-br/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-br/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Ger-tremen</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Na enrollañ</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Diwezhatoc’h</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Na enrollañ biken</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Enrollañ</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Na hizivaat</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Diwezhatoc’h</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Hizivaat</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Ar vaezienn ger-tremen a rank bezañ leuniet</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Enankit ur ger-tremen</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Ne cʼhaller ket enrollañ an titour kennaskañ</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">N’haller ket enrollañ ar ger-tremen</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Enrollañ an titour kennaskañ-mañ?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Enrollañ ar ger-tremen?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Hizivaat an titour kennaskañ-mañ?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Hizivaat ar ger-tremen?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Ouzhpennañ an anv arveriad dʼar gerioù-tremen enrollet?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Hizivaat an anv arveriad?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Ker</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Dibab an eur</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Ardoer titouroù kennaskañ</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Merañ ar gerioù-tremen</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Brasaat an titouroù kennaskañ aliet</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Dispakañ ar gerioù-tremen enrollet</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Berraat an titouroù kennaskañ aliet</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Kuzhat ar gerioù-tremen enrollet</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Titouroù kennaskañ aliet</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Gerioù-tremen enrollet</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Implij ur ger-tremen solut?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Gwarezit ho kontoù gant ur ger-tremen solut, ha savet ent dargouezhek. Haezit ho kerioù-tremen buan en ur enrollañ anezho war ho kont.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2">Gwarezit ho kontoù en ur ober gant ur ger-tremen kreñv ha savet ent ankivil. Enrollet e vo en ho kont evit bezañ implijet en dazont.</string>
 
@@ -151,20 +127,12 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Nullañ</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Diuzañ ur gartenn gred</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Ober gant ur gartenn enrollet</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Astenn ar cʼhartennoù kred kinniget</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Dispakañ ar c’hartennoù enrollet</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Bihanaat ar cʼhartennoù kred kinniget</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Kuzhat ar c’hartennoù enrollet</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Merañ ar cʼhartennoù kred</string>
 
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Merañ ar c’hartennoù</string>
@@ -172,8 +140,6 @@
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Enrollañ ar gartenn-mañ en surentez?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Hizivaat deiziad termen ar gartenn?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Enrigenet e vo niverenn ar gartenn. Ne vo ket enrollet ar c’hod surentez.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s a enrinego ho niverenn gartenn. Ne vo ket enrollet ho poneg surentez.</string>
@@ -181,12 +147,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Dibab ur chomlec’h</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Displegañ ar chomlec’hioù kinniget</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Dispakañ ar chomlec’hioù enrollet</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Plegañ ar chomlec’hioù kinniget</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Kuzhat ar chomlec’hioù enrollet</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ca/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ca/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Contrasenya</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">No desis</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ara no</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">No desis mai</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Desa</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">No actualitzis</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ara no</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Actualitza</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">El camp de la contrasenya no pot estar buit</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Escriviu una contrasenya</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">No es pot desar l’inici de sessió</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">No s\'ha pogut desar la contrasenya</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Voleu desar aquest inici de sessió?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Voleu desar la contrasenya?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Voleu actualitzar aquest inici de sessió?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Voleu actualitzar la contrasenya?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Voleu afegir el nom d’usuari a la contrasenya desada?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Voleu actualitzar el nom d\'usuari?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">des.</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Defineix l’hora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Gestiona els inicis de sessió</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Gestiona les contrasenyes</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Amplia els inicis de sessió suggerits</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Amplia les contrasenyes desades</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Redueix els inicis de sessió suggerits</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Redueix les contrasenyes desades</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Inicis de sessió suggerits</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Contrasenyes desades</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Voleu utilitzar una contrasenya segura?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protegiu els comptes amb una contrasenya segura generada aleatòriament. Si la deseu en el compte, podreu accedir-hi ràpidament.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2">Protegiu els vostres comptes amb una contrasenya segura generada aleatòriament. Es desarà al vostre compte per a usar-la més endavant.</string>
 
@@ -153,28 +129,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancel·la</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Seleccioneu una targeta de crèdit</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Usa una targeta desada</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Amplia les targetes de crèdit suggerides</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Amplia les targetes desades</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Redueix les targetes de crèdit suggerides</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Redueix les targetes desades</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Gestiona les targetes de crèdit</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Gestiona les targetes</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Voleu desar aquesta targeta de forma segura?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Voleu actualitzar la data de caducitat de la targeta?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">El número de targeta es xifrarà. El codi de seguretat no es desarà.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">El %s xifra el número de la targeta. El codi de seguretat no es desarà.</string>
@@ -182,12 +148,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Trieu l’adreça</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Amplia les adreces suggerides</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Amplia les adreces desades</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Redueix les adreces suggerides</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Redueix les adreces desades</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-cak/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-cak/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Ewan tzij</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Man tiyak</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Wakami mani</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Majub\'ey tiyak</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Tiyak</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Man tik\'ex ruwäch</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Wakami mani</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Tik\'ex</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Man tikirel ta kowöl ri ruk\'ojlem ewan tzij</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Titz\'ib\'äx jun ewan tzij</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Man xtikïr ta xyak rutikirib\'al molojri\'ïl</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Man tikirel ta niyak ri ewan tzij</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿La niyak rutikirib\'al re moloj re\'?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">¿La niyak ewan tzij?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿La nik\'ex rutikirib\'al re moloj re\'?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">¿La nik\'ex ri ewan tzij?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">¿La nitz\'aqatisäx rub\'i\' winäq pa ri ewan tzij yakon?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
     <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
     <string name="mozac_feature_prompts_content_description_input_label">Etal richin ninim jun ruk\'ojlem rokem tz\'ib\'anïk</string>
@@ -95,20 +81,12 @@
     <string name="mozac_feature_prompts_dec">Kab\'lajik\'</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Tib\'an ruk\'ojlem wakami</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Tinuk\'samajïx rutikirib\'al molojri\'ïl</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Kenuk\'samajïx ewan taq tzij</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Kerik\' ri chilab\'en tikirib\'äl taq molojri\'ïl</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Kerik\' kij ri yakon ewan taq tzij</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Kek\'ol ri chilab\'en tikirib\'äl taq molojri\'ïl</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Kek\'ol ri yakon ewan taq tzij</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Chilab\'en taq molojri\'ïl</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Xeyak ewan taq tzij</string>
@@ -136,20 +114,12 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Tiq\'at</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Ticha\' rutarjeta\' kre\'ito\'</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Tokisäx yakon tarjeta\'</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Kerik\' ri chilab\'en rutarjeta\' kre\ito\'</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Kerik yakon taq tarjeta\'</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Kek\'ol ri chilab\'en rutarjeta\' kre\ito\'</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Kek\'ol yakon taq tarjeta\'</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Kenuk\'samajïx kikre\'ito\' taq tarjeta\'</string>
 
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Kenuk\'samajïx taq tarjeta\'</string>
@@ -158,8 +128,6 @@
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">¿Tik\'ex ruq\'ijul nik\'is tarjeta\'?</string>
 
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Ri rajilab\'al tarjeta\' ewan rusik\'ixik. Man xtiyake\' ta ri rub\'itz\'ib\' jikomal.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s nrewaj rusik\'ixij ri rajilab\'al atarjeta\'. Ri jikon rub\'itz\'ib\' man xtiyake\' ta kan.</string>
@@ -167,12 +135,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Ticha\' ochochib\'äl</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Kerik\' ri chilab\'en ochochib\'äl</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Kerik\' yakon taq ochochib\'äl</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Kek\'ol ri chilab\'en ochochib\'äl</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Kek\'ol yakon taq ochochib\'äl</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-co/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-co/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Parolla d’intesa</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ùn arregistrà micca</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Micca subitu</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Ùn arregistrà mai</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Arregistrà</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ùn micca rinnovà</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Micca subitu</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Piglià in contu</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">U campu di a parolla d’intesa ùn deve micca esse viotu</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Stampittate una parolla d’intesa</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Impussibule d’arregistrà l’identificazione di cunnessione</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Ùn si pò micca arregistrà a parolla d’intesa</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Arregistrà st’identificazioni di cunnessione</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Arregistrà a parolla d’intesa ?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Mudificà st’identificazione di cunnessione ?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Mudificà a parolla d’intesa ?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Aghjunghje un nome d’utilizatore à a parolla d’intesa arregistrata ?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Mudificà u nome d’utilizatore ?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">dice.</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Sceglie l’ora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Urganizà l’identificazioni di cunnessione</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Amministrà e parolle d’intesa</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Spiegà l’identificazioni di cunnessione suggerite</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Spiegà e parolle d’intesa arregistrate</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ripiegà l’identificazioni di cunnessione suggerite</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Ripiegà e parolle d’intesa arregistrate</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Identificazioni di cunnessione suggerite</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Parolle d’intesa arregistrate</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Impiegà una parolla d’intesa forte ?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Prutigite i vostri conti impieghendu una parolla d’intesa forte è ingenerata à l’azardu. Accidite in furia à e vostre parolle d’intesa arregistrendule in u vostru contu.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2">Prutigite i vostri conti impieghendu una parolla d’intesa forte è ingenerata à l’azardu. Serà arregistrata in u vostru contu per un aghjovu futuru.</string>
 
@@ -151,28 +127,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Abbandunà</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Selezziunà una carta bancaria</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Impiegà una carta arregistrata</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Spiegà e carte bancarie suggerite</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Spiegà e carte arregistrate</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ripiegà e carte bancarie suggerite</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Ripiegà e carte arregistrate</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Urganizà e carte bancarie</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Amministrà e carte</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Arregistrà sta carta di manera sicura ?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Mudificà a data di scadenza di a carta ?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">U numeru di a carta serà cifratu. U codice di sicurità ùn serà micca arregistratu.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s cifra u vostru numeru di carta. U vostru codice di sicurità ùn serà micca arregistratu.</string>
@@ -180,12 +146,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Selezziunà un indirizzu</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Spiegà l’indirizzi suggeriti</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Spiegà l’indirizzi arregistrati</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ripiegà l’indirizzi suggeriti</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Ripiegà l’indirizzi arregistrati</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-cs/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-cs/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Heslo</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Neukládat</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Teď ne</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nikdy neukládat</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Uložit</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Neaktualizovat</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Teď ne</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Aktualizovat</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Heslo nesmí být prázdné</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Zadejte heslo</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Přihlašovací údaje nelze uložit</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Heslo není možné uložit</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Uložit tyto přihlašovací údaje?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Uložit heslo?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Aktualizovat tyto přihlašovací údaje?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Aktualizovat heslo?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Přidat k uloženému heslu uživatelské jméno?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Aktualizovat uživatelské jméno?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Pro</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Nastavit čas</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Správa přihlašovacích údajů</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Správa přihlašovacích údajů</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zobrazit navrhované přihlašovací údaje</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Rozbalit uložená hesla</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Skýt navrhované přihlašovací údaje</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Sbalit uložená hesla</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Navrhované přihlašovací údaje</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Uložená hesla</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Chcete použít silné heslo?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Chraňte své účty používáním silných a náhodně generovaných hesel. Uložte si svá hesla ve svém účtu a získejte tak rychlý přístup ke svým heslům.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Chraňte své účty pomocí silného, náhodně vygenerovaného hesla. To se uloží do vašeho účtu pro budoucí použití.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Zrušit</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Vyberte platební kartu</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Použít uloženou kartu</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zobrazit návrhy platebních karet</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Rozbalit uložené karty</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Skrýt návrhy platebních karet</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Sbalit uložené karty</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Správa platebních karet</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Spravovat karty</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Bezpečně uložit tuto kartu?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Aktualizovat platnost karty?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Číslo karty bude uložené šifrované. Bezpečnostní kód uložen nebude.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s zašifruje číslo vaší karty. Váš bezpečnostní kód nebude uložen.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Vyberte adresu</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zobrazit navrhované adresy</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Rozbalit uložené adresy</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Skrýt navrhované adresy</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Sbalit uložené adresy</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-cy/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-cy/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Cyfrinair</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Peidio â chadw</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Nid nawr</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Byth cadw</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Cadw</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Peidio â diweddaru</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Nid nawr</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Diweddaru</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Rhaid i faes cyfrinair beidio â bod yn wag</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Rhowch gyfrinair</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Methu cadw mewngofnod</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Methu cadw cyfrinair</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Cadw’r mewngofnod hwn?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Cadw cyfrinair?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Diweddaru’r mewngofnod hwn?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Diweddaru cyfrinair?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Ychwanegu enw defnyddiwr i gyfrinair wedi’i gadw?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Diweddaru enw defnyddiwr?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Rhag</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Gosod yr amser</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Rheoli mewngofnodion</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Rheoli cyfrineiriau</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ehangu’r mewngofnodion</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Ehangu cyfrineiriau sydd wedi\'u cadw</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Lleihau’r mewngofnodion</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Cau cyfrineiriau sydd wedi\'u cadw</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Mewngofnodion</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Cyfrineiriau wedi\'u cadw</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Defnyddio cyfrinair cryf?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Diogelwch eich cyfrifon trwy ddefnyddio cyfrinair cryf wedi\'i gynhyrchu ar hap. Cewch fynediad cyflym i\'ch cyfrineiriau trwy eu cadw yn eich cyfrif.</string>
 
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Gwarchodwch eich cyfrifon trwy ddefnyddio cyfrinair cryf wedi\'i gynhyrchu ar hap. Bydd yn cael ei gadw yn eich cyfrif i\'w ddefnyddio yn y dyfodol.</string>
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Diddymu</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Dewiswch gerdyn credyd</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Defnyddio cerdyn sydd wedi\'i gadw</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ehangu awgrymiad y cardiau credyd</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Ehangu cardiau sydd wedi\'u cadw</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Lleihau awgrymiad y cardiau credyd</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Cau cardiau sydd wedi\'u cadw</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Rheoli cardiau credyd</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Rheoli cardiau</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Cadw’r cerdyn hwn yn ddiogel?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Diweddaru dyddiad dod i ben cerdyn?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Bydd rhif y cerdyn yn cael ei amgryptio. Ni fydd y cod diogelwch yn cael ei gadw.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">Mae %s yn amgryptio rhif eich cerdyn. Ni fydd eich cod diogelwch yn cael ei gadw.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Dewiswch gyfeiriad</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ehangu awgrymiadau cyfeiriadau</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Ehangu cyfeiriadau sydd wedi\'u cadw</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Lleihau awgrymiadau cyfeiriadau</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Cau cyfeiriadau sydd wedi\'u cadw</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-da/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-da/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Adgangskode</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Gem ikke</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ikke nu</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Gem aldrig</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Gem</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Opdater ikke</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ikke nu</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Opdater</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Feltet Adgangskode må ikke være tomt</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Indtast en adgangskode</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Kunne ikke gemme login</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Kan ikke gemme adgangskode</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Gem dette login?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Gem adgangskode?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Opdater dette login?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Opdater adgangskode?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Føj brugernavn til gemt adgangskode?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Opdater brugernavn?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Vælg tidspunkt</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Håndter logins</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Håndter adgangskoder</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Udvid foreslåede logins</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Udvid gemte adgangskoder</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Sammenfold foreslåede logins</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Sammenfold gemte adgangskoder</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Foreslåede logins</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Gemte adgangskoder</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Brug stærk adgangskode?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Beskyt dine konti ved at bruge en stærk, tilfældigt genereret adgangskode. Få hurtig adgang til dine adgangskoder ved at gemme dem på din konto.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Beskyt dine konti ved at bruge en stærk, tilfældigt genereret adgangskode. Den vil blive gemt på din konto til senere brug.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Annuller</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Vælg betalingskort</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Brug gemt kort</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Udvid foreslåede betalingskort</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Udvid gemte kort</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Sammenfold foreslåede betalingskort</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Sammenfold gemte kort</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Håndter betalingskort</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Håndter kort</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Gem dette kort sikkert?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Opdater kortets udløbsdato?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Kortnummeret vil blive krypteret. Sikkerhedskoden vil ikke blive gemt.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s krypterer dit kortnummer. Din sikkerhedskode bliver ikke gemt.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Vælg adresse</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Udvid foreslåede adresser</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Udvid gemte adresser</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Sammenfold foreslåede adresser</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Sammenfold gemte adresser</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-de/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-de/strings.xml
@@ -25,8 +25,6 @@
     <string name="mozac_feature_prompt_password_hint">Passwort</string>
 
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Nicht speichern</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Nicht jetzt</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nie speichern</string>
@@ -35,29 +33,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Speichern</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Nicht aktualisieren</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Nicht jetzt</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Aktualisieren</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Das Passwortfeld darf nicht leer bleiben</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Passwort eingeben</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Zugangsdaten konnten nicht gespeichert werden</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Passwort kann nicht gespeichert werden</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Diese Zugangsdaten speichern?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Passwort speichern?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Diese Zugangsdaten aktualisieren?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Passwort aktualisieren?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Benutzernamen zum gespeicherten Passwort hinzufügen?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Benutzernamen aktualisieren?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -109,20 +95,12 @@
     <string name="mozac_feature_prompts_dec">Dez</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Zeit einstellen</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Zugangsdaten verwalten</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Passwörter verwalten</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Vorgeschlagene Zugangsdaten ausklappen</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Gespeicherte Passwörter ausklappen</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Vorgeschlagene Zugangsdaten einklappen</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Gespeicherte Passwörter einklappen</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Vorgeschlagene Zugangsdaten</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Gespeicherte Passwörter</string>
@@ -136,8 +114,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Starkes Passwort verwenden?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Schützen Sie Ihre Konten, indem Sie ein starkes, zufällig generiertes Passwort verwenden. Greifen Sie schnell auf Ihre Passwörter zu, indem Sie es in Ihrem Konto speichern.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Schützen Sie Ihre Konten, indem Sie ein starkes, zufällig generiertes Passwort verwenden. Es wird zur zukünftigen Verwendung in Ihrem Konto gespeichert.</string>
 
@@ -166,28 +142,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Abbrechen</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Kreditkarte auswählen</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Eine gespeicherte Karte verwenden</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Vorgeschlagene Kreditkarten ausklappen</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Gespeicherte Karten ausklappen</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Vorgeschlagene Kreditkarten einklappen</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Gespeicherte Karten einklappen</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Kreditkarten verwalten</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Karten verwalten</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Soll diese Karte sicher gespeichert werden?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Ablaufdatum der Karte aktualisieren?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Die Kartennummer wird verschlüsselt. Der Sicherheitscode wird nicht gespeichert.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s verschlüsselt Ihre Kartennummer. Ihr Sicherheitscode wird nicht gespeichert.</string>
@@ -195,12 +161,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Adresse auswählen</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Vorgeschlagene Adressen ausklappen</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Gespeicherte Adressen ausklappen</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Vorgeschlagene Adressen einklappen</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Gespeicherte Adressen einklappen</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-dsb/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-dsb/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Gronidło</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Njeskładowaś</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Nic něnto</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nigda njeskładowaś</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Składowaś</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Njeaktualizěrowaś</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Nic něnto</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Aktualizěrowaś</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Gronidłowe pólo njesmějo prozne byś</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Gronidło zapódaś</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Pśizjawjenje njedajo se składowaś</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Gronidło njedajo se składowaś</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Toś to pśizjawjenje składowaś?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Gronidło składowaś?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Toś to pśizjawjenje aktualizěrowaś?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Gronidło aktualizěrowaś?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Wužywaŕske mě skłaźonemu gronidłoju pśidaś?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Wužywaŕske mě aktualizěrowaś?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Cas nastajiś</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Pśizjawjenja zastojaś</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Gronidła zastojaś</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Naraźone pśizjawjenja pokazaś</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Skłaźone gronidła pokazaś</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Naraźone pśizjawjenja schowaś</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Skłaźone gronidła schowaś</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Naraźone pśizjawjenja</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Skłaźone gronidła</string>
@@ -126,8 +104,6 @@
     <string name="mozac_feature_prompts_suggest_strong_password_title">Mócne gronidło wužywaś?</string>
 
 
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Wužywajśo mócne, pśipadnje generěrowane gronidło, aby swóje konta šćitał. Dostańśo malsny pśistup k swójim gronidłam, gaž jo w swójom konśe składujośo.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Wužywajśo mócne, pśipadnje generěrowane gronidło, aby swóje konta šćitał. Buźo se do wašogo konta za pśichodne wužywanje składowaś.</string>
 
@@ -156,28 +132,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Pśetergnuś</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Kreditowu kórtu wubraś</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Skłaźonu kórtu wužywaś</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Naraźone kreditowe kórty pokazaś</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Skłaźone kórty pokazaś</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Naraźone kreditowe kórty schowaś</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Skłaźone kórty schowaś</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Kreditowe kórty zastojaś</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Kórty zastojaś</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Toś tu kórtu wěsće składowaś?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Datum spadnjenja kórty aktualizěrowaś?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Numer kórty buźo se koděrowaś. Wěstotny kod njebuźo se składowaś.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s waš kórtowy numer koděrujo. Waš wěstotny kod njebuźo se składowaś.</string>
@@ -185,12 +151,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Adresu wubraś</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Naraźone adrese pokazaś</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Skłaźone adrese pokazaś</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Naraźone adrese schowaś</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Skłaźone adrese schowaś</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-el/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-el/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Κωδικός πρόσβασης</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Χωρίς αποθήκευση</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Όχι τώρα</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Ποτέ αποθήκευση</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Αποθήκευση</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Να μη γίνει ενημέρωση</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Όχι τώρα</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Ενημέρωση</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Το πεδίο κωδικού πρόσβασης δεν πρέπει να είναι κενό</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Εισαγάγετε έναν κωδικό πρόσβασης</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Αποτυχία αποθήκευσης σύνδεσης</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Αδυναμία αποθήκευσης κωδικού πρόσβασης</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Αποθήκευση σύνδεσης;</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Αποθήκευση κωδικού πρόσβασης;</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Ενημέρωση σύνδεσης;</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Ενημέρωση κωδικού πρόσβασης;</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Προσθήκη ονόματος χρήστη στον αποθηκευμένο κωδικό πρόσβασης;</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Ενημέρωση ονόματος χρήστη;</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Δεκ</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Ορισμός ώρας</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Διαχείριση συνδέσεων</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Διαχείριση κωδικών πρόσβασης</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ανάπτυξη προτεινόμενων συνδέσεων</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Ανάπτυξη των αποθηκευμένων κωδικών πρόσβασης</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Σύμπτυξη προτεινόμενων συνδέσεων</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Σύμπτυξη αποθηκευμένων κωδικών πρόσβασης</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Προτεινόμενες συνδέσεις</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Αποθηκευμένοι κωδικοί πρόσβασης</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Χρήση ισχυρού κωδικού πρόσβασης;</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Προστατέψτε τους λογαριασμούς σας με έναν ισχυρό, τυχαίο κωδικό πρόσβασης. Αποκτήστε γρήγορη πρόσβαση στους κωδικούς πρόσβασής σας αποθηκεύοντάς τους στον λογαριασμό σας.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Προστατέψτε τους λογαριασμούς σας με έναν ισχυρό, τυχαίο κωδικό πρόσβασης. Θα αποθηκευτεί στον λογαριασμό σας για μελλοντική χρήση.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Ακύρωση</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Επιλογή πιστωτικής κάρτας</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Χρήση αποθηκευμένης κάρτας</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ανάπτυξη προτεινόμενων πιστωτικών καρτών</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Ανάπτυξη αποθηκευμένων καρτών</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Σύμπτυξη προτεινόμενων πιστωτικών καρτών</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Σύμπτυξη αποθηκευμένων καρτών</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Διαχείριση πιστωτικών καρτών</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Διαχείριση καρτών</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Ασφαλής αποθήκευση κάρτας;</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Ενημέρωση ημερομηνίας λήξης κάρτας;</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Ο αριθμός της κάρτας θα κρυπτογραφηθεί. Ο κωδικός ασφαλείας δεν θα αποθηκευτεί.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">Το %s κρυπτογραφεί τον αριθμό της κάρτας σας. Ο κωδικός ασφαλείας σας δεν θα αποθηκευτεί.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Επιλογή διεύθυνσης</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ανάπτυξη προτεινόμενων διευθύνσεων</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Ανάπτυξη αποθηκευμένων διευθύνσεων</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Σύμπτυξη προτεινόμενων διευθύνσεων</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Σύμπτυξη αποθηκευμένων διευθύνσεων</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-en-rCA/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-en-rCA/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Password</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Don’t save</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Not now</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Never save</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Save</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Don’t update</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Not now</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Update</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Password field must not be empty</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Enter a password</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Unable to save login</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Can’t save password</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Save this login?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Save password?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Update this login?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Update password?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Add username to saved password?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Update username?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Set time</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Manage logins</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Manage passwords</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expand suggested logins</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expand saved passwords</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Collapse suggested logins</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Collapse saved passwords</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Suggested logins</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Saved passwords</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Use strong password?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protect your accounts by using a strong, randomly generated password. Get quick access to your passwords by saving it in your account.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Protect your accounts by using a strong, randomly generated password. It’ll be saved into your account for future use.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancel</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Select credit card</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Use saved card</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expand suggested credit cards</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expand saved cards</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Collapse suggested credit cards</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Collapse saved cards</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Manage credit cards</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Manage cards</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Securely save this card?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Update card expiration date?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Card number will be encrypted. Security code won’t be saved.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s encrypts your card number. Your security code won’t be saved.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Select address</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expand suggested addresses</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Expand saved addresses</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Collapse suggested addresses</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Collapse saved addresses</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-en-rGB/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-en-rGB/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Password</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Don’t save</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Not now</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Never save</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Save</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Don’t update</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Not now</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Update</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Password field must not be empty</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Enter a password</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Unable to save login</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Can’t save password</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Save this login?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Save password?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Update this login?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Update password?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Add username to saved password?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Update username?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Set time</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Manage logins</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Manage passwords</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expand suggested logins</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expand saved passwords</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Collapse suggested logins</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Collapse saved passwords</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Suggested logins</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Saved passwords</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Use strong password?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protect your accounts by using a strong, randomly generated password. Get quick access to your passwords by saving it in your account.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Protect your accounts by using a strong, randomly generated password. It’ll be saved into your account for future use.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancel</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Select credit card</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Use saved card</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expand suggested credit cards</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expand saved cards</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Collapse suggested credit cards</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Collapse saved cards</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Manage credit cards</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Manage cards</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Securely save this card?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Update card expiration date?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Card number will be encrypted. Security code won’t be saved.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s encrypts your card number. Your security code won’t be saved.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Select address</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expand suggested addresses</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Expand saved addresses</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Collapse suggested addresses</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Collapse saved addresses</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-eo/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-eo/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Pasvorto</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ne konservi</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ne nun</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Neniam konservi</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Konservi</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ne ĝisdatigi</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ne nun</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Ĝisdatigi</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">La pasvorto ne povas esti malplena</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Tajpu pasvorton</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Ne eblas konservi legitimilon</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Ne eblas konservi la pasvorton</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Ĉu konservi tiun ĉi legitimilon?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Ĉu konservi pasvorton?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Ĉu ĝisdatigi tiun ĉi akreditilon?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Ĉu ĝisdatigi pasvorton?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Ĉu aldoni nomon de uzanto al la konservita pasvorto?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Ĉu ĝisdatigi nomon de uzanto?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Difini horon</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Administri legitimilojn</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Administri pasvortojn</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Malfaldi sugestitajn legitimilojn</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Malfaldi konservitajn pasvortojn</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Faldi sugestitajn legitimilojn</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Faldi konservitajn pasvortojn</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Sugestitaj legitimiloj</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Konservitaj pasvortoj</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Ĉu uzi fortan pasvorton?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protektu viajn kontojn per uzo de forta, hazarde kreita pasvorto. Konservu pasvortojn en via konto por havi rapidan aliron al ili.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Protektu viajn kontojn per forta, hazarde kreita pasvorto. Ĝi estos konservita en via konto por estonta uzo.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Nuligi</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Elekti kreditkarton</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Uzi konservitan karton</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Malfaldi sugestitajn kreditkartojn</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Elporti konservitajn pasvortojn</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Faldi sugestitajn kreditkartojn</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Faldi konservitajn kartojn</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Administri kreditkartojn</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Administri kartojn</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Ĉu sekure konservi tiun ĉi kreditkarton?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Ĉu ĝisdatigi la daton de senvalidiĝo de kreditkarto?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">La numero de kreditkaro estos ĉifrita. La sekureca kodo ne estos konservita.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s ĉifras vian numeron de karto. Via sekureca kodo ne estos konservita.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Elekti adresojn</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Malfaldi sugestitajn adresojn</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Malfaldi konservitajn adresojn</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Faldi sugestitajn adresojn</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Faldi konservitajn adresojn</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es-rAR/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es-rAR/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Contraseña</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">No guardar</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">No ahora</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">No guardar nunca</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Guardar</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">No actualizar</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">No ahora</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Actualizar</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">El campo de contraseña no puede estar vacío</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Ingresar una contraseña</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">No se puede guardar el inicio de sesión</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">No se puede guardar la contraseña</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Guardar este inicio de sesión?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">¿Guardar contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Actualizar este inicio de sesión?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">¿Actualizar contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">¿Agregar nombre de usuario a la contraseña guardada?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">¿Actualizar nombre de usuario?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dic</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Establecer hora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Administrar inicios de sesión</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Administrar contraseñas</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir los inicios de sesión sugeridos</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expandir las contraseñas guardadas</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer los inicios de sesión sugeridos</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Contraer contraseñas guardadas</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Inicios de sesión sugeridos</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Contraseñas guardadas</string>
@@ -125,8 +103,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">¿Usar contraseña segura?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protegé tus cuentas usando una contraseña segura generada al azar. Conseguí acceso rápido a tus contraseñas guardándolas en tu cuenta.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Protegé tus cuentas usando una contraseña segura generada al azar. Se guardará en tu cuenta para uso futuro.</string>
 
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancelar</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Seleccionar tarjeta de crédito</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Usar tarjeta guardada</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ampliar las tarjetas de crédito sugeridas</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expandir tarjetas guardadas</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer tarjetas de crédito sugeridas</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Contraer tarjetas guardadas</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Administrar tarjetas de crédito</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Administrar tarjetas</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">¿Guardar esta tarjeta de forma segura?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">¿Actualizar la fecha de vencimiento de la tarjeta?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">El número de tarjeta será cifrado. El código de seguridad no se guardará.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s cifra tu número de tarjeta. El código de seguridad no se guardará.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seleccionar dirección</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir direcciones sugeridas</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Expandir las direcciones guardadas</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer direcciones sugeridas</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Contraer direcciones guardadas</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es-rCL/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es-rCL/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Contraseña</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">No guardar</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ahora no</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nunca guardar</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Guardar</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">No actualizar</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ahora no</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Actualizar</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">El campo de contraseña no puede estar vacío</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Ingresar una contraseña</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">No se pudo guardar la credencial</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">No se puede guardar la contraseña</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Guardar esta credencial?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">¿Guardar contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Actualizar esta credencial?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">¿Actualizar contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">¿Añadir nombre de usuario a la contraseña guardada?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">¿Actualizar nombre de usuario?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dic</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Ajustar hora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Administrar credenciales</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Gestionar contraseñas</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir credenciales sugeridas</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expandir contraseñas guardadas</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer credenciales sugeridas</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Contraer contraseñas guardadas</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Credenciales sugeridas</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Contraseñas guardadas</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">¿Usar contraseña segura?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protege tus cuentas utilizando una contraseña segura generada aleatoriamente. Obtén acceso rápido a tus contraseñas guardándolas en tu cuenta.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Protege tus cuentas utilizando una contraseña segura generada aleatoriamente. Se guardará en tu cuenta para uso futuro.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancelar</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Seleccionar tarjeta de crédito</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Usar tarjeta guardada</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir tarjetas de crédito sugeridas</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expandir tarjetas guardadas</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ocultar tarjetas de crédito sugeridas</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Contraer tarjetas guardadas</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Gestionar tarjetas de crédito</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Gestionar tarjetas</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">¿Guardar esta tarjeta de forma segura?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">¿Actualizar la fecha de vencimiento de la tarjeta?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">El número de la tarjeta será encriptado. El código de seguridad no será guardo.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s cifra tu número de tarjeta. Tu código de seguridad no será guardado.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seleccionar dirección</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir direcciones sugeridas</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Expandir direcciones guardadas</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ocultar direcciones sugeridas</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Contraer direcciones guardadas</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es-rES/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es-rES/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Contraseña</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">No guardar</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ahora no</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">No guardar nunca</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Guardar</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">No actualizar</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ahora no</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Actualizar</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">El campo de contraseña no puede estar vacío</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Introduce una contraseña</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">No se puede guardar el inicio de sesión</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">No se ha podido guardar la contraseña</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Guardar este inicio de sesión?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">¿Guardar contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Actualizar este inicio de sesión?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">¿Actualizar contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">¿Añadir nombre de usuario a la contraseña guardada?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">¿Actualizar nombre de usuario?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dic</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Establecer hora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Administrar inicios de sesión</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Administrar contraseñas</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir inicios de sesión sugeridos</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expandir las contraseñas guardadas</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer inicios de sesión sugeridos</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Contraer las contraseñas guardadas</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Inicios de sesión sugeridos</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Contraseñas guardadas</string>
@@ -125,8 +103,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">¿Usar contraseña segura?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protege tus cuentas utilizando una contraseña segura generada aleatoriamente. Obtén acceso rápido a tus contraseñas guardándolas en tu cuenta.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Protege tus cuentas utilizando una contraseña segura generada aleatoriamente. Se guardará en tu cuenta para uso futuro.</string>
 
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancelar</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Seleccionar tarjeta de crédito</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Usar tarjeta guardada</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir la lista de tarjetas de crédito sugeridas</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expandir tarjetas guardadas</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer la lista de tarjetas de crédito sugeridas</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Contraer tarjetas guardadas</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Administrar tarjetas de crédito</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Administrar tarjetas</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">¿Guardar esta tarjeta de forma segura?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">¿Actualizar la fecha de caducidad de la tarjeta?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">El número de tarjeta será cifrado. El código de seguridad no se guardará.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s cifra tu número de tarjeta. Tu código de seguridad no se guardará.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seleccionar dirección</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir direcciones sugeridas</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Expandir direcciones guardadas</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer direcciones sugeridas</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Contraer direcciones guardadas</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es-rMX/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es-rMX/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Contraseña</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">No guardar</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ahora no</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nunca guardar</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Guardar</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">No actualizar</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ahora no</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Actualizar</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">El campo de contraseña no puede estar vacío</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Ingresa una contraseña</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">No se puede guardar el inicio de sesión</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">No se pudo guardar la contraseña</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Guardar este inicio de sesión?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">¿Guardar contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Actualizar este inicio de sesión?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">¿Actualizar contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">¿Agregar nombre de usuario a la contraseña guardada?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">¿Actualizar nombre de usuario?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dic</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Establecer hora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Administrar inicios de sesión</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Administrar contraseñas</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir los inicios de sesión sugeridos</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expandir las contraseñas guardadas</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer los inicios de sesión sugeridos</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Contraer contraseñas guardadas</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Inicios de sesión sugeridos</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Contraseñas guardadas</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">¿Usar contraseña segura?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protege tus cuentas utilizando una contraseña segura generada aleatoriamente. Obtén acceso rápido a tus contraseñas guardándolas en tu cuenta.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Protege tus cuentas utilizando una contraseña segura generada aleatoriamente. Se guardará en tu cuenta para uso futuro.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancelar</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Seleccionar tarjeta de crédito</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Usar tarjeta guardada</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir sección de tarjetas de crédito sugeridas</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expandir tarjetas guardadas</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ocultar las tarjetas de crédito sugeridas</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Contraer tarjetas guardadas</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Administrar tarjetas de crédito</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Administrar tarjetas</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">¿Guardar esta tarjeta de forma segura?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">¿Actualizar la fecha de vencimiento de la tarjeta?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">El número de tarjeta se encriptará. El código de seguridad no se guardará.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s encripta tu número de tarjeta. Tu código de seguridad no se guardará.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seleccionar dirección</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir direcciones sugeridas</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Expandir direcciones guardadas</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ocultar direcciones sugeridas</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Contraer direcciones guardadas</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-es/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Contraseña</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">No guardar</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ahora no</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">No guardar nunca</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Guardar</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">No actualizar</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ahora no</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Actualizar</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">El campo de contraseña no puede estar vacío</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Introduce una contraseña</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">No se puede guardar el inicio de sesión</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">No se ha podido guardar la contraseña</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Guardar este inicio de sesión?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">¿Guardar contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Actualizar este inicio de sesión?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">¿Actualizar contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">¿Añadir nombre de usuario a la contraseña guardada?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">¿Actualizar nombre de usuario?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dic</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Establecer hora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Administrar inicios de sesión</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Administrar contraseñas</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir inicios de sesión sugeridos</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expandir las contraseñas guardadas</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer inicios de sesión sugeridos</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Contraer las contraseñas guardadas</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Inicios de sesión sugeridos</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Contraseñas guardadas</string>
@@ -125,8 +103,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">¿Usar contraseña segura?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protege tus cuentas utilizando una contraseña segura generada aleatoriamente. Obtén acceso rápido a tus contraseñas guardándolas en tu cuenta.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Protege tus cuentas utilizando una contraseña segura generada aleatoriamente. Se guardará en tu cuenta para uso futuro.</string>
 
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancelar</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Seleccionar tarjeta de crédito</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Usar tarjeta guardada</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir la lista de tarjetas de crédito sugeridas</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expandir tarjetas guardadas</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer la lista de tarjetas de crédito sugeridas</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Contraer tarjetas guardadas</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Administrar tarjetas de crédito</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Administrar tarjetas</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">¿Guardar esta tarjeta de forma segura?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">¿Actualizar la fecha de caducidad de la tarjeta?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">El número de tarjeta será cifrado. El código de seguridad no se guardará.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s cifra tu número de tarjeta. Tu código de seguridad no se guardará.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seleccionar dirección</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir direcciones sugeridas</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Expandir direcciones guardadas</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer direcciones sugeridas</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Contraer direcciones guardadas</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-et/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-et/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Parool</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ära salvesta</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Mitte praegu</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Ära salvesta kunagi</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Salvesta</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ära uuenda</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Mitte praegu</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Uuenda</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Parooli väli ei tohi olla tühi</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Sisesta parool</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Kasutajatunnuste salvestamine pole võimalik</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Parooli ei saa salvestada</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Kas salvestada need kasutajatunnused?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Salvesta parool?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Kas uuendada kasutajatunnused?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Uuenda parool?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Kas lisada salvestatud paroolile kasutajanimi?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
     <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
     <string name="mozac_feature_prompts_content_description_input_label">Nimetus sisestuskasti tekstiväljale</string>
@@ -95,20 +81,12 @@
     <string name="mozac_feature_prompts_dec">dets</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Aja määramine</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Halda kasutajakontosid</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Halda paroole</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Laienda soovitatud kasutajakontosid</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Laienda salvestatud paroolid</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ahenda soovitatud kasutajakontod</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Ahenda salvestatud paroolid</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Soovitatud kasutajakontod</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Salvestatud paroolid</string>
@@ -142,28 +120,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Loobu</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Vali krediitkaart</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Kasuta salvestatud kaarti</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Laienda soovitatud krediitkaarte</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Laienda salvestatud kaardid</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ahenda soovitatud krediitkaarte</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Ahenda salvestatud kaardid</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Halda krediitkaarte</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Halda kaarte</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Kas salvestada see kaart turvaliselt?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Kas uuendada kaardi aegumiskuupäeva?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Kaardi number krüptitakse. Turvakoodi ei salvestata.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s krüpteerib kaardi numbri. Turvakoodi ei salvestata.</string>
@@ -171,12 +139,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Vali aadress</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Laienda soovitatud aadressid</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Laienda salvestatud aadressid</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ahenda soovitatud aadressid</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Ahenda salvestatud aadressid</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-eu/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-eu/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Pasahitza</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ez gorde</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Une honetan ez</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Ez gorde inoiz</string>
@@ -27,25 +25,15 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Gorde</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ez eguneratu</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Une honetan ez</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Eguneratu</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Pasahitzaren eremuak ezin du hutsik egon</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Idatzi pasahitz bat</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Ezin da saio-hasiera gorde</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Ezin da pasahitza gorde</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Gorde saio-hasiera hau?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Gorde pasahitza?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Eguneratu saio-hasiera hau?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Eguneratu pasahitza?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
@@ -95,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Abe</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Ezarri denbora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Kudeatu saio-hasierak</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Kudeatu pasahitzak</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zabaldu iradokitako saio-hasierak</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Zabaldu gordetako pasahitzak</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Tolestu iradokitako saio-hasierak</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Tolestu gordetako pasahitzak</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Iradokitako saio-hasierak</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Gordetako pasahitzak</string>
@@ -152,28 +132,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Utzi</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Hautatu kreditu-txartela</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Erabili gordetako txartela</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zabaldu iradokitako kreditu-txartelak</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Zabaldu gordetako txartelak</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Tolestu iradokitako kreditu-txartelak</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Tolestu gordetako txartelak</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Kudeatu kreditu-txartelak</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Kudeatu txartelak</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Gorde txartela modu seguruan?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Eguneratu txartelaren iraungitze-data?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Txartel-zenbakia zifratu egingo da. Segurtasun-kodea ez da gordeko.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s(e)k zure txartel-zenbakia zifratzen du. Zure segurtasun-kodea ez da gordeko.</string>
@@ -181,12 +151,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Hautatu helbidea</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zabaldu iradokitako helbideak</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Zabaldu gordetako helbideak</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Tolestu iradokitako helbideak</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Tolestu gordetako helbideak</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-fi/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-fi/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Salasana</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Älä tallenna</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ei nyt</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Älä tallenna koskaan</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Tallenna</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Älä päivitä</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ei nyt</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Päivitä</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Salasanakenttä ei saa olla tyhjä</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Kirjoita salasana</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Kirjautumistietojen tallennus epäonnistui</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Salasanaa ei voi tallentaa</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Tallennetaanko tämä kirjautumistieto?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Tallennetaanko salasana?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Päivitetäänkö tämä kirjautumistieto?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Päivitetäänkö salasana?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Lisätäänkö käyttäjätunnus tallennettuun salasanaan?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Päivitetäänkö käyttäjätunnus?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">joulu</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Aseta aika</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Hallitse kirjautumistietoja</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Hallitse salasanoja</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Laajenna ehdotetut kirjautumistiedot</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Laajenna tallennetut salasanat</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Supista ehdotetut kirjautumistiedot</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Supista tallennetut salasanat</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Ehdotetut kirjautumistiedot</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Tallennetut salasanat</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Haluatko käyttää vahvaa salasanaa?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Suojaa tilejäsi käyttämällä vahvaa, satunnaisesti luotua salasanaa. Pääset nopeasti käyttämään salasanoja tallentamalla ne tilillesi.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Suojaa tilejäsi käyttämällä vahvaa, satunnaisesti luotua salasanaa. Se tallennetaan tilillesi myöhempää käyttöä varten.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Peruuta</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Valitse luottokortti</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Käytä tallennettua korttia</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Laajenna ehdotetut luottokortit</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Laajenna tallennetut kortit</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Supista ehdotetut luottokortit</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Supista tallennetut kortit</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Hallitse luottokortteja</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Hallitse kortteja</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Tallennetaanko tämä kortti turvallisesti?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Päivitetäänkö kortin viimeinen voimassaolopäivä?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Kortin numero salataan. Suojakoodia ei tallenneta.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s salaa korttisi numeron. Turvakoodiasi ei tallenneta.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Valitse osoite</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Laajenna ehdotetut osoitteet</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Laajenna tallennetut osoitteet</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Supista ehdotetut osoitteet</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Supista tallennetut osoitteet</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-fr/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-fr/strings.xml
@@ -23,8 +23,6 @@
     <string name="mozac_feature_prompt_password_hint">Mot de passe</string>
 
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ne pas enregistrer</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Plus tard</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Ne jamais enregistrer</string>
@@ -33,29 +31,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Enregistrer</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ne pas mettre à jour</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Plus tard</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Mettre à jour</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Le champ mot de passe ne doit pas être vide</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Saisissez un mot de passe</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Impossible d’enregistrer l’identifiant</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Impossible d’enregistrer le mot de passe</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Enregistrer ces identifiants ?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Enregistrer le mot de passe ?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Mettre à jour cet identifiant ?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Mettre à jour le mot de passe ?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Ajouter un nom d’utilisateur au mot de passe enregistré ?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Mettre à jour le nom d’utilisateur ?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -106,20 +92,12 @@
     <string name="mozac_feature_prompts_dec">déc.</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Choisir l’heure</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Gérer les identifiants</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Gérer les mots de passe</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Développer les identifiants suggérés</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Développer les mots de passe enregistrés</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Réduire les identifiants suggérés</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Réduire les mots de passe enregistrés</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Identifiants suggérés</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Mots de passe enregistrés</string>
@@ -133,8 +111,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Utiliser un mot de passe compliqué ?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protégez vos comptes en utilisant un mot de passe compliqué, généré aléatoirement. Accédez rapidement à vos mots de passe en les enregistrant dans votre compte.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Protégez vos comptes en utilisant un mot de passe robuste, généré aléatoirement. Il sera enregistré dans votre compte pour de futures utilisations.</string>
 
@@ -163,28 +139,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Annuler</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Sélectionner une carte bancaire</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Utiliser une carte enregistrée</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Développer les cartes bancaires suggérées</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Développer les cartes enregistrées</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Réduire les cartes bancaires suggérées</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Réduire les cartes enregistrées</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Gérer les cartes bancaires</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Gérer les cartes</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Enregistrer cette carte en toute sécurité ?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Mettre à jour la date d’expiration de la carte ?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Le numéro de carte sera chiffré. Le code de sécurité ne sera pas enregistré.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s chiffre votre numéro de carte. Votre code de sécurité ne sera pas enregistré.</string>
@@ -192,12 +158,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Sélectionner une adresse</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Développer les adresses suggérées</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Développer les adresses enregistrées</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Réduire les adresses suggérées</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Réduire les adresses enregistrées</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-fy-rNL/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-fy-rNL/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Wachtwurd</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Net bewarje</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">No net</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nea bewarje</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Bewarje</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Net bywurkje</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">No net</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Bywurkje</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Wachtwurdfjild mei net leech wêze</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Folje in wachtwurd yn</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Kin oanmelding net bewarje</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Kin wachtwurd net bewarje</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Dizze oanmelding bewarje?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Wachtwurd bewarje?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Dizze oanmelding bywurkje?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Wachtwurd bywurkje?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Brûkersnamme oan bewarre wachtwurd tafoegje?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Brûkersnamme bywurkje?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">des</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Tiid ynstelle</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Oanmeldingen beheare</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Wachtwurden beheare</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Foarstelde oanmeldingen útklappe</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Bewarre wachtwurden te útklappe</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Foarstelde oanmeldingen ynklappe</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Bewarre wachtwurden ynklappe</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Foarstelde oanmeldingen</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Bewarre wachtwurden</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Sterk wachtwurd brûke?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Beskermje jo accounts mei in sterk, willekeurich oanmakke wachtwurd. Krij rappe tagong ta jo wachtwurden troch it op te slaan yn jo account.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Beskermje jo accounts mei in sterk, willekeurich oanmakke wachtwurd. Dit wurdt foar takomstich gebrûk yn jo account bewarre.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Annulearje</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Selektearje creditcard</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Bewarre kaart brûke</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Foarstelde creditcards útklappe</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Bewarre kaarten te útklappe</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Foarstelde creditcards ynklappe</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Bewarre kaarten ynklappe</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Creditcards beheare</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Kaarten beheare</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Dizze kaart feilich bewarje?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Ferrindatum kaart bywurkje?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">It kaartnûmer sil fersifere wurde. De befeiligingskoade wurdt net bewarre.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s fersiferet jo kaartnûmer. Jo befeiligingskoade wurdt net bewarre.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Adres selektearje</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Foarstelde adressen útklappe</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Bewarre adressen útklappe</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Foarstelde adressen ynklappe</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Bewarre adressen ynklappe</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-gl/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-gl/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Contrasinal</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Non gardar</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Agora non</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Non gardar nunca</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Gardar</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Non actualizar</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Agora non</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Actualizar</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">O campo de contrasinal non debe estar baleiro</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Introduza un contrasinal</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Non foi posíbel gardar o acceso</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Non se pode gardar o contrasinal</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Gardar esta identificación?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Gardar o contrasinal?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Actualizar esta identificación?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Actualizar o contrasinal?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Engadir nome de usuario ao contrasinal gardado?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Actualizar o nome de usuario?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -98,20 +84,12 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Establecer a hora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Xestionar as identificacións</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Xestionar os contrasinais</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir os inicios de sesión suxeridos</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expandir os contrasinais gardados</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer os inicios de sesión suxeridos</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Contraer os contrasinais gardados</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Inicios de sesión suxeridos</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Contrasinais gardados</string>
@@ -125,8 +103,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Usar un contrasinal seguro?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protexa as súas contas mediante un contrasinal seguro e xerado aleatoriamente. Obteña acceso rápido aos seus contrasinais gardándoos na súa conta.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Protexa as súas contas mediante un contrasinal seguro e xerado aleatoriamente. Gardarase na súa conta para o uso futuro.</string>
 
@@ -155,20 +131,12 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancelar</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Seleccionar a tarxeta de crédito</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Usar unha tarxeta gardada</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ampliar as tarxetas de crédito suxeridas</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expandir as tarxetas gardadas</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer as tarxetas de crédito suxeridas</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Contraer as tarxetas gardadas</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Xestionar as tarxetas de crédito</string>
 
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Xestionar tarxetas</string>
@@ -176,8 +144,6 @@
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Gardar esta tarxeta de forma segura?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Actualizar a data de caducidade da tarxeta?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">O número de tarxeta cifrarase. O código de seguridade non se gardará.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s cifra o seu número de tarxeta. O seu código de seguranza non se gardará.</string>
@@ -185,12 +151,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seleccione o enderezo</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir os enderezos suxeridos</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Amplíe os enderezos gardados</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Contraer os enderezos suxeridos</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Contraer os enderezos gardados</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-hr/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-hr/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Lozinka</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Nemoj spremiti</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ne sada</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nikad ne spremaj</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Spremi</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Nemoj aktualizirati</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ne sada</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Aktualiziraj</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Polje lozinke ne smije biti prazno</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Unesite lozinku</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Nije moguće spremiti prijavu</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Nije moguće spremiti lozinku</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Spremiti ovu prijavu?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Spremiti lozinku?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Aktualizirati ovu prijavu?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Ažurirati lozinku?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Dodati korisničko ime spremljenoj lozinki?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Ažurirati korisničko ime?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Pro</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Postavi vrijeme</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Upravljaj prijavama</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Upravljanje lozinkama</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Proširi predložene prijave</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Proširite spremljene lozinke</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Sažmi predložene prijave</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Skupite spremljene lozinke</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Predložene prijave</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Spremljene lozinke</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Koristi jaku lozinku?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Zaštitite svoje račune pomoću snažne, nasumično generirane lozinke. Brzo pristupite svojim lozinkama tako da ih spremite na svoj račun.</string>
 
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2">Zaštiti svoje račune pomoću snažne, nasumično generirane lozinke. Loznka će se spremiti u tvoj račun za buduću upotrebu.</string>
@@ -150,28 +126,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Odustani</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Odaberi kreditnu karticu</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Koristi spremljenu karticu</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Proširi predložene kreditne kartice</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Proširi spremljene kartice</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Sažmi predložene kreditne kartice</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Skupi spremljene kartice</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Upravljaj kreditnim karticama</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Upravljanje karticama</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Sigurno spremiti ovu karticu?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Ažuriraj datum isteka kartice?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Broj kartice će biti šifriran. Sigurnosni kod neće biti spremljen.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s šifrira broj vaše kartice. Vaš sigurnosni kod neće biti spremljen.</string>
@@ -179,12 +145,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Odaberite adresu</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Proširi predložene adrese</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Proširi spremljene adrese</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Sažmi predložene adrese</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Skupi spremljene adrese</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-hsb/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-hsb/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Hesło</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Njeskładować</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Nic nětko</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Ženje njeskładować</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Składować</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Njeaktualizować</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Nic nětko</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Aktualizować</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Hesłowe polo njesmě prózdne być</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Hesło zapodać</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Přizjewjenje njeda so składować</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Hesło njeda so składować</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Tute přizjewjenje składować?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Hesło składować?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Tute přizjewjenje aktualizować?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Hesło aktualizować?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Wužiwarske mjeno składowanemu hesłu přidać?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Wužiwarske mjeno aktualizować?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Čas nastajić</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Přizjewjenja rjadować</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Hesła rjadować</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Namjetowane přizjewjenja pokazać</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Składowane hesła pokazać</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Namjetowane přizjewjenja schować</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Składowane hesła schować</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Namjetowane přizjewjenja</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Składowane hesła</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Sylne hesło wužiwać?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Wužiwajće sylne, připadnje generěrowane hesło, zo byšće swoje konta škitał. Dóstańće spěšny přistup k swojim hesłam, hdyž jo w swojim konće składujeće.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Wužiwajće sylne, připadnje generěrowane hesło, zo byšće swoje konta škitał. Budźe so do wašeho konta za přichodne wužiwanje składować.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Přetorhnyć</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Kreditnu kartu wubrać</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Składowanu kartu wužiwać</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Namjetowane kreditne karty pokazać</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Składowane karty pokazać</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Namjetowane kreditne karty schować</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Składowane karty schować</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Kreditne karty rjadować</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Karty rjadować</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Tutu kartu wěsće składować?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Datum spadnjenja karty aktualizować?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Čisło karty budźe so zaklučować. Wěstotny kod njebudźe so składować.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s waše kartowe čisło zaklučuje. Waš wěstotny kod njebudźe so składować.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Adresu wubrać</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Namjetowane adresy pokazać</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Składowane adresy pokazać</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Namjetowane adresy schować</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Składowane adresy schować</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-hu/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-hu/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Jelszó</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ne mentse</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Most nem</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Sose mentse</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Mentés</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ne frissítse</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Most nem</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Frissítés</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">A jelszómező nem lehet üres</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Adjon meg egy jelszót</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">A bejelentkezés nem menthető</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">A jelszó nem menthető</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Menti ezt a bejelentkezést?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Menti a jelszót?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Frissíti ezt a bejelentkezést?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Jelszó frissítése?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Hozzáadja a felhasználónevet a mentett jelszóhoz?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Frissíti a felhasználónevet?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">dec.</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Idő beállítása</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Bejelentkezések kezelése</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Jelszavak kezelése</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Javasolt bejelentkezések kibontása</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Mentett jelszavak kibontása</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Javasolt bejelentkezések összecsukása</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Mentett jelszavak összecsukása</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Javasolt bejelentkezések</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Mentett jelszavak</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Erős jelszót használ?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Védje fiókjait erős, véletlenszerűen előállított jelszóval. Kapjon gyors hozzáférést a jelszavaihoz azáltal, hogy elmenti a fiókjába.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Védje meg fiókjait egy erős, véletlenszerűen előállított jelszóval. A fiókjába lesz mentve későbbi felhasználás céljából.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Mégse</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Válasszon bankkártyát</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Mentett kártya használata</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Javasolt bankkártyák kibontása</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Mentett kártyák kibontása</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Javasolt bankkártyák összecsukása</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Mentett kártyák összecsukása</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Bankkártyák kezelése</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Kártyák kezelése</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Elmenti biztonságosan ezt a kártyát?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Frissíti a kártya lejárati dátumát?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">A kártyaszám titkosítva lesz. A biztonsági kód nem kerül mentésre.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">A %s titkosítja a kártyaszámát. A biztonsági kód nem lesz mentve.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Cím kiválasztása</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Javasolt címek kibontása</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Mentett címek kibontása</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Javasolt címek összecsukása</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Mentett címek összecsukása</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-hy-rAM/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-hy-rAM/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Գաղտնաբառ</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Չպահպանել</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ոչ հիմա</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Երբեք չպահպանել</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Պահպանել</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Չթարմացնել</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ոչ հիմա</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Թարմացնել</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Գաղտնաբառի դաշտը չպետք է դատարկ լինի</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Մուտքագրեք գաղտնաբառ</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Անհնար է պահել մուտքանունը</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Հնարավոր չէ պահել գաղտնաբառը</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Պահպանե՞լ մուտքանունը</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Պահե՞լ գաղտնաբառը</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Թարմացնե՞լ մուտքանունը:</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Թարմացնե՞լ գաղտնաբառը:</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Ավելացնե՞լ օգտվողի անունը գաղտնաբառին:</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Թարմացնե՞լ օգտվողի անունը:</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Դեկ</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Կայել ժամանակ</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Կառավարել մուտքանունները</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Կառավարել գաղտնաբառերը</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ընդլայնել առաջարկվող մուտքանունները</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Ընդարձակել պահված գաղտնաբառերը</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Կոծկել առաջարկվող մուտքանունները</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Կոծկել պահված գաղտնաբառերը</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Առաջարկվող մուտքանուններ</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Պահված գաղտնաբառեր</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Օգտագործե՞լ ուժեղ գաղտնաբառ</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Պաշտպանեք ձեր հաշիվները՝ օգտագործելով ուժեղ, պատահականորեն ստեղծված գաղտնաբառ: Արագորեն մատչեք Ձեր գաղտնաբառերը՝ դրանք պահելով ձեր հաշվում:</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Պաշտպանեք ձեր հաշիվները՝ օգտագործելով ուժեղ, պատահականորեն ստեղծված գաղտնաբառ: Այն կպահվի ձեր հաշվում՝ հետագա օգտագործման համար:</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Չեղարկել</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Ընտրեք բանկային քարտ</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Օգտագործել պահված քարտը</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ընդարձակել առաջարկվող բանկային քարտերը</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Ընդարձակել պահված քարտերը</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Կոծկել առաջարկվող բանկային քարտերը</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Կոծկել պահված քարտերը</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Կառավարել բանկային քարտերը</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Կառավարել քարտերը</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Ապահով պահե՞լ այս քարտը:</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Թարմացնե՞լ քարտի գործողության ժամկետը:</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Քարտի համարը կկոդավորվի: Անվտանգության կոդը չի պահվի:</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s-ը գաղտնագրում է ձեր քարտի համարը: Անվտանգության ձեր կոդը չի պահպանվի:</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Ընտրեք հասցե</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ընդլայնել առաջարկվող հասցեները</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Ընդարձակել պահված հասցեները</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Կոծկել առաջարկվող հասցեները</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Կոծկել պահված հասցեները</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ia/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ia/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Contrasigno</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Non salvar</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Non ora</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Non salvar mais</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Salvar</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Non actualisar</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Non ora</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Actualisar</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Le campo del contrasigno non debe esser vacue</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Insere un contrasigno</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Impossibile salvar le credentiales</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Impossibile salvar le contrasigno</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Salvar iste credentiales?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Salvar le contrasigno?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Actualisar iste credentiales?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Actualisar le contrasigno?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Adder le nomine de usator al contrasigno salvate?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Actualisar le nomine de usator?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,21 +83,13 @@
     <string name="mozac_feature_prompts_dec">dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Adjustar le hora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Gerer credentiales</string>
 
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Gerer contrasignos</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expander le credentiales suggerite</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expander le contrasignos salvate</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Collaber le credentiales suggerite</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Comprimer le contrasignos salvate</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Credentiales suggerite</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Contrasignos salvate</string>
@@ -125,8 +103,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Usar contrasigno forte?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protege tu contos per un forte, contrasigno aleatorimente generate. Obtene accesso rapide a tu contrasignos reservante los in tu conto.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Protege tu contos per un forte, contrasigno aleatorimente generate. Illo sera salvate in tu conto pro uso futur.</string>
 
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancellar</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Eliger le carta de credito</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Usar un carta salvate</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expander le cartas de credito suggerite</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expander le cartas salvate</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Collaber le cartas de credito suggerite</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Comprimer le cartas salvate</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Gerer le cartas de credito</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Gerer le cartas</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Securmente salveguardar iste carta?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Actualisar le data de expiration del carta?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Le numero de carta sera cryptate. Le codice de securitate non sera salvate.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s crypta tu numero de carta. Tu codice de securitate non sera salvate.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seliger adress</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expander adresses suggerite</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Expander adresses salvate</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Collaber adresses suggerite</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Collaber adresses salvate</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-in/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-in/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Sandi</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Jangan simpan</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Jangan sekarang</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Jangan pernah simpan</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Simpan</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Jangan perbarui</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Jangan sekarang</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Perbarui</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Bidang kata sandi tidak boleh kosong</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Masukkan kata sandi</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Gagal menyimpan info masuk</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Tidak dapat menyimpan kata sandi</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Simpan info masuk ini?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Simpan sandi?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Perbarui info masuk ini?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Perbarui kata sandi?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Tambahkan nama pengguna ke kata sandi yang disimpan?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Perbarui nama pengguna?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Des</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Atur waktu</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Kelola info masuk</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Kelola kata sandi</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Perlihatkan log masuk yang disarankan</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Bentangkan kata sandi tersimpan</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ciutkan log masuk yang disarankan</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Ciutkan kata sandi tersimpan</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Log masuk yang disarankan</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Sandi tersimpan</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Gunakan sandi yang kuat?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Lindungi akun Anda dengan menggunakan kata sandi yang kuat dan dibuat secara acak. Dapatkan akses cepat ke kata sandi Anda dengan menyimpannya di akun Anda.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2">Lindungi akun Anda dengan menggunakan kata sandi yang kuat dan dibuat secara acak. Ini akan disimpan ke akun Anda untuk digunakan di masa mendatang.</string>
 
@@ -149,28 +125,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Batal</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Pilih kartu kredit</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Gunakan kartu tersimpan</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Perluas kartu kredit yang disarankan</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Bentangkan kartu tersimpan</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ciutkan kartu kredit yang disarankan</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Ciutkan kartu tersimpan</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Kelola kartu kredit</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Kelola kartu</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Simpan kartu ini dengan aman?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Perbarui tanggal kedaluwarsa kartu?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Nomor kartu akan dienkripsi. Kode keamanan tidak akan disimpan.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s mengenkripsi nomor kartu Anda. Kode keamanan Anda tidak akan disimpan.</string>
@@ -178,12 +144,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Pilih alamat</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Bentangkan alamat yang disarankan</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Bentangkan alamat tersimpan</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ciutkan alamat yang disarankan</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Ciutkan alamat tersimpan</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-is/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-is/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Lykilorð</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ekki vista</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ekki núna</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Aldrei vista</string>
@@ -27,25 +25,15 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Vista</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ekki uppfæra</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ekki núna</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Uppfæra</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Lykilorðareiturinn má ekki vera tómur</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Settu inn lykilorð</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Gat ekki vistað innskráningarupplýsingar</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Get ekki vistað lykilorð</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Vista þessa innskráningu?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Vista lykilorð?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Uppfæra þessa innskráningu?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Uppfæra lykilorð?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
@@ -95,22 +83,14 @@
     <string name="mozac_feature_prompts_dec">Des</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Stilla tíma</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Sýsla með innskráningar</string>
 
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Sýsla með lykilorð</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Fletta út tillögum að innskráningu</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Fletta út vistuð lykilorð</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Fella saman tillögur að innskráningu</string>
 
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Fella saman vistuð lykilorð</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Tillögur að innskráningu</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Vistuð lykilorð</string>
@@ -152,28 +132,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Hætta við</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Veldu greiðslukort</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Nota vistað kort</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Fletta út tillögum að greiðslukortum</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Fletta út vistuð greiðslukort</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Fella saman tillögur að greiðslukortum</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Fella saman vistuð greiðslukort</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Sýsla með greiðslukort</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Sýsla með greiðslukort</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Vista þetta kort á öruggan hátt?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Uppfæra gildistíma korts?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Kortanúmer verður dulritað. Öryggiskóði verður ekki vistaður.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s dulkóðar kortanúmerið þitt. Öryggiskóðinn þinn verður ekki vistaður.</string>
@@ -181,12 +151,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Veldu póstfang</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Fletta út tillögum að póstföngum</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Fletta út vistuðum heimilisföngum</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Fella saman tillögur að póstföngum</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Fella saman vistuð heimilisföng</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-it/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-it/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Password</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Non salvare</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Non adesso</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Non salvare mai</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Salva</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Non aggiornare</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Non adesso</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Aggiorna</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">È necessario inserire una password</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Inserisci una password</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Impossibile salvare le credenziali</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Impossibile salvare la password</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Salvare queste credenziali?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Salvare la password?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Aggiornare queste credenziali?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Aggiornare la password?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Aggiungere il nome utente alle credenziali salvate?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Aggiornare il nome utente?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dic</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Imposta ora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Gestione credenziali</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Gestisci password</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Espandi le credenziali suggerite</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Espandi le password salvate</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Comprimi le credenziali suggerite</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Comprimi le password salvate</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Credenziali suggerite</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Password salvate</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Usare una password complessa?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Proteggi i tuoi account utilizzando una password complessa, generata in modo casuale. Accedi rapidamente alle tue password salvandole nel tuo account.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Proteggi i tuoi account utilizzando una password complessa generata in modo casuale. Verrà salvata nel tuo account per un uso futuro.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Annulla</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Seleziona carta di credito</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Utilizza carta salvata</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Espandi l’elenco delle carte di credito suggerite</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Espandi le carte salvate</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Comprimi l’elenco delle carte di credito suggerite</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Comprimi le carte salvate</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Gestisci carte di credito</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Gestisci carte</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Salvare questa carta in modo sicuro?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Aggiornare la data di scadenza della carta?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Il numero della carta sarà crittato. Il codice di sicurezza non verrà salvato.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s critta il numero della tua carta. Il codice di sicurezza non verrà salvato.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seleziona indirizzo</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Espandi gli indirizzi suggeriti</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Espandi gli indirizzi salvati</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Comprimi gli indirizzi suggeriti</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Comprimi gli indirizzi salvati</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-iw/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-iw/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">ססמה</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">לא לשמור</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">לא כעת</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">לעולם לא לשמור</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">לשמור</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">לא לעדכן</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">לא כעת</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">עדכון</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">שדה הססמה לא יכול להישאר ריק</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">נא להכניס ססמה</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">לא ניתן לשמור את הכניסה</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">לא ניתן לשמור את הססמה</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">לשמור כניסה זו?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">לשמור את הססמה?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">לעדכן כניסה זו?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">לעדכן את הססמה?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">להוסיף שם משתמש לססמה השמורה?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">לעדכן את שם המשתמש?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">דצמ׳</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">הגדרת זמן</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">ניהול כניסות</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">ניהול ססמאות</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">הרחבת הכניסות המוצעות</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">הרחבת ססמאות שמורות</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">צמצום הכניסות המוצעות</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">צמצום ססמאות שמורות</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">כניסות מוצעות</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">ססמאות שמורות</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">להשתמש בססמה חזקה?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">כדאי להגן על החשבונות שלך על־ידי שימוש בססמה חזקה רנדומלית. ניתן לקבל גישה מהירה לססמאות שלך על־ידי שמירתן בחשבון שלך.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">ניתן להגן על החשבונות שלך על־ידי שימוש בססמה חזקה הנוצרת באופן אקראי. הססמה תישמר בחשבון שלך לשימוש עתידי.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">ביטול</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">בחירת כרטיס אשראי</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">שימוש בכרטיס השמור</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">הרחבת כרטיסי האשראי המוצעים</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">הרחבת כרטיסים שמורים</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">צמצום כרטיסי האשראי המוצעים</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">צמצום כרטיסים שמורים</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">ניהול כרטיסי אשראי</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">ניהול כרטיסים</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">לשמור את הכרטיס הזה באופן מאובטח?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">לעדכן את תאריך התפוגה של הכרטיס?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">מספר הכרטיס יוצפן. קוד האבטחה לא יישמר.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">‏%s מצפין את מספר הכרטיס שלך. קוד האבטחה שלך לא יישמר.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">בחירת כתובת</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">הרחבת הכתובות המוצעות</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">הרחבת כתובות דוא״ל</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">צמצום הכתובות המוצעות</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">צמצום כתובות דוא״ל</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ja/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ja/strings.xml
@@ -25,8 +25,6 @@
     <string name="mozac_feature_prompt_password_hint">パスワード</string>
 
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">保存しない</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">後で</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">保存しない</string>
@@ -35,29 +33,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">保存する</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">更新しない</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">後で</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">更新</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">パスワードを入力してください</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">パスワードを入力してください</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">ログイン情報を保存できません</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">パスワードを保存できません</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">このログイン情報を保存しますか？</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">パスワードを保存しますか？</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">このログイン情報を更新しますか？</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">パスワードを更新しますか？</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">保存されたパスワードにユーザー名を追加しますか？</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">ユーザー名を更新しますか？</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -109,20 +95,12 @@
     <string name="mozac_feature_prompts_dec">12月</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">時刻の設定</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">ログイン情報の管理</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">パスワードを管理</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">提案されたログイン情報を展開</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">保存したパスワードを展開</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">提案されたログイン情報を折りたたむ</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">保存したパスワードを折りたたむ</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">提案されたログイン情報</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">保存されたパスワード</string>
@@ -136,8 +114,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">強固なパスワードを使用しますか？</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">強固でランダムに生成されたパスワードを使用してアカウントを保護しましょう。そのパスワードをアカウントに保存しておけば、すぐにアクセスできます。</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">強固でランダムに生成されたパスワードを使用してアカウントを保護しましょう。パスワードは今後使用するためにアカウントに保存されます。</string>
 
@@ -166,28 +142,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">キャンセル</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">クレジットカードを選択</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">保存したカード情報を使用</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">提案されたクレジットカード情報を展開する</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">保存したカード情報を展開</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">提案されたクレジットカード情報を折りたたむ</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">保存したカード情報を折りたたむ</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">クレジットカードを管理</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">カード情報を管理</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">このカードの情報を安全に保存しますか？</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">カードの有効期限を更新しますか？</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">カード番号は暗号化されます。セキュリティコードは保存されません。</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s がカード番号を暗号化します。セキュリティコードは保存しません。</string>
@@ -195,12 +161,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">アドレスの選択</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">提案されたアドレス情報を展開する</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">保存したアドレス情報を展開</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">提案されたアドレス情報を折りたたむ</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">保存したアドレス情報を折りたたむ</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-kab/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-kab/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Awal uffir</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ur seklas ara</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Mačči tura</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Urǧin sekles</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Sekles</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ur leqqem ara</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Mačči tura</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Leqqem</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Urti n wawal uffir ur ilaq ara ad yili d ilem</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Sekcem awal uffir</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Ur yezmir ara ad isekles anekcum</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Ur sseklas ara awal uffir</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Sekles anekcum-agi?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Sekles awal uffir?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Leqqem anekcum-agi?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Leqqem awal uffir?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Rnu isem n useqdac ɣer wawal uffir yettwaskelsen?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Leqqem isem n useqdac?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Duj</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Sbadu akud</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Sefrek inekcam</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Sefrek awalen uffiren</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Sken-d inekcam isumar</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Snerni awalen n uεeddi i yettwaskelsen</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ffer inekcam isumar</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Fneḍ awalen n uεeddi i yettwaskelsen</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Inekcam yettwasumren</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Awalen uffiren yettwakelsen</string>
@@ -125,8 +103,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Seqdec awal n uɛeddi iǧehden?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Mmesten imiḍanen-ik s useqdec n wawal n uεeddi iǧehden, yettusefrek s wudem kan akka. Kcem s zzerb ɣer wawalen-ik n uεeddi s usekles-nsen deg umiḍan-ik.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Mmesten imiḍanen-ik s useqdec n wawal uffir iǧehden aṭas, yettusirwen kan akka. Ad yettwasekles deg umiḍan-ik i d-iteddun.</string>
 
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Sefsex</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Fren takarḍa n usmad</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Seqdec tkarḍa yettwaskelsen</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Semɣer tikerḍiwin n usmad i d-yettusumren</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Snerni tikarḍiwin i yettwaskelsen</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Fneẓ tikerḍiwin n usmad i d-yettusumren</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Fneẓ awalen n tikarḍiwin i yettwaskelsen</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Sefrektikarḍiwin n usmad</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Sefrek tikarḍiwin</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Asekles n tkarḍa-a s wudem aɣellsan?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Leqqem azemz n keffu n tkarḍa?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Uṭṭun n tkarḍa ad yettwawgelhen. Tangalt n tɣellist ur tettwaseklas ara.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s ittewgelhin uṭṭun n tkarḍa-k·m. Tangalt-ik n tɣellist ur tezmir ara ad tettwasekles.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Fren tansa</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Snefli tansiwin d-yettwasumren</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Snerni tansiwin i yettwaskelsen</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Fneẓ tansiwin d-yettwasumren</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Fneẓ tansiwin i yettwaskelsen</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-kk/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-kk/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Пароль</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Сақтамау</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Қазір емес</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Ешқашан сақтамау</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Сақтау</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Жаңартпау</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Қазір емес</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Жаңарту</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Пароль өрісі бос болмауы тиіс</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Парольді енгізіңіз</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Логинді сақтау мүмкін емес</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Парольді сақтау мүмкін емес</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Бұл логинді сақтау керек пе?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Парольді сақтау керек пе?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Бұл логинді жаңарту керек пе?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Парольді жаңарту керек пе?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Пайдаланушы атын сақталған парольге қосу керек пе?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Пайдаланушы атын жаңарту керек пе?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Жел</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Уақытты орнату</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Логиндерді басқару</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Парольдерді басқару</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ұсынылған логиндерді жазық қылу</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Сақталған парольдерді жазық қылу</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ұсынылған логиндерді қайыру</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Сақталған парольдерді бүктеу</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Ұсынылған логиндер</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Сақталған парольдер</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Қатаң парольді қолдану керек пе?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Қатаң, кездейсоқ жасалған парольді пайдалану арқылы тіркелгілеріңізді қорғаңыз. Парольдерді тіргіңізге сақтау арқылы жылдам қол жеткізіңіз.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Өз тіркелгілеріңізді күшті, кездейсоқ жасалған парольді пайдалану арқылы қорғаңыз. Ол болашақта пайдалану үшін тіркелгіңізге сақталады.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Бас тарту</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Несиелік картаны таңдау</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Сақталған картаны пайдалану</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ұсынылған несиелік карталарды жаю</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Сақталған карталарды жазық қылу</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ұсынылған несиелік карталарды жию</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Сақталған карталарды бүктеу</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Несиелік карталарды басқару</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Карталарды басқару</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Бұл картаны қауіпсіз сақтау керек пе?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Картаның жарамдылық мерзімін жаңарту керек пе?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Карта нөмірі шифрленеді. Қауіпсіздік коды сақталмайды.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%sкартаңыздың нөмірін шифрлейді. Қауіпсіздік кодыңыз сақталмайтын болады.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Адресті таңдау</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ұсынылған адрестерді жазық қылу</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Сақталған адрестерді жазық қылу</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ұсынылған адрестерді бүктеу</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Сақталған адрестерді бүктеу</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-kmr/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-kmr/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Pêborîn</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Tomar neke</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ne niha</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Qet tomar neke</string>
@@ -27,26 +25,16 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Tomar bike</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Nûve neke</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ne niha</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Nûve bike</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Divê qada pêborînê vala nemîne</string>
 
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Şîfreyekê binivîse</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Hesab nehate tomarkirin</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Şîfre nayê tomarkirin</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Vî hesabî tomar bike?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Şîfreyê tomar bike?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Vî hesabî nûve bike?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Şîfreyê venû bike?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
@@ -96,21 +84,13 @@
     <string name="mozac_feature_prompts_dec">Ber</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Demê eyar bike</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Hesaban birêve bibe</string>
 
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Şîfreyan bi krê ve bibe</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Hesabên pêşniyarkirî fireh bike</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Şîfreyên tomarkirî fireh bike</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Hesabên pêşniyarkirî teng bike</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Şîfreyên tomarkirî teng bike</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Hesabên pêşniyarkirî</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Şîdreyên tomarkirî</string>
@@ -127,28 +107,14 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Betal bike</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Karta krediyê hilbijêre</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Kartên krediyê yên pêşniyarkirî fireh bike</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Kartên krediyê yên pêşniyarkirî teng bike</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Kartên krediyê bi rê ve bibe</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Vê kardê bi awayekî ewle hilînî?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Dîroka dawî ya kardê venû bikin?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Hejmara kardê dê bê şîfrekirin. Koda ewlekariyê dê neyê hilanîn.</string>
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Navnîşanê hilbijêre</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Navnîşanên pêşniyarkirî berfireh bike</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Hesabên pêşniyarkirî teng bike</string>
     <!-- Text for the manage addresses button. -->
     <string name="mozac_feature_prompts_manage_address">Navnîşanan bi rê ve bibe</string>
 

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ko/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ko/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">비밀번호</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">저장 안 함</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">나중에</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">저장 안 함</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">저장</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">업데이트 안 함</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">나중에</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">업데이트</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">비밀번호 필드는 비워 둘 수 없습니다</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">비밀번호 입력</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">로그인을 저장할 수 없음</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">비밀번호를 저장할 수 없음</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">이 로그인을 저장하시겠습니까?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">비밀번호를 저장하시겠습니까?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">이 로그인을 업데이트하시겠습니까?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">비밀번호를 업데이트하시겠습니까?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">저장된 비밀번호에 사용자 이름을 추가하시겠습니까?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">사용자 이름을 업데이트하시겠습니까?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">12월</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">시간 설정</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">로그인 관리</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">비밀번호 관리</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">제안된 로그인 펼치기</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">저장된 비밀번호 펼치기</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">제안된 로그인 접기</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">저장된 비밀번호 접기</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">제안된 로그인</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">저장된 비밀번호</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">강력한 비밀번호를 사용하시겠습니까?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">무작위로 생성된 강력한 비밀번호를 사용하여 계정을 보호하세요. 비밀번호를 계정에 저장하여 비밀번호에 빠르게 액세스하세요.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">무작위로 생성된 강력한 비밀번호를 사용하여 계정을 보호하세요. 나중에 사용할 수 있도록 계정에 저장됩니다.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">취소</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">신용 카드 선택</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">저장된 카드 사용</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">제안된 신용 카드 펼치기</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">저장된 비밀번호 펼치기</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">제안된 신용 카드 접기</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">저장된 비밀번호 접기</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">신용 카드 관리</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">카드 관리</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">이 카드를 안전하게 저장하시겠습니까?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">카드 유효 기간을 업데이트하시겠습니까?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">카드 번호는 암호화됩니다. 보안 코드는 저장되지 않습니다.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s는 카드 번호를 암호화합니다. 보안 코드는 저장되지 않습니다.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">주소 선택</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">제안된 주소 펼치기</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">저장된 주소 펼치기</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">제안된 주소 접기</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">저장된 주소 접기</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-meh/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-meh/strings.xml
@@ -15,8 +15,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Contraseña</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Nchuva´a</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Nkuvi ntañu´u</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nchuva\'a ni\'i íchi</string>
@@ -25,29 +23,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Chuva´a</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Nsa actualizar</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Nkuvi ntañu´u</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Actualizar</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Campo contraseña nkuvi koo kino sukua</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Chu\'un contraseña</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Nkuvi chuva´a tutu nátava</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Ntu kuvi chuva\'a contraseña</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Chuva\'a nuu kajie´e sesión ya´a?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Chuva\'a contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">¿Naxi\'ña nuu kajie´e sesión ya´a?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Naxi\'ña contraseña?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">¿Tee sivɨ ñivɨ nu contraseña nchuva\'a?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
     <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
     <string name="mozac_feature_prompts_content_description_input_label">Etiqueta sa chu\'unu iin campo de entrada de texto</string>
@@ -94,20 +80,12 @@
     <string name="mozac_feature_prompts_dec">Dic</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Tee hora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Ke\'i nuu kajie´e sesión</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Tetiñu da contraseñas</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Sá´á ka\'nu da nuu kajie\'e sesión sugeridos</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Sá\'á ka\'nu nu nchuva\'a contraseñas</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Sá´á luli da nuu kajie\'e sesión sugeridos</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Sá\'á luli nu nchuva\'a contraseñas</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Nuu kajie´e sesión sugeridos</string>
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Da contraseñas nchuva\'a</string>
 
@@ -139,20 +117,12 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Nkuvi-ka</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Kaji tarjeta crédito</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Ni\'i tarjeta nchuva\'a</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Sá´á ka\'nu da tarjetas crédito sugeridas</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Sá\'á ka\'nu nu nchuva\'a daa tarjetas</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Chiyu\'u daa tarjetas crédito sugeridas</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Sá\'á luli nu nchuva\'a da tarjetas</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Ke\'i daa tarjetas crédito</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Ke\'i daa tarjetas</string>
 
@@ -161,19 +131,13 @@
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">¿Natee fecha nɨ\'ɨ tarjeta?</string>
 
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">El número de tarjeta se encriptará. El código de seguridad no se guardará.</string>
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Kaji dirección</string>
 
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir direcciones sugeridas</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Sá\'á ka\'nu nu nchuva\'a daa nuu</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Chiyu\'u daa nuu sugeridas</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Sá\'á luli nu nchuva\'a da nuu</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-nb-rNO/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-nb-rNO/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Passord</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ikke lagre</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ikke nå</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Lagre aldri</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Lagre</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ikke oppdater</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ikke nå</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Oppdater</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Passordfeltet kan ikke stå tomt</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Skriv inn et passord</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Klarte ikke å lagre innloggingen</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Kan ikke lagre passordet</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Lagre denne innloggingen?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Lagre passord?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Vil du oppdatere denne innloggingen?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Oppdatere passord?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Vil du legge til brukernavn til lagret passord?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Oppdatere brukernavn?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Des</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Angi tid</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Behandle innlogginger</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Behandle passord</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Utvid foreslåtte innlogginger</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Utvid lagrede passord</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Slå sammen foreslåtte innlogginger</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Skjul lagrede passord</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Foreslåtte innlogginger</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Lagrede passord</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Bruke sterkt passord?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Beskytt kontoene dine ved å bruke et sterkt, tilfeldig generert passord. Få rask tilgang til passordene dine ved å lagre dem på kontoen din.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Beskytt dine kontoer ved å bruke et sterkt, tilfeldig generert passord. Den blir lagret på kontoen din for fremtidig bruk.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Avbryt</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Velg betalingskort</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Bruk lagret kort</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Utvid foreslåtte betalingskort</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Utvid lagrede kort</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Slå sammen foreslåtte betalingskort</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Skjul lagrede kort</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Behandle betalingskort</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Behandle kort</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Lagre dette kortet trygt?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Oppdatere kortets utløpsdato?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Kortnummer vil bli kryptert. Sikkerhetskoden blir ikke lagret.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s krypterer kortnummeret ditt. Sikkerhetskoden din blir ikke lagret.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Velg adresse</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Utvid foreslåtte adresser</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Utvid lagrede adresser</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Slå sammen foreslåtte adresser</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Skjul lagrede adresser</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-nl/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-nl/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Wachtwoord</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Niet opslaan</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Niet nu</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nooit opslaan</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Opslaan</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Niet bijwerken</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Niet nu</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Bijwerken</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Wachtwoordveld mag niet leeg zijn</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Vul een wachtwoord in</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Kan aanmelding niet opslaan</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Kan wachtwoord niet opslaan</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Deze aanmelding opslaan?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Wachtwoord opslaan?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Deze aanmelding bijwerken?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Wachtwoord bijwerken?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Gebruikersnaam aan opgeslagen wachtwoord toevoegen?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Gebruikersnaam bijwerken?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Tijd instellen</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Aanmeldingen beheren</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Wachtwoorden beheren</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Voorgestelde aanmeldingen uitvouwen</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Opgeslagen wachtwoorden uitvouwen</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Voorgestelde aanmeldingen inklappen</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Opgeslagen wachtwoorden inklappen</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Voorgestelde aanmeldingen</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Opgeslagen wachtwoorden</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Sterk wachtwoord gebruiken?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Bescherm uw accounts met een sterk, willekeurig aangemaakt wachtwoord. Krijg snel toegang tot uw wachtwoorden door ze in uw account op te slaan.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Bescherm uw accounts met een sterk, willekeurig aangemaakt wachtwoord. Dit wordt voor toekomstig gebruik in uw account opgeslagen.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Annuleren</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Selecteer creditcard</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Opgeslagen kaart gebruiken</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Voorgestelde creditcards uitbreiden</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Opgeslagen kaarten uitvouwen</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Voorgestelde creditcards inklappen</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Opgeslagen kaarten inklappen</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Creditcards beheren</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Kaarten beheren</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Deze kaart veilig opslaan?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Vervaldatum kaart bijwerken?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Het kaartnummer wordt versleuteld. De beveiligingscode wordt niet opgeslagen.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s versleutelt uw kaartnummer. Uw beveiligingscode wordt niet opgeslagen.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Adres selecteren</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Voorgestelde adressen uitvouwen</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Opgeslagen adressen uitvouwen</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Voorgestelde adressen inklappen</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Opgeslagen adressen inklappen</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-nn-rNO/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-nn-rNO/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Passord</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ikkje lagre</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ikkje no</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Lagre aldri</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Lagre</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ikkje oppdater</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ikkje no</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Oppdater</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Passordfeltet kan ikkje stå tomt</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Skriv inn passord</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Klarte ikkje å lagre innlogginga</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Kan ikkje lagre passordet</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Lagre denne innlogginga?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Lagre passord?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Vil du oppdatere denne innlogginga?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Oppdatere passord?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Leggje brukarnamn til lagra passord?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Oppdatere brukarnamn?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Des</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Oppgi tid</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Handsam innloggingar</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Handsam passord</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Utvid føreslåtte innloggingar</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Utvid lagra passord</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Slå saman føreslåtte innloggingar</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Skjul lagra passord</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Føreslåtte innloggingar</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Lagra passord</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Bruke sterkt passord?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Beskytt kontoen din ved å bruke eit sterkt, tilfeldig generert passord. Få rask tilgang til passorda dine ved å lagre det i kontoen din.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Vern kontoen din ved å bruke eit sterkt, tilfeldig generert passord. Det vert lagra i kontoen din for framtitig bruk.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Avbryt</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Vel betalingskort</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Bruk lagra kort</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Utvid føreslått betalingskort</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Utvid lagra passord</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Minimer føreslått betalingskort</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Skjul lagra kort</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Handsam betalingskort</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Handsam kort</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Lagre dette kortet trygt?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Oppdatere siste bruksdato for kortet?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Kortnummeret vil bli kryptert. Tryggingskoden vert ikkje lagra.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s krypterer kortnummeret ditt. Sikkerheitskoden din vert ikkje lagra.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Vel adresse</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Utvid føreslåtte adresser</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Utvid lagra adresser</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Slå saman føreslåtte adresser</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Skjul lagra adresser</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-oc/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-oc/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Senhal</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Enregistrar pas</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Pas ara</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Enregistrar pas jamai</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Enregistrar</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Metre pas a jorn</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Pas ara</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Metre a jorn</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Lo camp senhal pòt pas èsser void</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Picatz un senhal</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Impossible d’enregistrar l’identificant</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Enregistrament de senhal impossible</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Salvar aqueste identificant ?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Salvar lo senhal ?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Metre a jorn aqueste identificant ?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Actualizar lo senhal ?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Apondre un nom d’utilizaire al senhal salvat ?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Actualizar lo nom d’utilizaire ?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Causida del temps</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Gerir los identificants</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Gerir los senhals</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Espandir los identificants suggerits</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Desplegar los senhals salvats</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Plegar los identificants suggerits</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Plegar los senhals salvats</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Identificants recomandats</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Senhals salvats</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Utilizar un senhal segur ?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Protegissètz vòstres comptes en utilizant un senhal complicat, generat a l\'azard. Accedissètz rapidament a vòstres senhals en los salvant dins vòstre compte.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2">Protegissètz vòstres comptes en utilizant un senhal fòrt e generat a l\'azard. Serà salvat dins vòstre compte per d\'usatges futurs.</string>
 
@@ -151,28 +127,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Anullar</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Seleccionar carta de crèdit</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Utilizar una carta enregistrada</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Espandir las cartas de crèdit suggeridas</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Desplegar las cartas enregistradas</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Plegar las cartas de crèdit suggeridas</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Plegar las cartas enregistradas</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Gerir las cartas de crèdit</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Gerir las cartas</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Salvar d’un biais segur aquesta carta ?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Actualizar la data d’expiracion de la carta ?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Los numèros de carta son chifrats. Se gardarà pas lo còdi de seguretat.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s chifra lo numèro de carta. Lo còdi de seguretat s’enregistrarà pas.</string>
@@ -180,12 +146,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seleccion d’adreça</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Espandir las adreças suggeridas</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Desplegar las adreças enregistradas</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Plegar las adreças suggeridas</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Plegar las adreças enregistradas</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pa-rIN/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pa-rIN/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">ਪਾਸਵਰਡ</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">ਨਾ ਸੰਭਾਲੋ</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">ਹੁਣੇ ਨਹੀਂ</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">ਕਦੇ ਨਾ ਸੰਭਾਲੋ</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">ਸੰਭਾਲੋ</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">ਅੱਪਡੇਟ ਨਾ ਕਰੋ</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">ਹੁਣੇ ਨਹੀਂ</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">ਅੱਪਡੇਟ ਕਰੋ</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">ਪਾਸਵਰਡ ਖੇਤਰ ਖਾਲੀ ਨਹੀਂ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">ਪਾਸਵਰਡ ਦਿਓ</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">ਲਾਗਇਨ ਸੰਭਾਲਣ ਲਈ ਅਸਮਰੱਥ</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">ਪਾਸਵਰਡ ਸੰਭਾਲਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ ਹੈ</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">ਇਹ ਲਾਗਇਨ ਸੰਭਾਲਣਾ ਹੈ?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">ਪਾਸਵਰਡ ਸੰਭਾਲਣਾ ਹੈ?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">ਇਹ ਲਾਗਇਨ ਅੱਪਡੇਟ ਕਰਨਾ ਹੈ?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">ਪਾਸਵਰਡ ਅੱਪਡੇਟ ਕਰਨਾ ਹੈ?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">ਵਰਤੋਂਕਾਰ-ਨਾਂ ਨੂੰ ਸੰਭਾਲੇ ਪਾਸਵਰਡ ਵਿੱਚ ਜੋੜਨਾ ਹੈ?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">ਵਰਤੋਂਕਾਰ-ਨਾਂ ਨੂੰ ਅੱਪਡੇਟ ਕਰਨਾ ਹੈ?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">ਦਸੰ</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">ਸਮਾਂ ਸੈੱਟ ਕਰੋ</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">ਲਾਗਇਨਾਂ ਦਾ ਇੰਤਜ਼ਾਮ</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">ਪਾਸਵਰਡਾਂ ਦਾ ਇੰਤਜ਼ਾਮ</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ਸੁਝਾਏ ਲਾਗਇਨ ਫੈਲਾਓ</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">ਸੰਭਾਲੇ ਹੋਏ ਪਾਸਵਰਡਾਂ ਨੂੰ ਫੈਲਾਓ</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ਸੁਝਾਏ ਲਾਗਇਨ ਸਮੇਟੋ</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">ਸੰਭਾਲੇ ਹੋਏ ਪਾਸਵਰਡਾਂ ਨੂੰ ਸਮੇਟੋ</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">ਸੁਝਾਏ ਗਏ ਲਾਗਇਨ</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">ਸੰਭਾਲੇ ਹੋਏ ਪਾਸਵਰਡ</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">ਮਜ਼ਬੂਤ ਪਾਸਵਰਡ ਵਰਤਣਾ ਹੈ?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">ਆਪਣੇ ਖਾਤਿਆਂ ਨੂੰ ਮਜ਼ਬੂਤ, ਰਲਵੇਂ ਮਿਲਵੇਂ ਤਿਆਰ ਕੀਤੇ ਪਾਸਵਰਡ ਨੂੰ ਵਰਤ ਕੇ ਸੁਰੱਖਿਅਤ ਕਰੋ। ਆਪਣੇ ਪਾਸਵਰਡਾਂ ਨੂੰ ਆਪਣੇ ਖਾਤੇ ਵਿੱਚ ਸੰਭਾਲ ਕੇ ਫ਼ੌਰਨ ਲਵੋ।</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">ਮਜ਼ਬੂਤ, ਬੇਤਰਤੀਬੇ ਤਿਆਰ ਕੀਤੇ ਪਾਸਵਰਡ ਨਾਲ ਆਪਣੇ ਖਾਤਿਆਂ ਨੂੰ ਸੁਰੱਖਿਆ ਦਿਓ। ਇਸ ਨੂੰ ਭਵਿੱਖ ਵਿੱਚ ਤੁਹਾਡੇ ਖਾਤੇ ਵਿੱਚ ਸੰਭਾਲਿਆ ਜਾਵੇਗਾ।</string>
 
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">ਰੱਦ ਕਰੋ</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">ਕਰੈਡਿਟ ਕਾਰਡ ਚੁਣੋ</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">ਸੰਭਾਲੇ ਕਾਰਡ ਨੂੰ ਵਰਤੋਂ</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ਸੁਝਾਏ ਗਏ ਕਰੈਡਿਟ ਕਾਰਡ ਨੂੰ ਫੈਲਾਓ</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">ਸੰਭਾਲੇ ਹੋਏ ਕਾਰਡਾਂ ਨੂੰ ਫੈਲਾਓ</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ਸੁਝਾਏ ਗਏ ਕਰੈਡਿਟ ਕਾਰਡ ਨੂੰ ਸਮੇਟੋ</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">ਸੰਭਾਲੇ ਹੋਏ ਕਾਰਡਾਂ ਨੂੰ ਸਮੇਟੋ</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">ਕਰੈਡਿਟ ਕਾਰਡਾਂ ਦਾ ਇੰਤਜ਼ਾਮ ਕਰੋ</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">ਕਾਰਡਾਂ ਦਾ ਇੰਤਜ਼ਾਮ ਕਰੋ</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">ਇਹ ਕਾਰਡ ਨੂੰ ਸੁਰੱਖਿਅਤ ਢੰਗ ਨਾਲ ਸੰਭਾਲਣਾ ਹੈ?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">ਕਾਰਡ ਦੀ ਮਿਆਦ ਪੁੱਗਣ ਦੀ ਤਾਰੀਖ ਨੂੰ ਅੱਪਡੇਟ ਕਰਨਾ ਹੈ?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">ਕਾਰਡ ਨੰਬਰ ਨੂੰ ਇੰਕ੍ਰਿਪਟ ਕੀਤਾ ਜਾਵੇਗਾ। ਸੁਰੱਖਿਆ ਕੋਡ ਸੰਭਾਲਿਆ ਨਹੀਂ ਜਾਵੇਗਾ।</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s ਤੁਹਾਡੇ ਕਾਰਡ ਨੂੰ ਇੰਕ੍ਰਿਪਟ ਕਰਦਾ ਹੈ। ਤੁਹਾਡੇ ਸੁਰੱਖਿਆ ਕੋਡ ਨੂੰ ਸੰਭਾਲਿਆ ਨਹੀਂ ਜਾਵੇਗਾ।</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">ਸਿਰਨਾਵਾਂ ਚੁਣੋ</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ਸੁਝਾਏ ਸਿਰਨਾਵਿਆਂ ਨੂੰ ਫੈਲਾਓ</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">ਸੰਭਾਲੇ ਹੋਏ ਸਿਰਨਾਵਿਆਂ ਨੂੰ ਫੈਲਾਓ</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ਸੁਝਾਏ ਸਿਰਨਾਵਿਆਂ ਨੂੰ ਸਮੇਟੋ</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">ਸੰਭਾਲੇ ਹੋਏ ਸਿਰਨਾਵਿਆਂ ਨੂੰ ਸਮੇਟੋ</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pa-rPK/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pa-rPK/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">پاس‌ورڈ</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">ایہہ نہ رکھو</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">ہݨے نہیں</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">کدے نہ رکھو</string>
@@ -28,29 +26,17 @@
     <string name="mozac_feature_prompt_save_confirmation">سانجھا کرو</string>
 
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">ایہنوں نہ نواں کرو</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">ہݨے نہیں</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">نواں کرو</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">پاس‌ورڈ نہیں پایا</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">پاس‌ورڈ پایو</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">پاس‌ورڈ رکھ نہیں سکدا</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">پاس‌ورڈ سنبھالیا نہیں جا سکدا اے</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">پاس‌ورڈ رکھیو؟</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">پاس‌ورڈ سنبھالݨا اے؟</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">ایہنوں نواں کریو؟</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">پاس‌ورڈ اپڈیٹ کرنا اے؟</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">پاس‌ورڈ نال ورتنوالے دا ناں وی رکھیو؟</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">ورتݨ ناں نوں اپڈیٹ کرنا اے؟</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -99,20 +85,12 @@
 
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">ویلے نوں بدلو</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">پاس‌ورڈاں دا انتظام</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">پاس‌ورڈاں دا انتظام کرو</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تجویز دے ویروے ویکھو</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">سنبھالے پوئے پاس‌ورڈاں نوں پھیلاؤ</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تجویز لُکاؤ</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">سنبھالے ہوئے پاس‌ورڈاں نوں سموٹو</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">تجویز دے ویروے</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">سنبھالے ہوئے پاس‌ورڈ</string>
@@ -126,8 +104,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">مضبوط پاس‌ورڈ ورتݨا اے؟</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">آپݨے کھاتیاں نوں مضبوط، رلویں ملویں تیار کیتے پاس‌ورڈ نوں ورت کے سرکھیت کرو۔ آپݨے پاس‌ورڈاں نوں آپݨے کھاتے وچ سنبھال کے فورن لوو۔</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2">مضبوط، بے ترتیبے تیار کیتے پاس‌ورڈ نال آپݨے کھاتیاں نوں سرکھیاں دیو۔ ایس نوں مستقبل چ تہاڈے کھاتے وچ سنبھالیا جاوےگا۔</string>
 
@@ -152,21 +128,13 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">رد کرو</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">کریڈٹ کارڈ چݨو</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">سنبھالے کارڈ نوں ورتو</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تجویز دے کارڈ ویکھو</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">سنبھالے ہوئے کارڈاں نوں پھیلاؤ</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تجویز دے کارڈ لکاؤ</string>
 
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">سنبھالے ہاوئے کارڈاں نوں سمیٹو</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">کریڈٹ کارڈاں دا انتظام کرو</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">کارڈاں دا انتظام کرو</string>
     <!-- Text for the title of a save credit card dialog. -->
@@ -175,8 +143,6 @@
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">تسیں کارڈ دی میاد پگݨ دی تاریخ نوں بدلݨا چاہیدے او؟</string>
 
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">کارڈ نمبر نوں اوہلا پا لا جاۓگا۔ سرکھیا کوڈ رکھ نہیں جاۓگا۔</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s تہاڈے کارڈ نوں انکرپٹ کردا اے۔ تہاڈے سرکھیا کوڈ نوں سنبھالیا نہیں جاوےگا۔</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">پتہ چݨو</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ہور پتے ویکھو</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">سنبھالے ہوئے سرناویاں نوں پھیلاؤ</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تجویز دے پتے لکاؤ</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">سنبھالے ہوئے سرناویاں نوں سمیٹو</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pl/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pl/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Hasło</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Nie zachowuj</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Nie teraz</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nigdy nie zachowuj</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Zachowaj</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Nie aktualizuj</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Nie teraz</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Aktualizuj</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Pole hasła nie może być puste</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Wpisz hasło</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Nie można zachować danych logowania</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Nie można zachować hasła</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Czy zachować te dane logowania?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Czy zachować hasło?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Czy zaktualizować te dane logowania?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Czy zaktualizować hasło?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Czy dodać nazwę użytkownika do zachowanego hasła?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Czy zaktualizować nazwę użytkownika?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">gru</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Ustaw czas</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Zarządzaj danymi logowania</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Zarządzaj hasłami</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Rozwiń podpowiadane dane logowania</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Rozwiń zachowane hasła</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zwiń podpowiadane dane logowania</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Zwiń zachowane hasła</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Podpowiadane dane logowania</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Zachowane hasła</string>
@@ -126,8 +104,6 @@
     <string name="mozac_feature_prompts_suggest_strong_password_title">Czy użyć silnego hasła?</string>
 
 
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Chroń swoje konta za pomocą silnego, losowo wygenerowanego hasła. Miej szybki dostęp do haseł, zachowując je na swoim koncie.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Chroń swoje konta za pomocą silnego, losowo wygenerowanego hasła. Zostanie ono zachowane na Twoim koncie, aby zawsze mieć do niego dostęp.</string>
 
@@ -156,28 +132,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Anuluj</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Wybierz kartę płatniczą</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Użyj zachowanej karty</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Rozwiń podpowiadane karty płatnicze</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Rozwiń zachowane karty</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zwiń podpowiadane karty płatnicze</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Zwiń zachowane karty</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Zarządzaj kartami płatniczymi</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Zarządzaj kartami</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Czy bezpiecznie zachować tę kartę?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Czy zaktualizować datę ważności karty?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Numer karty zostanie zaszyfrowany. Kod zabezpieczający nie zostanie zachowany.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s szyfruje numer karty. Kod zabezpieczający nie zostanie zachowany.</string>
@@ -185,12 +151,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Wybierz adres</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Rozwiń podpowiadane adresy</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Rozwiń zachowane adresy</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zwiń podpowiadane adresy</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Zwiń zachowane adresy</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pt-rBR/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pt-rBR/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Senha</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Não salvar</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Agora não</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nunca salvar</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Salvar</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Não atualizar</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Agora não</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Atualizar</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">O campo da senha não deve ficar vazio</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Digite uma senha</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Não foi possível salvar a conta</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Não foi possível salvar a senha</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Salvar esta conta?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Salvar senha?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Atualizar esta conta?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Atualizar senha?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Adicionar nome de usuário à senha salva?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Atualizar nome de usuário?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dez</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Ajustar hora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Gerenciar contas</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Gerenciar senhas</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir sugestão de contas</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expandir senhas salvas</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Recolher sugestão de contas</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Recolher senhas salvas</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Sugestão de contas</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Senhas salvas</string>
@@ -125,8 +103,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Usar senha forte?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Proteja suas contas usando uma senha forte gerada aleatoriamente. Tenha acesso rápido às suas senhas, salvando na sua conta.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Proteja suas contas usando uma senha forte gerada aleatoriamente. Ela é salva na sua conta para uso futuro.</string>
 
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancelar</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Selecionar cartão de crédito</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Usar cartão salvo</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir sugestões de cartão de crédito</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expandir cartões salvos</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Recolher sugestões de cartão de crédito</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Recolher cartões salvos</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Gerenciar cartões de crédito</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Gerenciar cartões</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Salvar este cartão com segurança?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Atualizar data de validade do cartão?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">O número do cartão será criptografado. O código de segurança não será salvo.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">O %s criptografa o número do seu cartão. O código de segurança não é salvo.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Selecionar endereço</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir endereços sugeridos</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Expandir endereços salvos</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Recolher endereços sugeridos</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Recolher endereços salvos</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pt-rPT/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-pt-rPT/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Palavra-passe</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Não guardar</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Agora não</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nunca guardar</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Guardar</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Não atualizar</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Agora não</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Atualizar</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">O campo de palavra-passe não deve estar vazio</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Introduza uma palavra-passe</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Não foi possível guardar a credencial</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Não foi possível guardar a palavra-passe</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Guardar esta credencial?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Guardar palavra-passe?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Atualizar esta credencial?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Atualizar palavra-passe?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Adicionar nome de utilizador à palavra-passe guardada?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Atualizar o nome de utilizador?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dez</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Definir hora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Gerir credenciais</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Gerir palavras-passes</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir credenciais sugeridas</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expandir palavras-passe guardadas</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Colapsar credenciais sugeridas</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Colapsar palavras-passe guardadas</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Credenciais sugeridas</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Palavras-passe guardadas</string>
@@ -125,8 +103,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Utilizar uma palavra-passe forte?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Proteja as suas contas utilizando uma palavra-passe forte e gerada aleatoriamente. Obtenha acesso rápido às suas palavras-passe, guardando-as na sua conta.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Proteja as suas contas utilizando uma palavra-passe forte e gerada aleatoriamente. Esta será guardada na sua conta para utilização futura.</string>
 
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Cancelar</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Selecionar cartão de crédito</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Utilizar cartão guardado</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir os cartões de créditos sugeridos</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expandir cartões guardados</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Colapsar os cartões de crédito sugeridos</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Colapsar cartões guardados</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Gerir cartões de crédito</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Gerir cartões</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Guardar este cartão com segurança?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Atualizar a data de validade do cartão?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">O número do cartão será encriptado. O código de segurança não será guardado.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">O %s encripta o número do seu cartão. O seu código de segurança não será guardado.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Selecionar endereço</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandir endereços sugeridos</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Expandir endereços guardados</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Colapsar endereços sugeridas</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Colapsar endereços guardados</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ro/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ro/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Parolă</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Nu salva</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Nu acum</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nu salva niciodată</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Salvează</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Nu actualiza</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Nu acum</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Actualizează</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Câmpul de parolă nu trebuie să fie gol</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Introdu parola</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Datele de autentificare nu au putut fi salvate</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Nu se poate salva parola</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Salvezi aceste date de autentificare?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Salvați parola?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Actualizezi aceste date de autentificare?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Modificați parola?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Adaugi numele de utilizator la parola salvată?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Modificați numele de utilizator?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -98,28 +84,18 @@
 
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Seteazâ ora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Gestionează autentificările</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Gestioneazâ parolele</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Extinde datele de autentificare sugerate</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expandeazâ parolele salvate</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Restrânge datele de autentificare sugerate</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Restrânge parolele salvate</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Date de autentificare sugerate</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Parole salvate</string>
 
     <!-- Content description for the suggest strong password prompt to allow users to fill a form with a suggested strong password -->
     <string name="mozac_feature_prompts_suggest_strong_password_content_description">Sugerează o parolă puternică</string>
-    <!-- Header for the suggest strong password prompt to allow users to fill a form with a suggested strong password -->
-    <string name="mozac_feature_prompts_suggest_strong_password" moz:removedIn="128" tools:ignore="UnusedResources">Sugerează o parolă puternică</string>
     <!-- Header for the suggest strong password prompt to allow users to fill a form with a suggested strong password -->
     <string name="mozac_feature_prompts_suggest_strong_password_2">Utilizează o parolă puternică</string>
 
@@ -150,27 +126,17 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Anulează</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Selectează cardul de credit</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Folosește cartela salvată</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Epandează cardurile de credit sugerate</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Epandează cardurile de credit </string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Restrânge cardurile de credit sugerate</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Restrânge cardurile salvate</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Gestionează cardurile de credit</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Gestionează cardurile </string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Salvează securizat acest card?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Actualizează data de expirare a cardului?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Numărul cardului va fi criptat. Codul de securitate nu va fi salvat.</string>
 
     </resources>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ru/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ru/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Пароль</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Не сохранять</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Не сейчас</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Никогда не сохранять</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Сохранить</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Не обновлять</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Не сейчас</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Обновить</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Поле пароля не может быть пустым</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Введите пароль</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Не удалось сохранить логин</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Не удалось сохранить пароль</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Сохранить этот логин?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Сохранить пароль?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Обновить этот логин?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Обновить пароль?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Добавить имя пользователя к сохранённому паролю?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Обновить имя пользователя?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Дек</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Установка времени</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Управление паролями</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Управление паролями</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Развернуть предлагаемые пароли</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Развернуть сохранённые пароли</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Свернуть предлагаемые пароли</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Свернуть сохранённые пароли</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Предлагаемые пароли</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Сохранённые пароли</string>
@@ -125,8 +103,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Использовать надёжный пароль?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Защитите свои аккаунты с помощью надёжных, сгенерированных случайным образом паролей. Получите быстрый доступ к своим паролям, сохранив их в своем аккаунте.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Защитите свои аккаунты с помощью надежного пароля, сгенерированного случайным образом. Он будет сохранен в вашем аккаунте для использования в будущем.</string>
 
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Отмена</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Выберите банковскую карту</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Использовать сохранённую карту</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Развернуть предлагаемые банковские карты</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Развернуть сохранённые карты</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Свернуть предлагаемые банковские карты</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Свернуть сохранённые карты</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Управление банковскими картами</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Управление картами</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Сохранить надёжно эту карту?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Обновить срок действия карты?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Номер карты будет зашифрован. Код безопасности не будет сохранён.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s шифрует номер вашей карты. Ваш код безопасности не будет сохранён.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Выберите адрес</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Развернуть предлагаемые адреса</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Развернуть сохранённые адреса</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Свернуть предлагаемые адреса</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Свернуть сохранённые адреса</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sc/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sc/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Crae</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Non sarves</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Immoe nono</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Non sarves mai</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Sarva</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">No atualizes</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Immoe nono</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Atualiza</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Sa crae non podet èssere bòida</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Inserta una crae</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Impossìbile sarvare is credentziales</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Impossìbile sarvare sa crae</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Boles sarvare custa credentziale?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Boles sarvare sa crae?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Boles atualizare custa credentziale?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Boles atualizare sa crae?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Boles agiùnghere su nòmine de utente a sa crae sarvada?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Boles atualizare su nùmene de utente?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -98,20 +84,12 @@
     <string name="mozac_feature_prompts_dec">Ida</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Cunfigura s’ora</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Gesti is credentziales</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Gesti is craes</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ismànnia is credentziales cussigiadas</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Ismànnia is craes sarvadas</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Mìnima is credentziales cussigiadas</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Mìnima is craes sarvadas</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Credentziales cussigiadas</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Craes sarvadas</string>
@@ -126,8 +104,6 @@
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Boles impreare una crae segura?</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Ampara is contos tuos impreende una crae segura, generada in automàticu. Recùpera is craes tuas sarvende·ddas in su contu tuo.</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2">Ampara is contos tuos impreende una crae segura, generada in automàticu. At a èssere sarvada in su contu tuo pro su benidore.</string>
 
     <!-- Strings shown in a dialog that appear when users try to refresh a certain kind of webpages -->
@@ -138,20 +114,12 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Annulla</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Seletziona una carta de crèditu</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Imprea una carta sarvada</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ismànnia is cartas de crèditu cussigiadas</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Ismànnia is cartas sarvadas</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Mìnima is cartas de crèditu cussigiadas</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Mìnima is cartas sarvadas</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Gesti is cartas de crèditu</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Gesti is cartas</string>
     <!-- Text for the title of a save credit card dialog. -->
@@ -159,8 +127,6 @@
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Boles atualizare sa data de iscadèntzia de sa carta?</string>
 
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Su nùmeru de carta at a èssere tzifradu. Su còdighe de seguresa no at a èssere sarvadu.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s tzifrat su nùmeru de sa carta tua. Su còdighe de seguresa no at a èssere sarvadu.</string>
@@ -168,12 +134,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Seletziona un’indiritzu</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Ismànnia is indiritzos cussigiados</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Ismànnia is indiritzos sarvados</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Mìnima is indiritzos cussigiados</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Mìnima is indiritzos sarvados</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-si/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-si/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">මුරපදය</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">සුරකින්න එපා</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">දැන් නොවේ</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">කිසිවිට නොසුරකින්න</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">සුරකින්න</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">යාවත්කාල නොකරන්න</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">දැන් නොවේ</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">යාවත්කාල</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">මුරපද ක්‍ෂේත්‍රය හිස් නොවිය යුතුය</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">මුරපදය යොදන්න</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">පිවිසුම සුරැකීමට නොහැකිය</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">මුරපදය සුරැකීමට නොහැකිය</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">මෙම පිවිසුම සුරකින්නද?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">මුරපදය සුරකින්නද?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">පිවිසුම සංශෝධනයක්ද?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">මුරපදය යාවත්කාල කරන්නද?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">සුරැකි මුරපදයට පරි. නාමය එක් කරන්නද?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
     <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
     <string name="mozac_feature_prompts_content_description_input_label">පෙළ ආදාන ක්‍ෂේත්‍රයක් ඇතුල් කිරීමට නම්පත</string>
@@ -96,28 +82,18 @@
     <string name="mozac_feature_prompts_dec">උඳු</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">කාලය සකසන්න</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">පිවිසුම් කළමනාකරණය</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">මුරපද කළමනාකරණය</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">යෝජිත පිවිසුම් විහිදන්න</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">සුරැකි මුරපද විහිදන්න</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">යෝජිත පිවිසුම් හකුලන්න</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">සුරැකි මුරපද හකුළන්න</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">යෝජිත පිවිසුම්</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">සුරැකි මුරපද</string>
 
     <!-- Content description for the suggest strong password prompt to allow users to fill a form with a suggested strong password -->
     <string name="mozac_feature_prompts_suggest_strong_password_content_description">ශක්තිමත් මුරපදයක් යෝජනා කරන්න</string>
-    <!-- Header for the suggest strong password prompt to allow users to fill a form with a suggested strong password -->
-    <string name="mozac_feature_prompts_suggest_strong_password" moz:removedIn="128" tools:ignore="UnusedResources">ශක්තිමත් මුරපදයක් යෝජනා කරන්න</string>
     <!-- Header for the suggest strong password prompt to allow users to fill a form with a suggested strong password -->
     <string name="mozac_feature_prompts_suggest_strong_password_2">ශක්තිමත් මුරපදයක් භාවිතා කරන්න</string>
     <!-- Title for using the suggest strong password confirmation dialog. %1$s will be replaced with the generated password -->
@@ -144,29 +120,19 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">අවලංගු</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">ණයපතක් තෝරන්න</string>
 
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">සුරැකි පත යොදාගන්න</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">යෝජිත ණයපත් විහිදන්න</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">සුරැකි පත් විහිදන්න</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">යෝජිත ණයපත් හකුලන්න</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">සුරැකි පත් හකුළන්න</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">ණයපත් කළමනාකරණය</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">පත් කළමනාකරණය</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">මෙම පත ආරක්‍ෂිතව සුරකින්නද?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">පත ඉකුත්වන දිනය යාවත්කාල කරන්නද?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">පතෙහි අංකය සංකේතනය වනු ඇත. ආරක්‍ෂණ කේතය සුරැකෙන්නේ නැත.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s ඔබගේ පතෙහි අංකය සංකේතනය කරයි. ඔබගේ ආරක්‍ෂණ කේතය සුරැකෙන්නේ නැත.</string>
@@ -174,12 +140,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">ලිපිනය තෝරන්න</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">යෝජිත ලිපින විහිදන්න</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">සුරැකි ලිපින විහිදන්න</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">යෝජිත ලිපින හකුලන්න</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">සුරැකි ලිපින හකුළන්න</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sk/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sk/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Heslo</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Neuložiť</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Teraz nie</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nikdy neukladať</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Uložiť</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Neaktualizovať</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Teraz nie</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Aktualizovať</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Pole s heslom nesmie byť prázdne</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Zadajte heslo</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Prihlasovacie údaje sa nepodarilo uložiť</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Heslo nie je možné uložiť</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Chcete uložiť tieto prihlasovacie údaje?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Uložiť heslo?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Chcete aktualizovať tieto prihlasovacie údaje?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Aktualizovať heslo?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Chcete k uloženému heslu pridať používateľské meno?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Aktualizovať používateľské meno?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Nastaviť čas</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Spravovať prihlasovacie údaje</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Spravovať heslá</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Rozbaliť navrhované prihlasovacie údaje</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Rozbaliť uložené heslá</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zbaliť navrhované prihlasovacie údaje</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Zbaliť uložené heslá</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Navrhované prihlasovacie údaje</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Uložené heslá</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Použiť silné heslo?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Chráňte svoje účty pomocou silného, náhodne generovaného hesla. Získajte rýchly prístup k svojim heslám tým, že si ich uložíte do svojho účtu.</string>
 
 
     <!-- Content description for the suggest strong password confirmation dialog -->
@@ -156,28 +132,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Zrušiť</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Vyberte platobnú kartu</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Použiť uloženú kartu</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Rozbaliť navrhované platobné karty</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Rozbaliť uložené karty</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zbaliť navrhované platobné karty</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Zbaliť uložené karty</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Spravovať platobné karty</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Spravovať karty</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Bezpečne uložiť túto kartu?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Aktualizovať dátum vypršania platnosti karty?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Číslo karty bude zašifrované. Bezpečnostný kód sa neuloží.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s zašifruje číslo vašej karty. Váš bezpečnostný kód sa neuloží.</string>
@@ -185,12 +151,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Vyberte adresu</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Rozbaliť navrhované adresy</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Rozbaliť uložené adresy</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zbaliť navrhované adresy</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Zbaliť uložené adresy</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-skr/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-skr/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">پاس ورڈ</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">محفوظ نہ کرو</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">ہݨ کائناں</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">کݙاہیں وی محفوظ نہ کرو</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">محفوظ کرو</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">اپ ڈیٹ  نہ کرو</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">ہݨ کائناں</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">اپ ڈیٹ کرو</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">پاس ورڈ خانہ خالی کائنی ہووݨاں چاہیدا</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">پاس ورڈ درج کرو</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">لاگ ان محفوظ کرݨ کنوں قاصر</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">پاس ورڈ محفوظ کائنی کر سڳدا</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">ایہ لاگ ان محفوظ کروں؟</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">پاس ورڈ محفوظ کروں؟</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">ایہ لاگ ان اپ ڈیٹ کروں؟</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">پاس ورڈ اپ ڈیٹ کروں؟</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">محفوظ تھئے پاس ورڈ وچ ورتݨ ناں شامل کروں؟</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">ورتݨ ناں اپ ڈیٹ کروں؟</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -98,21 +84,13 @@
 
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">وقت ٹھیک کرو</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">لاگ ان منیج کرو</string>
 
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">پاس ورڈز دا بندوبست کرو</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تجویز تھئے لاگ اناں کوں ودھاؤ</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">محفوظ تھئے پاس ورڈ کھنڈاؤ</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تجویز تھئے لاگ اناں کوں کٹھا کرو</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">محفوظ تھئے پاس ورڈ ولھیٹو</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">تجویز تھئے لاگ ان</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">محفوظ تھئے پاس ورڈ</string>
@@ -128,8 +106,6 @@
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">تَکڑا پاس ورڈ وَرتو؟</string>
 
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">ہک مضبوط، بے ترتیبا تیار تھیا پاس ورڈ ورت تے  آپݨے اکاؤنٹس دی حفاظت کرو۔ آپݨے اکاؤنٹ وچ محفوظ کرتے آپݨے پاس ورڈز تائیں فوری رسائی گھنو۔</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">ہک مضبوط، بے ترتیبا تیار تھیا پاس ورڈ ورت تے  آپݨے اکاؤنٹس دی حفاظت کرو۔ ایہ مستقبل وچ ورتݨ کیتے تہاݙے کھاتے وچ محفوظ تھی ویسی۔</string>
 
@@ -158,28 +134,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">منسوخ</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">کریڈٹ کارڈ چݨو</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">محفوظ تھیا کارڈ ورتو</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تجویز تھئے کریڈٹ کارڈاں کوں ودھاؤ</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">محفوظ تھئے کارڈ کھنڈاؤ</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تجویز تھئے کریڈٹ کارڈاں کوں کٹھا کرو</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">محفوظ تھئے کارڈ ولھیٹو</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">کریڈیٹ کارڈ منیج کرو</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">کارڈز منیج کرو</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">ایہ کارڈ حفاظت نال محفوظ کروں؟</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">کارڈ مُکݨ تریخ اپ ڈیٹ کروں؟</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">کارڈ نمبر دی خفیہ کاری کیتی ویسی۔ حفاظتی کوڈ محفوظ کائناں کیتا ویسی۔</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s تُہاݙے کارڈ نمبر کوں انکرپٹ کرین٘دا ہِے۔ تُہاݙا سیکیورٹی کوڈ محفوظ کائناں تھیسی۔</string>
@@ -187,12 +153,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">پتہ چُݨو</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تجویز تھئے پتیاں کوں ودھاؤ</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">محفوظ تھئے پتے کھنڈاؤ</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تجویز تھئے پتیاں کوں کٹھا کرو</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">محفوظ تھئے پتے ولھیٹو</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sl/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sl/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Geslo</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ne shrani</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ne zdaj</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Nikoli ne shranjuj</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Shrani</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ne posodobi</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ne zdaj</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Posodobi</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Polje za geslo ne sme biti prazno</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Vnesite geslo</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Ni mogoče shraniti povezave</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Gesla ni mogoče shraniti</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Shranim to prijavo?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Shranim geslo?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Posodobim to prijavo?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Posodobim geslo?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Dodaj shranjenemu geslu uporabniško ime?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Posodobim uporabniško ime?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Nastavi čas</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Upravljanje prijav</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Upravljanje gesel</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Razširi predlagane prijave</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Prikaži shranjena gesla</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Strni predlagane prijave</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Skrij shranjena gesla</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Predlagane prijave</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Shranjena gesla</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Želite uporabiti močno geslo?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Zaščitite svoje račune z močnimi, naključno ustvarjenimi gesli. Za hiter dostop si jih shranite v račun.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Zaščitite svoje račune z uporabo močnih, naključno ustvarjenih gesel. Shranjena bodo v vaš račun za nadaljnjo uporabo.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Prekliči</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Izberite kreditno kartico</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Uporabi shranjeno kartico</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Razširi predlagane kreditne kartice</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Prikaži shranjene kartice</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Strni predlagane kreditne kartice</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Skrij shranjene kartice</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Upravljanje kreditnih kartic</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Upravljanje kartic</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Želite varno shraniti to kartico?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Posodobi datum poteka veljavnosti kartice?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Številka kartice bo šifrirana. Varnostna koda ne bo shranjena.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s šifrira številko vaše kartice. Varnostna koda se ne bo shranila.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Izbira naslova</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Razširi predlagane naslove</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Prikaži shranjene naslove</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Strni predlagane naslove</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Skrij shranjene naslove</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sq/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sq/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Fjalëkalim</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Mos e ruaj</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Jo tani</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Mos e ruaj kurrë</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Ruaje</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Mos e përditëso</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Jo tani</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Përditësoje</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Fusha e fjalëkalimit s’duhet të jetë e zbrazët</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Jepni një fjalëkalim</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">S’arrihet të ruhen kredenciale hyrjesh</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">S’ruhet dot fjalëkalimi</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Të ruhen këto kredenciale hyrjesh?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Të ruhet fjalëkalimi?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Të përditësohen këto kredenciale hyrjesh?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Të përditësohet fjalëkalimi?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Të shtohet emri i përdoruesit te fjalëkalimi i ruajtur?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Të përditësohet emër përdoruesi?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dhj</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Ujdisni kohën</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Administroni kredenciale hyrjesh</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Administroni fjalëkalime</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zgjeroji kredencialet e sugjeruara të hyrjeve</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Zgjero fjalëkalimet e ruajtur</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Tkurri kredencialet e sugjeruara të hyrjeve</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Tkurri fjalëkalimet e ruajtur</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Kredenciale të sugjeruara hyrjesh</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Fjalëkalime të ruajtur</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Të përdoret fjalëkalim i fortë?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Mbroni llogaritë tuaja duke përdorur një fjalëkalim të fortë, të prodhuar kuturu. Përfitoni hyrje të shpejtë te fjalëkalimet tuaja, duke e ruajtur te llogaria juaj.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Mbroni llogaritë tuaja duke përdorur një fjalëkalim të fuqishëm, të krijuar kuturu. Do të ruhet në llogarinë tuaj, për përdorim në të ardhmen.</string>
 
@@ -154,20 +130,12 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Anuloje</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Përzgjidhni kartë krediti</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Përdor kartë të ruajtur</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zgjero karta kreditit të sugjeruara</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Zgjero karta të ruajtura</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Tkurri kartat e kreditit të sugjeruara</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Tkurri kartat e ruajtura</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Administroni karta krediti</string>
 
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Administroni karta</string>
@@ -175,8 +143,6 @@
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Të ruhet në mënyrë të sigurt kjo kartë?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Të përditësohet data e skadimit të kartës?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Numri i kartës do të fshehtëzohet. Kodi i sigurisë s’do të ruhet.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s-i e fshehtëzon numrin e kartës tuaj. Kodi juaj i sigurisë s’do të ruhet.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Përzgjidhni adresë</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Zgjeroji adresat e sugjeruara</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Zgjeroji adresat e ruajtura</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Tkurri adresat e sugjeruara</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Tkurri adresat e ruajtura</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-su/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-su/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Kecap sandi</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Ulah diteundeun</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Moal waka</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Ulah diteundeun</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Teundeun</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Ulah ngapdét</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Moal waka</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Apdét</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Widang kecap sandi henteu kaci kosong</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Asupkeun sandi</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Teu bisa neundeun login</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Teu bisa nyimpen santi</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Teundeun ieu login?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Simpen sandi?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Apdét ieu login?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Anyarkeun sandi?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Tambahkeun sandiasma kana kecap sandi anu diteundeun?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Anyarkeun sandiasma?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dés</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Setél wanci</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Kokolakeun login</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Atur sandi</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Legaan saran login</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Legaan sandi anu disimpen</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Leutikan saran login</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Heureutan sandi nu disimpen</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Saran login</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Sandi nu disimpen</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Paké kecap sandi anu wedel?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Jaga akun anjeun maké sandi anu kuat, anu dihasilkeun sacara acak. Beunangkeun aksés gancang kana sandi anjeun ku nyimpen sandi dina akun anjeun.</string>
 
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Jaga akun anjeun maké sandikecap anu kuat, anu dihasilkeun kalawan acak. Éta sandi bakal disimpen kana akun anjeun pikeun dipaké ka hareupna.</string>
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Bolay</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Pilih kartu kiridit</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Paké kartu nu disimpen</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Legaan kartu kiridit anu disarankeun</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Legaan kartu nu disimpen</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Tilep saran kartu kiridit</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Heureutan kartu nu disimpen</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Kokolakeun kartu kiridit</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Atur kartu</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Teundeun ieu kartu sacara aman?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Mutahirkeun titimangsa kadaluwarsa kartu?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Nomer kartu bakal diénkrip. Kode kaamanan moal diteundeun.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s énkripsi nomer kartu anjeun. Kode kaamanan anjeun moal disimpen.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Pilih alamat</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Legaan saran alamat</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Legaan alamat nu disimpen</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Leutikan saran alamat</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Heureutan alamat nu disimpen</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sv-rSE/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-sv-rSE/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Lösenord</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Spara inte</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Inte nu</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Spara aldrig</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Spara</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Uppdatera inte</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Inte nu</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Uppdatera</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Lösenordsfältet får inte vara tomt</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Ange ett lösenord</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Kunde inte spara inloggningsuppgifter</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Det går inte att spara lösenordet</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Spara den här inloggningen?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Spara lösenord?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Vill du uppdatera den här inloggningen?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Uppdatera lösenord?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Lägg till användarnamn till det sparade lösenordet?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Uppdatera användarnamn?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Dec</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Ange tid</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Hantera inloggningar</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Hantera lösenord</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandera föreslagna inloggningar</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Expandera sparade lösenord</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Komprimera föreslagna inloggningar</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Komprimera sparade lösenord</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Föreslagna inloggningar</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Sparade lösenord</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Använd ett starkt lösenord?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Skydda dina konton med ett starkt, slumpmässigt skapat lösenord. Få snabb åtkomst till dina lösenord genom att spara det på ditt konto.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Skydda dina konton med ett starkt, slumpmässigt skapat lösenord. Den kommer att sparas på ditt konto för framtida användning.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Avbryt</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Välj kreditkort</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Använd sparat kort</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandera föreslagna kreditkort</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Expandera sparade kort</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Komprimera föreslagna kreditkort</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Komprimera sparade kort</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Hantera kreditkort</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Hantera kort</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Vill du spara det här kortet säkert?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Uppdatera kortets utgångsdatum?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Kortnummer kommer att krypteras. Säkerhetskoden kommer inte att sparas.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s krypterar ditt kortnummer. Din säkerhetskod kommer inte att sparas.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Välj adress</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Expandera föreslagna adresser</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Expandera sparade adresser</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Komprimera föreslagna adresser</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Komprimera sparade adresser</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-te/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-te/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">సంకేతపదం</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">భద్రపరచవద్దు</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">ఇప్పుడు కాదు</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">ఎప్పుడూ భద్రపరచవద్దు</string>
@@ -27,23 +25,11 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">భద్రపరుచు</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">తాజాకరించవద్దు</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">ఇప్పుడు కాదు</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">తాజాకరించు</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">సంకేతపదం ఖాళీగా ఉండకూడదు</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">సంకేతపదం ఇవ్వండి</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">ప్రవేశ వివరాలను భద్రపరచలేకపోతున్నాం</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">ఈ ప్రవేశాన్ని భద్రపరచాలా?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">ఈ ప్రవేశాన్ని తాజాకరించాలా?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">భద్రపరచిన సంకేతపదానికి వాడుకరి పేరును చేర్చాలా?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
     <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
     <string name="mozac_feature_prompts_content_description_input_label">పాఠ్య ఖాళీని పూరించడానికి లేబుల్</string>
@@ -87,14 +73,6 @@
     <string name="mozac_feature_prompts_nov">నవం</string>
     <!-- December month of the year (short description), used on the month chooser dialog. -->
     <string name="mozac_feature_prompts_dec">డిసెం</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">ప్రవేశాలను నిర్వహించండి</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">సూచించిన ప్రవేశాలను విస్తరించు</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">సూచించిన ప్రవేశాలను కుదించు</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">సూచించిన ప్రవేశాలు</string>
 
     <!-- Pressing this will dismiss the suggested strong password dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_dismiss">ఇప్పుడు కాదు</string>

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-tg/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-tg/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Ниҳонвожа</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Нигоҳ дошта нашавад</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Ҳоло не</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Ҳеҷ гоҳ нигоҳ дошта нашавад</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Нигоҳ доштан</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Навсозӣ карда нашавад</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Ҳоло не</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Навсозӣ кардан</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Ҷойи ниҳонвожа бояд холӣ набошад</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Ниҳонвожаеро ворид намоед</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Нигоҳ доштани маълумоти воридшавӣ ғайриимкон аст</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Ниҳонвожа нигоҳ дошта нашуд</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Маълумоти воридшавии ҷориро нигоҳ медоред?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Ниҳонвожаро нигоҳ медоред?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Маълумоти воридшавии ҷориро аз нав нигоҳ медоред?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Ниҳонвожаро аз нав нигоҳ медоред?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Номи корбарро ба ниҳонвожаи нигоҳдошташуда илова мекунед?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Номи корбарро навсозӣ мекунед?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Дек</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Танзими вақт</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Идоракунии воридшавӣ</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Идоракунии ниҳонвожаҳо</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Намоиш додани воридшавиҳои пешниҳодшуда</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Баркушодани ниҳонвожаҳои нигоҳдошташуда</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Пинҳон кардани воридшавиҳои пешниҳодшуда</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Пинҳон кардани ниҳонвожаҳои нигоҳдошташуда</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Воридшавиҳои пешниҳодшуда</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Ниҳонвожаҳои нигоҳдошташуда</string>
@@ -125,8 +103,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Аз ниҳонвожаи қавӣ истифода мебаред?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Ҳисобҳои худро бо истифода аз ниҳонвожаҳои қавӣ ва ба таври тасодуфӣ эҷодшуда муҳофизат намоед. Бо нигоҳ доштани ниҳонвожаҳои худ дар ҳисоби шахсӣ ба онҳо зуд дастрасӣ пайдо намоед.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Ҳисобҳои худро бо истифода аз ниҳонвожаҳои қавӣ ва ба таври тасодуфӣ эҷодшуда муҳофизат намоед. Ниҳонвожаҳо барои истифодаи оянда дар ҳисоби шумо нигоҳ дошта мешаванд.</string>
 
@@ -155,28 +131,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Бекор кардан</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Корти кредитиро интихоб кунед</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Истифодаи корти нигоҳдошташуда</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Кортҳои кредитии пешниҳодшударо нишон диҳед</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Баркушодани кортҳои нигоҳдошташуда</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Кортҳои кредитии пешниҳодшударо пинҳон кунед</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Пинҳон кардани кортҳои нигоҳдошташуда</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Идоракунии кортҳои кредитӣ</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Идоракунии кортҳо</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Ин кортро ба таври бехатар нигоҳ медоред?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Санаи анҷоми муҳлати кори кортро нав мекунед?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Рақами корт рамзгузорӣ карда мешавад. Рамзи амниятӣ нигоҳ дошта намешавад.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">«%s» рақами корти шуморо рамзгузорӣ мекунад. Рамзи амниятии шумо нигоҳ дошта намешавад.</string>
@@ -184,12 +150,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Интихоб кардани нишонӣ</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Намоиш додани нишониҳои пешниҳодшуда</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Баркушодани нишониҳои нигоҳдошташуда</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Пинҳон кардани нишониҳои пешниҳодшуда</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Пинҳон кардани нишониҳои нигоҳдошташуда</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-th/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-th/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">รหัสผ่าน</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">ไม่บันทึก</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">ยังไม่ทำตอนนี้</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">ไม่บันทึกเสมอ</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">บันทึก</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">ไม่อัปเดต</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">ยังไม่ทำตอนนี้</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">อัปเดต</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">ช่องป้อนรหัสผ่านจะต้องไม่ว่างเปล่า</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">ป้อนรหัสผ่าน</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">ไม่สามารถบันทึกการเข้าสู่ระบบ</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">ไม่สามารถบันทึกรหัสผ่านได้</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">บันทึกการเข้าสู่ระบบนี้?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">บันทึกรหัสผ่านหรือไม่?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">อัปเดตการเข้าสู่ระบบนี้?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">ปรับปรุงรหัสผ่านหรือไม่?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">เพิ่มชื่อผู้ใช้ในรหัสผ่านที่บันทึกไว้?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">ปรับปรุงชื่อผู้ใช้หรือไม่?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">ธ.ค.</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">ตั้งเวลา</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">จัดการการเข้าสู่ระบบ</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">จัดการรหัสผ่าน</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ขยายการเข้าสู่ระบบที่เสนอแนะ</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">ขยายรหัสผ่านที่บันทึกไว้</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ยุบการเข้าสู่ระบบที่เสนอแนะ</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">ยุบรหัสผ่านที่บันทึกไว้</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">การเข้าสู่ระบบที่เสนอแนะ</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">รหัสผ่านที่บันทึกไว้</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">ใช้รหัสผ่านที่คาดเดายากหรือไม่?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">ปกป้องบัญชีของคุณโดยใช้รหัสผ่านที่คาดเดายากและสร้างขึ้นแบบสุ่ม เข้าถึงรหัสผ่านของคุณอย่างรวดเร็วโดยบันทึกลงในบัญชีของคุณ</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">ปกป้องบัญชีของคุณด้วยการใช้รหัสผ่านที่แข็งแกร่งซึ่งสร้างขึ้นแบบสุ่ม รหัสผ่านดังกล่าวจะถูกบันทึกไว้ในบัญชีของคุณเพื่อใช้ในอนาคต</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">ยกเลิก</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">เลือกบัตรเครดิต</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">ใช้บัตรที่บันทึกไว้</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ขยายบัตรเครดิตที่เสนอแนะ</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">ขยายบัตรที่บันทึกไว้</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ยุบบัตรเครดิตที่เสนอแนะ</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">ยุบบัตรที่บันทึกไว้</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">จัดการบัตรเครดิต</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">จัดการบัตร</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">ต้องการบันทึกบัตรนี้อย่างปลอดภัยหรือไม่?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">ต้องการปรับปรุงวันหมดอายุบัตรหรือไม่?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">หมายเลขบัตรจะถูกเข้ารหัส รหัสความปลอดภัยจะไม่ถูกบันทึก</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s จะเข้ารหัสหมายเลขบัตรของคุณ รหัสความปลอดภัยของคุณจะไม่ถูกบันทึก</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">เลือกที่อยู่</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ขยายที่อยู่ที่เสนอแนะ</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">ขยายที่อยู่ที่บันทึกไว้</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">ยุบที่อยู่ที่เสนอแนะ</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">ยุบที่อยู่ที่บันทึกไว้</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-tr/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-tr/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Parola</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Kaydetme</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Şimdi değil</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Asla kaydetme</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Kaydet</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Güncelleme</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Şimdi değil</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Güncelle</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Parola alanı boş olmamalıdır</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Parola girin</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Hesap kaydedilemedi</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Parola kaydedilemedi</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Bu hesap kaydedilsin mi?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Parola kaydedilsin mi?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Bu hesap güncellensin mi?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Parola güncellensin mi?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Kayıtlı parolaya kullanıcı adı eklensin mi?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Kullanıcı adı güncellensin mi?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Ara</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Zamanı ayarla</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Hesapları yönet</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Parolaları yönet</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Önerilen hesapları genişlet</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Kayıtlı parolaları genişlet</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Önerilen hesapları daralt</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Kayıtlı parolaları daralt</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Önerilen hesaplar</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Kayıtlı parolalar</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Güçlü bir parola kullanılsın mı?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Güçlü, rastgele oluşturulmuş bir parola kullanarak hesaplarınızı koruyun. Parolalarınızı hesabınıza kaydederek hızlıca erişin.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Rastgele oluşturulan güçlü bir parolayla hesaplarınızı koruyun. Parola, ileride kullanabilmeniz için hesabınıza kaydedilecektir.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">İptal</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Kredi kartı seç</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Kayıtlı kartı kullan</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Önerilen kredi kartlarını genişlet</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Kayıtlı kartları genişlet</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Önerilen kredi kartlarını daralt</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Kayıtlı kartları daralt</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Kredi kartlarını yönet</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Kartları yönet</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Bu kart güvenli bir şekilde kaydedilsin mi?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Kartın son kullanma tarihi güncellensin mi?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Kart numarası şifrelenecektir. Güvenlik kodu kaydedilmeyecektir.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s kart numaranızı şifreler. Güvenlik kodunuz kaydedilmez.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Adres seçin</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Önerilen adresleri genişlet</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Kayıtlı adresleri genişlet</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Önerilen adresleri daralt</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Kayıtlı adresleri daralt</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-tt/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-tt/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Парол</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Сакламау</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Хәзер түгел</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Беркайчан да cакламау</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Саклау</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Яңартмау</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Хәзер түгел</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Яңарту</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Серсүз кыры буш булырга тиеш түгел</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Серсүзне кертегез</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Логинны саклап булмый</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Серсүзне саклап булмады</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Бу логин саклансынмы?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Серсүз саклансынмы?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Бу логин яңартылсынмы?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Серсүз яңартылсынмы?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Сакланган серсүз янына кулланучы исеме өстәлсенме?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
     <!-- For more info take a look here https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt -->
     <string name="mozac_feature_prompts_content_description_input_label">Текст кертү кырының тамгасы</string>
@@ -96,29 +82,19 @@
 
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Вакытны билгеләү</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Логиннар белән идарә итү</string>
 
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Серсүзләр белән идарә итү</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Тәкъдим ителгән логиннарны киңәйтү</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Сакланган серсүзләрне ачып салу</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Тәкъдим ителгән логиннарны төрү</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Сакланган серсүзләрне төрү</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Тәкъдим ителгән логиннар</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Сакланган серсүзләр</string>
 
     <!-- Content description for the suggest strong password prompt to allow users to fill a form with a suggested strong password -->
     <string name="mozac_feature_prompts_suggest_strong_password_content_description">Көчле серсүз тәкъдим итү</string>
-    <!-- Header for the suggest strong password prompt to allow users to fill a form with a suggested strong password -->
-    <string name="mozac_feature_prompts_suggest_strong_password" moz:removedIn="128" tools:ignore="UnusedResources">Көчле серсүз тәкъдим итү</string>
     <!-- Header for the suggest strong password prompt to allow users to fill a form with a suggested strong password -->
     <string name="mozac_feature_prompts_suggest_strong_password_2">Көчле серсүз кулланыгыз</string>
     <!-- Title for using the suggest strong password confirmation dialog. %1$s will be replaced with the generated password -->
@@ -145,20 +121,12 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Баш тарту</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Кредит картасын сайлау</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Сакланган картаны куллану</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Тәкъдим ителгән кредит карталарын җәю</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Сакланган карталарны ачып салу</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Тәкъдим ителгән кредит карталарын төрү</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Сакланган карталарны төрү</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Кредит карталары белән идарә итү</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Карталар белән идарә итү</string>
     <!-- Text for the title of a save credit card dialog. -->
@@ -166,20 +134,14 @@
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Картаның вакыты чыгу датасы яңартылсынмы?</string>
 
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Карта номеры шифрланган булачак. Иминлек коды сакланмаячак.</string>
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s картагызның номерын шифрлый. Иминлек кодыгыз сакланмаячак.</string>
 
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Адрес сайлау</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Тәкъдим ителгән адресларны ачып салу</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Сакланган адресларны ачып салу</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Тәкъдим ителгән адресларны төрү</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Сакланган адресларны төрү</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ug/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-ug/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">پارول</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">ساقلىما</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">ھازىر ئەمەس</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">ھەرگىز ساقلىما</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">ساقلا</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">يېڭىلانمىسۇن</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">ھازىر ئەمەس</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">يېڭىلاش</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">ئىم بۆلىكى بوش قالمايدۇ</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">ئىم كىرگۈزۈلىدۇ</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">كىرىش ئۇچۇرىنى ساقلىيالمايدۇ</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">ئىم ساقلىيالمايدۇ</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">بۇ كىرىشنى ساقلامدۇ؟</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">ئىم ساقلامدۇ؟</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">بۇ كىرىشنى يېڭىلامدۇ؟</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">ئىم يېڭىلامدۇ؟</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">ساقلانغان ئىمغا ئىشلەتكۈچى ئاتىنى قوشامدۇ؟</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">ئىشلەتكۈچى ئاتىنى يېڭىلامدۇ؟</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -99,20 +85,12 @@
 
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">ۋاقىت تەڭشىكى</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">كىرىشنى باشقۇرۇش</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">ئىم باشقۇرۇش</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تەۋسىيە كىرىشنى كېڭەيتىدۇ</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">ساقلىغان ئىمنى ياي</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تەۋسىيە كىرىشنى يىغ</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">ساقلىغان ئىمنى يىغ</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">تەۋسىيە كىرىش</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">ساقلانغان ئىم</string>
@@ -128,8 +106,6 @@
     <string name="mozac_feature_prompts_suggest_strong_password_title">كۈچلۈك ئىم ئىشلىتەمدۇ؟</string>
 
 
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">كۈچلۈك، ئىختىيارى ھاسىل قىلىنغان ئىم ئارقىلىق ھېساباتىڭىزنى قوغداڭ. ئىمنى ھېساباتىڭىزغا ساقلاپ تېز زىيارەت قىلىڭ.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">ئىختىيارى ھاسىللانغان كۈچلۈك ئىم ئارقىلىق ھېساباتىڭىزنى قوغداڭ. ئۇ كەلگۈسىدە ئىشلىتىش ئۈچۈن ھېساباتىڭىزدا ساقلىنىدۇ.</string>
 
@@ -158,28 +134,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">ۋاز كەچ</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">ئىناۋەتلىك كارتا تاللىنىدۇ</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">ساقلانغان كارتىنى ئىشلەت</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تەۋسىيە قىلىنغان ئىناۋەتلىك كارتىنى كېڭەيتىدۇ</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">ساقلانغان كارتىنى ياي</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تەۋسىيە قىلىنغان ئىناۋەتلىك كارتىنى يىغىدۇ</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">ساقلانغان كارتىنى يىغ</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">ئىناۋەتلىك كارتا باشقۇرۇش</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">كارتا باشقۇرۇش</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">بۇ كارتىنى بىخەتەر ساقلامدۇ؟</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">كارتىنىڭ مۇددىتى توشۇش قەرەلىنى يېڭىلامدۇ؟</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">كارتا نومۇرى شىفىرلىنىدۇ. بىخەتەرلىك كودى ساقلانمايدۇ.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s كارتا نومۇرىڭىزنى شىفىرلايدۇ. بىخەتەرلىك كودىڭىز ساقلانمايدۇ.</string>
@@ -188,12 +154,8 @@
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">ئادرېس تاللىنىدۇ</string>
 
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تەۋسىيە ئادرېسنى كېڭەيتىدۇ</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">ساقلانغان ئادرېسنى ياي</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">تەۋسىيە ئادرېسنى يىغىدۇ</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">ساقلانغان ئادرېسنى يىغ</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-vi/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-vi/strings.xml
@@ -17,8 +17,6 @@
     <!-- Text for password field in an authentication dialog. -->
     <string name="mozac_feature_prompt_password_hint">Mật khẩu</string>
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">Không lưu</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">Không phải bây giờ</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">Không bao giờ lưu</string>
@@ -27,29 +25,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">Lưu</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">Đừng cập nhật</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">Không phải bây giờ</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">Cập nhật</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">Trường mật khẩu không được để trống</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">Nhập mật khẩu</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">Không thể lưu thông tin đăng nhập</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">Không thể lưu mật khẩu</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">Lưu thông tin đăng nhập này?</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">Lưu mật khẩu?</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">Cập nhật thông tin đăng nhập này?</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">Cập nhật lại mật khẩu?</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">Thêm tên người dùng vào mật khẩu đã lưu?</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">Cập nhật tên người dùng?</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -97,20 +83,12 @@
     <string name="mozac_feature_prompts_dec">Thg12</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">Cài đặt thời gian</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">Quản lý đăng nhập</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">Quản lý mật khẩu</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Mở rộng thông tin đăng nhập được đề xuất</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">Mở rộng mật khẩu đã lưu</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Thu gọn thông tin đăng nhập được đề xuất</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">Thu gọn mật khẩu đã lưu</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">Thông tin đăng nhập được đề xuất</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">Mật khẩu đã lưu</string>
@@ -124,8 +102,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">Sử dụng mật khẩu mạnh?</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">Bảo vệ tài khoản của bạn bằng cách sử dụng mật khẩu mạnh, được tạo ngẫu nhiên. Truy cập nhanh vào mật khẩu của bạn bằng cách lưu nó vào tài khoản của bạn.</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">Bảo vệ tài khoản của bạn bằng cách sử dụng mật khẩu mạnh, được tạo ngẫu nhiên. Nó sẽ được lưu vào tài khoản của bạn để sử dụng trong tương lai.</string>
 
@@ -154,28 +130,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">Huỷ bỏ</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">Chọn thẻ tín dụng</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">Sử dụng thẻ đã lưu</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Mở rộng thẻ tín dụng được đề xuất</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">Mở rộng thẻ đã lưu</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Thu gọn thẻ tín dụng được đề xuất</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">Thu gọn thẻ đã lưu</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">Quản lý thẻ tín dụng</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">Quản lý thẻ tín dụng</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">Lưu thẻ này một cách an toàn?</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">Cập nhật ngày hết hạn thẻ?</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">Số thẻ sẽ được mã hóa. Mã bảo mật sẽ không được lưu.</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s mã hóa số thẻ của bạn. Mã bảo mật của bạn sẽ không được lưu.</string>
@@ -183,12 +149,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">Chọn địa chỉ</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Mở rộng các địa chỉ được đề xuất</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">Mở rộng địa chỉ đã lưu</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">Thu gọn các địa chỉ được đề xuất</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">Thu gọn địa chỉ đã lưu</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-zh-rCN/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-zh-rCN/strings.xml
@@ -25,8 +25,6 @@
     <string name="mozac_feature_prompt_password_hint">密码</string>
 
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">不保存</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">暂时不要</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">永不保存</string>
@@ -35,29 +33,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">保存</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">不更新</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">暂时不要</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">更新</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">密码不能为空</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">请输入密码</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">无法保存登录信息</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">无法保存密码</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">要保存此登录信息吗？</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">要保存密码吗？</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">要更新此登录信息吗？</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">要更新密码吗？</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">要将用户名添加到已存密码吗？</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">要更新用户名吗？</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -109,20 +95,12 @@
     <string name="mozac_feature_prompts_dec">12 月</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">设置时间</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">管理登录信息</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">管理密码</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">展开推荐的登录信息</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">展开保存的密码</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">折叠推荐的登录信息</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">折叠保存的密码</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">推荐的登录信息</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">保存的密码</string>
@@ -136,8 +114,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">要使用高强度密码吗？</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">使用随机生成的高强度密码保护您的账户。将密码保存到您的账户，取用更方便。</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">使用随机生成的高强度密码来保护您的账户。密码将保存到您的账户，以供将来使用。</string>
 
@@ -166,28 +142,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">取消</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">选择信用卡</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">使用保存的信用卡</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">展开建议的信用卡</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">展开保存的信用卡</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">折叠建议的信用卡</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">折叠保存的信用卡</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">管理信用卡</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">管理信用卡</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">安全地保存此卡片？</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">是否要更新卡片有效期？</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">卡号将被加密，且不会保存安全码。</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s 会将卡号加密保存。安全码不会被保存。</string>
@@ -195,12 +161,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">选择地址</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">展开建议的地址</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">展开保存的地址</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">折叠建议的地址</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">折叠保存的地址</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-zh-rTW/strings.xml
+++ b/mozilla-mobile/android-components/components/feature/prompts/src/main/res/values-zh-rTW/strings.xml
@@ -25,8 +25,6 @@
     <string name="mozac_feature_prompt_password_hint">密碼</string>
 
     <!-- Negative confirmation that we should not save the new or updated login -->
-    <string name="mozac_feature_prompt_dont_save" moz:removedIn="125" tools:ignore="UnusedResources">不要儲存</string>
-    <!-- Negative confirmation that we should not save the new or updated login -->
     <string name="mozac_feature_prompt_dont_save_2">現在不要</string>
     <!-- Negative confirmation that we should never save a login for this site -->
     <string name="mozac_feature_prompt_never_save">永不儲存</string>
@@ -35,29 +33,17 @@
     <!-- Positive confirmation that we should save the new or updated login -->
     <string name="mozac_feature_prompt_save_confirmation">儲存</string>
     <!-- Negative confirmation that we should not save the updated login -->
-    <string name="mozac_feature_prompt_dont_update" moz:removedIn="125" tools:ignore="UnusedResources">不要更新</string>
-    <!-- Negative confirmation that we should not save the updated login -->
     <string name="mozac_feature_prompt_dont_update_2">現在不要</string>
     <!-- Positive confirmation that we should save the updated login -->
     <string name="mozac_feature_prompt_update_confirmation">更新</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_empty_password" moz:removedIn="125" tools:ignore="UnusedResources">密碼不得為空白</string>
-    <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_empty_password_2">輸入密碼</string>
-    <!-- Error text displayed underneath the login field when it is in an error case -->
-    <string name="mozac_feature_prompt_error_unknown_cause" moz:removedIn="125" tools:ignore="UnusedResources">無法儲存登入資訊</string>
     <!-- Error text displayed underneath the password field when it is in an error case -->
     <string name="mozac_feature_prompt_error_unknown_cause_2">無法儲存密碼</string>
-    <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new login. -->
-    <string name="mozac_feature_prompt_login_save_headline" moz:removedIn="125" tools:ignore="UnusedResources">要儲存這筆登入資訊嗎？</string>
     <!-- Prompt message displayed when app detects a user has entered a new username and password and user decides if app should save the new password. -->
     <string name="mozac_feature_prompt_login_save_headline_2">要儲存密碼嗎？</string>
-    <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_update_headline" moz:removedIn="125" tools:ignore="UnusedResources">要更新這筆登入資訊嗎？</string>
     <!-- Prompt message displayed when app detects a user has entered a new password for an existing login and user decides if app should update the password. -->
     <string name="mozac_feature_prompt_login_update_headline_2">要更新密碼嗎？</string>
-    <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
-    <string name="mozac_feature_prompt_login_add_username_headline" moz:removedIn="130" tools:ignore="UnusedResources">要將使用者名稱加進儲存的密碼資訊嗎？</string>
     <!-- Prompt message displayed when app detects a user has entered a username for an existing login without a username and user decides if app should update the login. -->
     <string name="mozac_feature_prompt_login_add_username_headline_2">要更新使用者名稱嗎？</string>
     <!-- Text for a label for the field when prompt requesting a text is shown. -->
@@ -109,20 +95,12 @@
     <string name="mozac_feature_prompts_dec">12 月</string>
     <!-- Title of the time picker dialog. -->
     <string name="mozac_feature_prompts_set_time">設定時間</string>
-    <!-- Option in expanded select login prompt that links to login settings -->
-    <string name="mozac_feature_prompts_manage_logins" moz:removedIn="125" tools:ignore="UnusedResources">管理登入密碼</string>
     <!-- Option in expanded select password prompt that links to password settings -->
     <string name="mozac_feature_prompts_manage_logins_2">管理密碼</string>
-    <!-- Content description for expanding the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_expand_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">展開建議的登入資訊</string>
     <!-- Content description for expanding the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_expand_logins_content_description_2">展開儲存的密碼</string>
-    <!-- Content description for collapsing the saved logins options in the select login prompt -->
-    <string name="mozac_feature_prompts_collapse_logins_content_description" moz:removedIn="125" tools:ignore="UnusedResources">摺疊建議的登入資訊</string>
     <!-- Content description for collapsing the saved passwords options in the select password prompt -->
     <string name="mozac_feature_prompts_collapse_logins_content_description_2">摺疊儲存的密碼</string>
-    <!-- Header for the select login prompt to allow users to fill a form with a saved login -->
-    <string name="mozac_feature_prompts_saved_logins" moz:removedIn="125" tools:ignore="UnusedResources">建議的登入資訊</string>
 
     <!-- Header for the select password prompt to allow users to fill a form with a saved password -->
     <string name="mozac_feature_prompts_saved_logins_2">已存密碼</string>
@@ -136,8 +114,6 @@
 
     <!-- Title for using the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_title">要使用較強的密碼嗎？</string>
-    <!-- Content description for the suggest strong password confirmation dialog -->
-    <string name="mozac_feature_prompts_suggest_strong_password_description" moz:removedIn="130" tools:ignore="UnusedResources">使用隨機產生的強大密碼來保護您的帳號，並將密碼儲存到您的帳號快速使用。</string>
     <!-- Content description for the suggest strong password confirmation dialog -->
     <string name="mozac_feature_prompts_suggest_strong_password_description_2" moz:removedIn="133" tools:ignore="UnusedResources">請使用隨機產生的強密碼來保護您的帳號。將儲存到您的帳號以供未來使用。</string>
 
@@ -166,28 +142,18 @@
     <string name="mozac_feature_prompt_repost_negative_button_text">取消</string>
 
     <!-- Credit Card Autofill -->
-    <!-- Header for the select credit card prompt to allow users to fill a form with a saved credit card. -->
-    <string name="mozac_feature_prompts_select_credit_card" moz:removedIn="125" tools:ignore="UnusedResources">選擇信用卡</string>
     <!-- Header for the select card prompt to allow users to fill a form with a saved card. -->
     <string name="mozac_feature_prompts_select_credit_card_2">使用儲存的卡片資訊</string>
-    <!-- Content description for expanding the select credit card options in the select credit card prompt. -->
-    <string name="mozac_feature_prompts_expand_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">展開建議的信用卡</string>
     <!-- Content description for expanding the saved card options in the select card prompt. -->
     <string name="mozac_feature_prompts_expand_credit_cards_content_description_2">展開儲存的卡片資訊</string>
-    <!-- Content description for collapsing the select credit card options in the select credit prompt. -->
-    <string name="mozac_feature_prompts_collapse_credit_cards_content_description" moz:removedIn="125" tools:ignore="UnusedResources">摺疊建議的信用卡</string>
     <!-- Content description for collapsing the saved card options in the select prompt. -->
     <string name="mozac_feature_prompts_collapse_credit_cards_content_description_2">摺疊儲存的卡片資訊</string>
-    <!-- Option in the expanded select credit card prompt that links to credit cards settings. -->
-    <string name="mozac_feature_prompts_manage_credit_cards" moz:removedIn="125" tools:ignore="UnusedResources">管理信用卡</string>
     <!-- Option in the expanded select card prompt that links to cards settings. -->
     <string name="mozac_feature_prompts_manage_credit_cards_2">管理卡片</string>
     <!-- Text for the title of a save credit card dialog. -->
     <string name="mozac_feature_prompts_save_credit_card_prompt_title">安全地儲存這張卡的資料？</string>
     <!-- Text for the title of an update credit card dialog. -->
     <string name="mozac_feature_prompts_update_credit_card_prompt_title">是否要更新卡片效期？</string>
-    <!-- Subtitle text displayed under the title of the save credit card dialog. -->
-    <string name="mozac_feature_prompts_save_credit_card_prompt_body" moz:removedIn="125" tools:ignore="UnusedResources">將加密卡號，也不會儲存安全碼。</string>
 
     <!-- Subtitle text displayed under the title of the saved card dialog. Parameter will be replaced by app name-->
     <string name="mozac_feature_prompts_save_credit_card_prompt_body_2">%s 會加密您的卡號，且不會儲存安全碼。</string>
@@ -195,12 +161,8 @@
     <!-- Address Autofill -->
     <!-- Header for the select address prompt to allow users to fill a form with a saved address. -->
     <string name="mozac_feature_prompts_select_address_2">選擇地址</string>
-    <!-- Content description for expanding the select addresses options in the select address prompt. -->
-    <string name="mozac_feature_prompts_expand_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">展開建議的地址</string>
     <!-- Content description for expanding the saved addresses options in the select address prompt. -->
     <string name="mozac_feature_prompts_expand_address_content_description_2">展開儲存的地址資訊</string>
-    <!-- Content description for collapsing the select address options in the select address prompt. -->
-    <string name="mozac_feature_prompts_collapse_address_content_description" moz:removedIn="125" tools:ignore="UnusedResources">摺疊建議的地址</string>
     <!-- Content description for collapsing the saved address options in the select address prompt. -->
     <string name="mozac_feature_prompts_collapse_address_content_description_2">摺疊儲存的地址資訊</string>
     <!-- Text for the manage addresses button. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-an/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-an/strings.xml
@@ -565,8 +565,6 @@
     <string name="collection_open_tabs">Ubrir pestanyas</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Nombre d’a coleccion</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Renombrar</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Borrar</string>
     <!-- Text for the menu button to delete a top site from history -->
@@ -870,8 +868,6 @@
     <string name="tab_collection_dialog_message">Seguro que quiers borrar %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Borrar</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Accedendo a pantalla completa</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">S’ha copiau la URL</string>
     <!-- Sample text for accessibility font size -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ar/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ar/strings.xml
@@ -111,8 +111,6 @@
     <string name="navbar_cfr_title">تصفح أسرع مع نظام التنقل الجديد</string>
 
     <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-    <string name="navbar_cfr_message" moz:removedIn="130" tools:ignore="UnusedResources">يختفي هذا الشريط أثناء التمرير لأسفل للحصول على مساحة تصفح إضافية.</string>
-    <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_message_2">على موقع الويب، يختفي هذا الشريط أثناء التمرير لأسفل للحصول على مساحة تصفح إضافية.</string>
     <!-- Text for the message displayed for the popup promoting the long press of navigation in the navigation bar. -->
     <string name="navbar_navigation_buttons_cfr_message">اضغط مع الاستمرار على الأسهم للتنقل بين الصفحات في سجل علامة التبويب هذه.</string>
@@ -218,8 +216,6 @@
     <!-- Content description (not visible, for screen readers etc.): Label for plus icon used to add extension.
       The first parameter is the name of the extension (for example: ClearURLs). -->
     <string name="browser_menu_extension_plus_icon_content_description_2">أضف %1$s</string>
-    <!-- Content description (not visible, for screen readers etc.): Label for plus icon used to add extensions. -->
-    <string name="browser_menu_extension_plus_icon_content_description" moz:removedIn="124" tools:ignore="UnusedResources">أضف الامتداد</string>
     <!-- Browser menu button that opens AMO in a tab -->
     <string name="browser_menu_discover_more_extensions">اكتشف المزيد من الامتدادات</string>
     <!-- Browser menu description that is shown when one or more extensions are disabled due to extension errors -->
@@ -428,13 +424,6 @@
     <string name="onboarding_home_content_description_close_button">أغلق</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">تساعدك الإشعارات على القيام بالمزيد مع %s</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">واصِل</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">ليس الآن</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -1057,8 +1046,6 @@
     <string name="collection_open_tabs">افتح الألسنة</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">اسم التجميعة</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">غيّر الاسم</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">أزِل</string>
 
@@ -1207,8 +1194,6 @@
     <string name="bookmark_navigate_back_button_content_description">تصفّح للوراء</string>
     <!-- Content description for the bookmark list new folder navigation bar button -->
     <string name="bookmark_add_new_folder_button_content_description">أضِف مجلدا جديدا</string>
-    <!-- Content description for the bookmark navigation bar close button -->
-    <string name="bookmark_close_button_content_description" tools:ignore="UnusedResources" moz:removedIn="130">أغلق العلامات</string>
     <!-- Content description for bookmark search floating action button -->
     <string name="bookmark_search_button_content_description">ابحث في العلامات</string>
     <!-- Content description for the overflow menu for a bookmark item. Paramter will a folder name or bookmark title. -->
@@ -1408,16 +1393,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">أغلِق الألسنة الخاصة</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">محايد</string>
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">غير راضٍ أبدًا</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">غير راضٍ</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">راضٍ</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">راضٍ جدًا</string>
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
     <string name="notification_erase_title_android_14">أتود أن تغلق الألسنة الخاصة؟</string>
@@ -1487,8 +1462,6 @@
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">احذف</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">تدخل وضع ملء الشاشة</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">نُسخ المسار</string>
     <!-- Sample text for accessibility font size -->
@@ -2086,8 +2059,6 @@
     <string name="shortcut_name_hint">اسم الاختصار</string>
     <!-- Hint for editing URL of a shortcut. -->
     <string name="shortcut_url_hint">اختصار عنوان URL</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">حسنا</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">ألغِ</string>
 
@@ -2150,8 +2121,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">انقر لتفاصيل أكثر</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">انتقل لأعلى</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">أغلِق</string>
@@ -2249,8 +2218,6 @@
     <string name="review_quality_check_first_cfr_action" moz:removedIn="132" tools:ignore="UnusedResources">جرِّب مدقق المراجعة</string>
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" moz:removedIn="132" tools:ignore="UnusedResources">افتح مدقق المراجعة</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">افتح مدقق المراجعة</string>
     <!-- Content description (not visible, for screen readers etc.) for closing browser menu button to open review quality check bottom sheet. -->
@@ -2369,8 +2336,6 @@
     <string name="never_translate_site_dialog_cancel_preference">ألغِ</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">نزّل اللغات</string>
     <!-- Title of the toolbar for the translation feature screen where users may download different languages for translation. -->
     <string name="download_languages_translations_toolbar_title_preference">نزّل اللغات</string>
     <!-- Screen header presenting the download language preference feature. It will appear under the toolbar.The first parameter is "Learn More," a clickable text with a link. Talkback will append this to say "Double tap to open link to learn more". -->
@@ -2441,8 +2406,6 @@
     <string name="likert_scale_option_7" tools:ignore="BrandUsage,UnusedResources">لا أستخدم خاصية البحث على Firefox</string>
     <!-- Option for likert scale -->
     <string name="likert_scale_option_8" tools:ignore="UnusedResources">أنا لا أستخدم المزامنة</string>
-    <!-- Text shown in prompt for homepage microsurvey. Note: The word "Firefox" should NOT be translated. -->
-    <string name="microsurvey_prompt_homepage_title" tools:ignore="BrandUsage,UnusedResources" moz:removedIn="130">ما مدى رضاك عن صفحتك الرئيسية في Firefox؟</string>
     <!-- Text shown in prompt for printing microsurvey. "sec" It's an abbreviation for "second". Note: The word "Firefox" should NOT be translated. -->
     <string name="microsurvey_prompt_printing_title" tools:ignore="BrandUsage,UnusedResources">ساعد في تحسين الطباعة في Firefox. لن يستغرق الأمر سوى ثواني</string>
     <!-- Accessibility -->
@@ -2450,8 +2413,6 @@
     <string name="microsurvey_app_icon_content_description" tools:ignore="BrandUsage">شعار Firefox</string>
     <!-- Content description for the survey feature icon. -->
     <string name="microsurvey_feature_icon_content_description">أيقونة ميزة الاستطلاع</string>
-    <!-- Content description (not visible, for screen readers etc.) for opening microsurvey bottom sheet. -->
-    <string name="microsurvey_open_handle_content_description" tools:ignore="UnusedResources" moz:removedIn="130">افتح الاستطلاع</string>
     <!-- Content description (not visible, for screen readers etc.) for closing microsurvey bottom sheet. -->
     <string name="microsurvey_close_handle_content_description">أغلق الاستطلاع</string>
     <!-- Content description for "X" button that is closing microsurvey. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-azb/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-azb/strings.xml
@@ -126,8 +126,6 @@
     <!-- Text for the title displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_title">یئنی گزینمه ایله داها یئیین مرور ائله‌یین</string>
 
-    <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-    <string name="navbar_cfr_message" moz:removedIn="130" tools:ignore="UnusedResources">داها آرتیق مرور فضاسی اوچون آشاغی اسکرول ائتدیگینیز زامان بو بار اوزاقلاشیر.</string>
 
     <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_message_2">سایتدا، داها چوخ مرور فضاسی اوچون آشاغیا حرکت ائتدیگینیز زمان، بو بار گیزله‌نیر.</string>
@@ -445,16 +443,6 @@
     <string name="onboarding_home_content_description_close_button">باغلا</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">بیلدیریش‌لر %s ایله داها چوخ شئی ائتمه‌گه کومک ائدیر.</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">تاغلارینیزی جهازلار آراسیندا دؤنگل‌ ائله‌یین، یئندیرمه‌لری ایداره ائله‌یین، %s گیزلیلیک قوروماسیندان لاب یاخچی یارارلانماق حاقیندا اطلاعات آلین و آیری شئی‌لر.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">ایدامه وئر</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">ایندی یوخ</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -660,8 +648,6 @@
     <string name="toast_override_account_sync_server_done">موْزیلا حسابیْ/دؤنگل سروری دگیشدیریلدی. دگیشمه‌لری یئرینه سالماق اوچون اپلیکیشن‌دن چیخیلیر…</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">حساب</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">ادوات چوبوغو</string>
     <!-- Preference for changing where the AddressBar is positioned -->
     <string name="preferences_toolbar_2">آدرس چوبوغو یئری</string>
     <!-- Preference for changing default theme to dark or light mode -->
@@ -978,8 +964,6 @@
     <string name="preference_gestures_dynamic_toolbar">آلت‌لر چوبوغونو گیزلتمک اوچون اسکرول ائله‌</string>
 
 
-    <!-- Preference for switching tabs by swiping horizontally on the toolbar -->
-    <string name="preference_gestures_swipe_toolbar_switch_tabs" moz:removedIn="129" tools:ignore="UnusedResources">تاغ‌لاریْ دگیشدیرمک اوچون ادوات چوُبوغونو یانالار طرف چکین</string>
     <!-- Preference for showing the opened tabs by swiping up on the toolbar-->
     <string name="preference_gestures_swipe_toolbar_show_tabs">تاغ‌لاریْ آچماق اوچون ادوات چوُبوغونو یوخاریا چکین</string>
 
@@ -1179,8 +1163,6 @@
     <string name="collection_open_tabs">تاغ‌لاریْ آچ</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">مجموعه آدیْ</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">یئنی‌دن آدلاندیْر</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">قالدیر</string>
     <!-- Text for the menu button to delete a top site from history -->
@@ -1525,16 +1507,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">گیزلی تاغ‌لاریْ باغلا</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">اوْرتا</string>
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">چوْخ ناراضیْ</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">ناراضیْ</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">راضیْ</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">چوْخ راضیْ</string>
 
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
@@ -1621,8 +1593,6 @@
     <string name="tab_collection_dialog_message">%1$s مجموعه‌سینی سیلمه‌گه آرخایینسیز؟</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">سیل</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">بوتون اکران حالتینه گئچیلیر</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">اینترنت آدرسی کوْپی اوْلدو</string>
     <!-- Sample text for accessibility font size -->
@@ -2330,8 +2300,6 @@
     <string name="shortcut_name_hint">شورتکات آدیْ</string>
     <!-- Hint for editing URL of a shortcut. -->
     <string name="shortcut_url_hint">شورتکات‌ آدرسی</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">اولسون</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">لغو</string>
     <!-- Text for the menu button to open the homepage settings. -->
@@ -2396,8 +2364,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">چوْخ جزئیات اوچون کلیک ائله‌</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">یوخاریا گئت</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">باغلا</string>
@@ -2570,8 +2536,6 @@
     <string name="review_quality_check_second_cfr_message">بو رای‌لرین اعتباری وار؟ دوزلتیلمیش رتبه‌نی گؤرمک اوچون ایندی یوْخلایین.</string>
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" tools:ignore="UnusedResources">باخیش یوخلایانیْ آچ</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">بتا</string>
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">باخیش یوخلایانیْ آچ</string>
     <!-- Content description (not visible, for screen readers etc.) for closing browser menu button to open review quality check bottom sheet. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-be/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-be/strings.xml
@@ -382,16 +382,6 @@
     <string name="onboarding_home_content_description_close_button">Закрыць</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Апавяшчэнні дапамогуць вам зрабіць больш з %s</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Сінхранізуйце свае карткі паміж прыладамі, кіруйце сцягваннямі, атрымлівайце парады, як максімальна выкарыстоўваць ахову прыватнасці %s, і многае іншае.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Працягнуць</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Не зараз</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -1063,8 +1053,6 @@
     <string name="collection_open_tabs">Адкрыць карткі</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Назва калекцыі</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Перайменаваць</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Выдаліць</string>
 
@@ -1399,16 +1387,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">Закрыць прыватныя карткі</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">Нейтральны</string>
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">Вельмі незадаволены</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">Незадаволены</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">Задаволены</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">Вельмі задаволены</string>
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
     <string name="notification_erase_title_android_14">Закрыць прыватныя карткі?</string>
@@ -1490,8 +1468,6 @@
     <string name="tab_collection_dialog_message">Вы ўпэўнены, што хочаце выдаліць %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Выдаліць</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Уваход у поўнаэкранны рэжым</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL скапіраваны</string>
 
@@ -2158,8 +2134,6 @@
     <string name="top_sites_rename_dialog_title">Назва</string>
     <!-- Hint for renaming title of a shortcut -->
     <string name="shortcut_name_hint">Назва цэтліка</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">OK</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Адмена</string>
 
@@ -2216,8 +2190,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Пстрыкніце, каб атрымаць падрабязнасці</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Перайсці ўверх</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Закрыць</string>
@@ -2377,8 +2349,6 @@
     <string name="review_quality_check_second_cfr_message">Ці надзейныя гэтыя водгукі? Праверце зараз, каб убачыць скарэктаваны рэйтынг.</string>
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" tools:ignore="UnusedResources">Адкрыць сродак праверкі водгукаў</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">Адкрыць сродак праверкі водгукаў</string>
     <!-- Content description (not visible, for screen readers etc.) for closing browser menu button to open review quality check bottom sheet. -->
@@ -2548,8 +2518,6 @@
     <string name="never_translate_site_dialog_cancel_preference">Скасаваць</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">Сцягнуць мовы</string>
     <!-- Title of the toolbar for the translation feature screen where users may download different languages for translation. -->
     <string name="download_languages_translations_toolbar_title_preference">Сцягнуць мовы</string>
     <!-- Clickable text from the screen header that links to a website. -->
@@ -2592,13 +2560,6 @@
     <!-- Button text on the dialog used by the translations feature to cancel deleting a language. -->
     <string name="delete_language_file_dialog_negative_button_text">Скасаваць</string>
 
-    <!-- Title for the dialog used by the translations feature to confirm canceling a download in progress for a language file.
-    The first parameter is the name of the language, for example, "Spanish". -->
-    <string name="cancel_download_language_file_dialog_title" moz:removedIn="130" tools:ignore="UnusedResources">Скасаваць сцягванне %1$s?</string>
-    <!-- Button text on the dialog used by the translations feature confirms canceling a download in progress for a language file. -->
-    <string name="cancel_download_language_file_dialog_positive_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Так</string>
-    <!-- Button text on the dialog used by the translations feature to dismiss the dialog. -->
-    <string name="cancel_download_language_file_negative_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Не</string>
 
     <!-- Title for the data saving mode warning dialog used by the translations feature.
     This dialog will be presented when the user attempts to download a language or perform
@@ -2677,8 +2638,6 @@
     <!-- Accessibility -->
     <!-- Content description for the survey application icon. Note: The word "Firefox" should NOT be translated.  -->
     <string name="microsurvey_app_icon_content_description" tools:ignore="BrandUsage">Лагатып Firefox</string>
-    <!-- Content description (not visible, for screen readers etc.) for opening microsurvey bottom sheet. -->
-    <string name="microsurvey_open_handle_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Адкрыць апытанне</string>
     <!-- Content description (not visible, for screen readers etc.) for closing microsurvey bottom sheet. -->
     <string name="microsurvey_close_handle_content_description">Закрыць апытанне</string>
     <!-- Content description for "X" button that is closing microsurvey. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-br/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-br/strings.xml
@@ -109,8 +109,6 @@
     <!-- Text for the title displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_title">Gounezit amzer gant ar merdeiñ nevez</string>
     <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-    <string name="navbar_cfr_message" moz:removedIn="130" tools:ignore="UnusedResources">Mont a raio da guzhat ar varrenn-mañ pa vo dibunet ar bajenn war-zu an traoñ evit gounit muioc’h a blas.</string>
-    <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_message_2">War ul lec’hienn ez aio ar varrenn-mañ da guzhat pa vo  dibunet ar bajenn war-zu an traoñ evit kaout muioc’h a blas.</string>
 
     <!-- Text for the message displayed for the popup promoting the long press of navigation in the navigation bar. -->
@@ -216,8 +214,6 @@
     <!-- Content description (not visible, for screen readers etc.): Label for plus icon used to add extension.
       The first parameter is the name of the extension (for example: ClearURLs). -->
     <string name="browser_menu_extension_plus_icon_content_description_2">Ouzhpennañ %1$s</string>
-    <!-- Content description (not visible, for screen readers etc.): Label for plus icon used to add extensions. -->
-    <string name="browser_menu_extension_plus_icon_content_description" moz:removedIn="124" tools:ignore="UnusedResources">Ouzhpennañ an askouezh</string>
     <!-- Browser menu button that opens AMO in a tab -->
     <string name="browser_menu_discover_more_extensions">Dizoloit muioc’h a askouezhioù</string>
     <!-- Browser menu description that is shown when one or more extensions are disabled due to extension errors -->
@@ -426,16 +422,6 @@
     <string name="onboarding_home_content_description_close_button">Serriñ</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Gant ar rebuzadurioù e c’hallit ober muioc’h a draoù gant %s</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Goubredit hoc’h ivinelloù etre ho trevnadoù, merit ho pellgargadurioù, lennit alioù evit tapout seizh gwellañ gwarez buhez prevez %s ha muioc’h c’hoazh.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Kenderc’hel</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Ket bremañ</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -1122,8 +1108,6 @@
     <string name="collection_open_tabs">Digeriñ an ivinelloù</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Anv an dastumad</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Adenvel</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Dilemel</string>
     <!-- Text for the menu button to delete a top site from history -->
@@ -1266,8 +1250,6 @@
     <string name="bookmark_navigate_back_button_content_description">Kent</string>
     <!-- Content description for the bookmark list new folder navigation bar button -->
     <string name="bookmark_add_new_folder_button_content_description">Ouzhpennañ un teuliad</string>
-    <!-- Content description for the bookmark navigation bar close button -->
-    <string name="bookmark_close_button_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Serriñ ar sinedoù</string>
     <!-- Content description for bookmark search floating action button -->
     <string name="bookmark_search_button_content_description">Klask er sinedoù</string>
     <!-- Content description for the overflow menu for a bookmark item. Paramter will a folder name or bookmark title. -->
@@ -1462,16 +1444,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">Serriñ an ivinelloù prevez</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">Ali ebet</string>
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">Displijet-tre</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">Displijet</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">Plijet</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">Plijet-tre</string>
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
     <string name="notification_erase_title_android_14">Serriñ an ivinelloù prevez?</string>
@@ -1551,8 +1523,6 @@
     <string name="tab_collection_dialog_message">Sur ocʼh e fell deocʼh dilemel %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Dilemel</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Mod skramm a-bezh kroget</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL eilet</string>
     <!-- Sample text for accessibility font size -->
@@ -2221,8 +2191,6 @@
     <string name="shortcut_name_hint">Anv ar verradenn</string>
     <!-- Hint for editing URL of a shortcut. -->
     <string name="shortcut_url_hint">Berradenn URL</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">Mat eo</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Nullañ</string>
 
@@ -2288,8 +2256,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Klikit da gaout muioc’h a vunudoù</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Adpignat</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Serriñ</string>
@@ -2437,8 +2403,6 @@
     <string name="review_quality_check_first_cfr_action" moz:removedIn="132" tools:ignore="UnusedResources">Esaeit ar gwirier alioù</string>
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" moz:removedIn="132" tools:ignore="UnusedResources">Digeriñ ar gwirier alioù</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">Digeriñ ar gwirier alioù</string>
     <!-- Content description (not visible, for screen readers etc.) for closing browser menu button to open review quality check bottom sheet. -->
@@ -2583,8 +2547,6 @@
     <string name="never_translate_site_dialog_cancel_preference">Nullañ</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">Pellgargañ yezhoù</string>
     <!-- Title of the toolbar for the translation feature screen where users may download different languages for translation. -->
     <string name="download_languages_translations_toolbar_title_preference">Pellgargañ yezhoù</string>
     <!-- Clickable text from the screen header that links to a website. -->
@@ -2619,10 +2581,6 @@
     <!-- Button text on the dialog used by the translations feature to cancel deleting a language. -->
     <string name="delete_language_file_dialog_negative_button_text">Nullañ</string>
 
-    <!-- Button text on the dialog used by the translations feature confirms canceling a download in progress for a language file. -->
-    <string name="cancel_download_language_file_dialog_positive_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Ya</string>
-    <!-- Button text on the dialog used by the translations feature to dismiss the dialog. -->
-    <string name="cancel_download_language_file_negative_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Ket</string>
 
     <!-- Additional information for the data saving mode warning dialog used by the translations feature. This text explains the reason a download is required for a translation. -->
     <string name="download_language_file_dialog_message_all_languages">Pellgargañ a reomp ul lodenn eus ar yezhoù er c’hrubuilh evit mirout ho troidigezhioù prevez.</string>
@@ -2712,8 +2670,6 @@
     <string name="likert_scale_option_5" tools:ignore="UnusedResources">Displijet-tre</string>
     <!-- Option for likert scale -->
     <string name="likert_scale_option_6" tools:ignore="UnusedResources">Ne ran ket gantañ</string>
-    <!-- Text shown in prompt for homepage microsurvey. Note: The word "Firefox" should NOT be translated. -->
-    <string name="microsurvey_prompt_homepage_title" tools:ignore="BrandUsage,UnusedResources" moz:removedIn="130">Plijet hoc’h gant ho pennbajenn Firefox?</string>
     <!-- Text shown in prompt for printing microsurvey. "sec" It's an abbreviation for "second". Note: The word "Firefox" should NOT be translated. -->
     <string name="microsurvey_prompt_printing_title" tools:ignore="BrandUsage,UnusedResources">Skoazellit da lakaat ar moullañ e Firefox da vezañ gwelloc’h. Ne gemer nemet div eilenn</string>
     <!-- Text shown in the survey title for printing microsurvey. Note: The word "Firefox" should NOT be translated. -->
@@ -2725,8 +2681,6 @@
     <string name="microsurvey_app_icon_content_description" tools:ignore="BrandUsage">Logo Firefox</string>
     <!-- Content description for the survey feature icon. -->
     <string name="microsurvey_feature_icon_content_description">Arlun ar sontadeg</string>
-    <!-- Content description (not visible, for screen readers etc.) for opening microsurvey bottom sheet. -->
-    <string name="microsurvey_open_handle_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Digeriñ ar sontdeg</string>
     <!-- Content description (not visible, for screen readers etc.) for closing microsurvey bottom sheet. -->
     <string name="microsurvey_close_handle_content_description">Serriñ ar sontadeg</string>
     <!-- Content description for "X" button that is closing microsurvey. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ca/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ca/strings.xml
@@ -107,8 +107,6 @@
     <!-- Toolbar "contextual feature recommendation" (CFR) -->
     <!-- Text for the title displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_title">Navegueu més ràpid amb el nou sistema de navegació</string>
-    <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-    <string name="navbar_cfr_message" moz:removedIn="130" tools:ignore="UnusedResources">Aquesta barra s’amaga quan us desplaceu cap avall per guanyar espai de navegació.</string>
 
     <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_message_2">En un lloc web, aquesta barra s’amaga quan us desplaceu cap avall per guanyar espai de navegació.</string>
@@ -424,16 +422,6 @@
     <string name="onboarding_home_content_description_close_button">Tanca</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Les notificacions us ajuden a fer més coses amb el %s</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Sincronitzeu les vostres pestanyes entre dispositius, gestioneu les baixades, obteniu consells per treure el màxim profit de la protecció de privadesa del %s i molt més.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Continua</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Ara no</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -639,8 +627,6 @@
     <string name="toast_override_account_sync_server_done">S’ha modificat el servidor de comptes de Mozilla o del Sync. L’aplicació es tancarà per aplicar els canvis…</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">Compte</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">Barra d’eines</string>
     <!-- Preference for changing where the AddressBar is positioned -->
     <string name="preferences_toolbar_2">Ubicació de la barra d’adreces</string>
     <!-- Preference for changing default theme to dark or light mode -->
@@ -943,8 +929,6 @@
     <!-- Preference for using the dynamic toolbar -->
     <string name="preference_gestures_dynamic_toolbar">Amaga la barra d’eines en desplaçar-me</string>
 
-    <!-- Preference for switching tabs by swiping horizontally on the toolbar -->
-    <string name="preference_gestures_swipe_toolbar_switch_tabs" moz:removedIn="129" tools:ignore="UnusedResources">Canvia de pestanya en fer lliscar la barra d’eines cap als costats</string>
     <!-- Preference for showing the opened tabs by swiping up on the toolbar-->
     <string name="preference_gestures_swipe_toolbar_show_tabs">Mostra les pestanyes obertes en fer lliscar la barra d’eines cap amunt</string>
 
@@ -1135,8 +1119,6 @@
 
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Nom de la col·lecció</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Reanomena</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Elimina</string>
 
@@ -1472,16 +1454,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">Tanca les pestanyes privades</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">Neutre/a</string>
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">Molt insatisfet/a</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">Insatisfet/a</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">Satisfet/a</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">Molt satisfet/a</string>
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
     <string name="notification_erase_title_android_14">Voleu tancar les pestanyes privades?</string>
@@ -1563,8 +1535,6 @@
     <string name="tab_collection_dialog_message">Segur que voleu suprimir %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Suprimeix</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Esteu en mode de pantalla completa</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">S’ha copiat l’URL</string>
 
@@ -2237,8 +2207,6 @@
     <string name="shortcut_name_hint">Nom de la drecera</string>
     <!-- Hint for editing URL of a shortcut. -->
     <string name="shortcut_url_hint">URL de la drecera</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">D’acord</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Cancel·la</string>
 
@@ -2302,8 +2270,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Feu clic aquí per a veure més informació</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Navega cap amunt</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Tanca</string>
@@ -2465,8 +2431,6 @@
     <string name="review_quality_check_second_cfr_message">Són fiables aquestes ressenyes? Vegeu-ne una valoració ajustada.</string>
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" tools:ignore="UnusedResources">Obre el verificador de ressenyes</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">Obre el verificador de ressenyes</string>
     <!-- Content description (not visible, for screen readers etc.) for closing browser menu button to open review quality check bottom sheet. -->
@@ -2657,8 +2621,6 @@
     <string name="never_translate_site_dialog_cancel_preference">Cancel·la</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">Baixa llengües</string>
     <!-- Title of the toolbar for the translation feature screen where users may download different languages for translation. -->
     <string name="download_languages_translations_toolbar_title_preference">Baixa llengües</string>
     <!-- Screen header presenting the download language preference feature. It will appear under the toolbar.The first parameter is "Learn More," a clickable text with a link. Talkback will append this to say "Double tap to open link to learn more". -->
@@ -2681,8 +2643,6 @@
     <string name="download_language_all_languages_item_preference_to_delete">Suprimeix totes les llengües</string>
     <!-- Content description (not visible, for screen readers etc.): For a language list item that was downloaded, the user can now delete it. -->
     <string name="download_languages_item_content_description_downloaded_state">Suprimeix</string>
-    <!-- Content description (not visible, for screen readers etc.): For a language list item, downloading is in progress. -->
-    <string name="download_languages_item_content_description_in_progress_state" moz:removedIn="129" tools:ignore="UnusedResources">En curs</string>
 
     <!-- Content description (not visible, for screen readers etc.): For a language list item, deleting is in progress. -->
     <string name="download_languages_item_content_description_delete_in_progress_state">En curs</string>
@@ -2719,13 +2679,6 @@
     <!-- Button text on the dialog used by the translations feature to cancel deleting a language. -->
     <string name="delete_language_file_dialog_negative_button_text">Cancel·la</string>
 
-    <!-- Title for the dialog used by the translations feature to confirm canceling a download in progress for a language file.
-    The first parameter is the name of the language, for example, "Spanish". -->
-    <string name="cancel_download_language_file_dialog_title" moz:removedIn="130" tools:ignore="UnusedResources">Voleu cancel·lar la baixada de %1$s?</string>
-    <!-- Button text on the dialog used by the translations feature confirms canceling a download in progress for a language file. -->
-    <string name="cancel_download_language_file_dialog_positive_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Sí</string>
-    <!-- Button text on the dialog used by the translations feature to dismiss the dialog. -->
-    <string name="cancel_download_language_file_negative_button_text" moz:removedIn="130" tools:ignore="UnusedResources">No</string>
 
     <!-- Title for the data saving mode warning dialog used by the translations feature.
     This dialog will be presented when the user attempts to download a language or perform
@@ -2734,8 +2687,6 @@
     <string name="download_language_file_dialog_title">Voleu baixar en mode d’estalvi de dades (%1$s)?</string>
     <!-- Additional information for the data saving mode warning dialog used by the translations feature. This text explains the reason a download is required for a translation. -->
     <string name="download_language_file_dialog_message_all_languages">Les llengües es baixen parcialment a la memòria cau perquè les traduccions siguin privades.</string>
-    <!-- Additional information for the data saving mode warning dialog used by the translations feature. This text explains the reason a download is required for a translation without mentioning the cache. -->
-    <string name="download_language_file_dialog_message_all_languages_no_cache" moz:removedIn="129" tools:ignore="UnusedResources">Les llengües es baixen parcialment perquè les traduccions siguin privades.</string>
     <!-- Checkbox label text on the data saving mode warning dialog used by the translations feature. This checkbox allows users to ignore the data usage warnings. -->
     <string name="download_language_file_dialog_checkbox_text">Baixa sempre en mode d’estalvi de dades</string>
     <!-- Button text on the data saving mode warning dialog used by the translations feature to allow users to confirm they wish to continue and download the language file. -->
@@ -2796,11 +2747,7 @@
     <string name="micro_survey_continue_button_label" tools:ignore="UnusedResources">Continua</string>
     <!-- Survey view -->
     <!-- The survey header -->
-    <string name="micro_survey_survey_header" moz:removedIn="129" tools:ignore="UnusedResources">Empleneu aquesta enquesta</string>
-    <!-- The survey header -->
     <string name="micro_survey_survey_header_2">Empleneu l’enquesta</string>
-    <!-- The privacy notice link -->
-    <string name="micro_survey_privacy_notice" moz:removedIn="129" tools:ignore="UnusedResources">Avís de privadesa</string>
     <!-- The privacy notice link -->
     <string name="micro_survey_privacy_notice_2">Avís de privadesa</string>
     <!-- The submit button label text -->
@@ -2821,8 +2768,6 @@
     <string name="likert_scale_option_5" tools:ignore="UnusedResources">Molt insatisfet/a</string>
     <!-- Option for likert scale -->
     <string name="likert_scale_option_6" tools:ignore="UnusedResources">No l’utilitzo</string>
-    <!-- Text shown in prompt for homepage microsurvey. Note: The word "Firefox" should NOT be translated. -->
-    <string name="microsurvey_prompt_homepage_title" tools:ignore="BrandUsage,UnusedResources" moz:removedIn="130">Esteu satisfet/a de la pàgina d’inici del Firefox?</string>
     <!-- Text shown in prompt for printing microsurvey. "sec" It's an abbreviation for "second". Note: The word "Firefox" should NOT be translated. -->
     <string name="microsurvey_prompt_printing_title" tools:ignore="BrandUsage,UnusedResources">Ajudeu-nos a millorar la impressió en el Firefox. Només és un minut.</string>
     <!-- Text shown in prompt for printing microsurvey. Note: The word "Firefox" should NOT be translated. -->
@@ -2834,8 +2779,6 @@
     <string name="microsurvey_app_icon_content_description" tools:ignore="BrandUsage">Logotip del Firefox</string>
     <!-- Content description for the survey feature icon. -->
     <string name="microsurvey_feature_icon_content_description">Icona de la funció d’enquesta</string>
-    <!-- Content description (not visible, for screen readers etc.) for opening microsurvey bottom sheet. -->
-    <string name="microsurvey_open_handle_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Obre l’enquesta</string>
     <!-- Content description (not visible, for screen readers etc.) for closing microsurvey bottom sheet. -->
     <string name="microsurvey_close_handle_content_description">Tanca l’enquesta</string>
     <!-- Content description for "X" button that is closing microsurvey. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-cak/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-cak/strings.xml
@@ -199,8 +199,6 @@
     <!-- Content description (not visible, for screen readers etc.): Label for plus icon used to add extension.
       The first parameter is the name of the extension (for example: ClearURLs). -->
     <string name="browser_menu_extension_plus_icon_content_description_2">Titz\'aqatisäx %1$s</string>
-    <!-- Content description (not visible, for screen readers etc.): Label for plus icon used to add extensions. -->
-    <string name="browser_menu_extension_plus_icon_content_description" moz:removedIn="124" tools:ignore="UnusedResources">Titz\'aqatisäx k\'amal</string>
     <!-- Browser menu button that opens account settings -->
     <string name="browser_menu_account_settings">Rutzijol rub\'i\' taqoya\'l</string>
     <!-- Browser menu button that sends a user to help articles -->
@@ -364,16 +362,6 @@
     <string name="onboarding_home_content_description_close_button">Titz\'apïx</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Ri taq rutzijol yatkito\' richin nasamajij  ch\'aqa\' chik pa %s</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Ke\'axima\' ri taq ruwi\' chi kikojol ri taq okisaxel, ke\'anuk\'samajij taq qasanïk, ke\'ak\'ulu\' taq na\'oj chi rij rub\'eyal nawïl ri rutzil ruchajixik richinanem %s chuqa\' ch\'aqa\' chik.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Titikïr chik el</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Wakami mani</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -1002,8 +990,6 @@
     <string name="collection_open_tabs">Kejaq taq ruwi\'</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Rub\'i\' mol</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Tisik\'ïx chik</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Tiyuj</string>
 
@@ -1406,8 +1392,6 @@
     <string name="tab_collection_dialog_message">¿La kan nawajo\' nayuj %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Tiyuj</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Nok pa chijun ruwa</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL xwachib\'ëx</string>
 
@@ -2006,8 +1990,6 @@ Achi\'el: \nhttps://www.google.com/search?q=%s</string>
     <string name="top_sites_rename_dialog_title">B\'i\'aj</string>
     <!-- Hint for renaming title of a shortcut -->
     <string name="shortcut_name_hint">Rub\'i\' ri choj okem</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">ÜTZ</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Tiq\'at</string>
 
@@ -2051,8 +2033,6 @@ Achi\'el: \nhttps://www.google.com/search?q=%s</string>
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Tipitz\' richin ch\'aqa\' rub\'anikil</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Tib\'an okem ajsik</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Titz\'apïx</string>
@@ -2104,8 +2084,6 @@ Achi\'el: \nhttps://www.google.com/search?q=%s</string>
     <string name="review_quality_check_contextual_onboarding_primary_button_text">Ja\', titojtob\'ëx</string>
     <!-- Text for opt-out button from the review quality check contextual onboarding card. -->
     <string name="review_quality_check_contextual_onboarding_secondary_button_text">Wakami mani</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Text for minimize button from highlights card. When clicked the highlights card should reduce its size. -->
     <string name="review_quality_check_highlights_show_less">Tik\'ut jub\'a\'</string>
     <!-- Text for maximize button from highlights card. When clicked the highlights card should expand to its full size. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-co/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-co/strings.xml
@@ -113,8 +113,6 @@
     <!-- Text for the title displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_title">Navigà più prestu cù u sistema novu di navigazione</string>
     <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-    <string name="navbar_cfr_message" moz:removedIn="130" tools:ignore="UnusedResources">Sta barra si piatta quandu si sfila versu u bassu, per lascià più spaziu per a navigazione.</string>
-    <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_message_2">Nant’à un situ web, sta barra si piatta quandu si sfila versu u bassu, per lascià più spaziu per a navigazione.</string>
 
     <!-- Text for the message displayed for the popup promoting the long press of navigation in the navigation bar. -->
@@ -419,16 +417,6 @@
     <string name="onboarding_home_content_description_close_button">Chjode</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">E nutificazioni vi aiutanu à fane di più cù %s</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Sincrunizate l’unghjette trà i vostri apparechji, urganizate i scaricamenti, ottinite cunsiglii per sfruttà u più bellu di a prutezzione di a vita privata da %s, è ancu di più.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Cuntinuà</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Micca subitu</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -627,8 +615,6 @@
     <string name="toast_override_account_sync_server_done">Servitore di contu o di sincrunizazione Mozilla mudificatu. Chjusura di l’appiecazione per piglià i cambiamenti in contu…</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">Contu</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">Barra d’attrezzi</string>
     <!-- Preference for changing where the AddressBar is positioned -->
     <string name="preferences_toolbar_2">Pusizione di a barra d’indirizzu</string>
     <!-- Preference for changing default theme to dark or light mode -->
@@ -937,8 +923,6 @@
     <!-- Preference for using the dynamic toolbar -->
     <string name="preference_gestures_dynamic_toolbar">Sfilà per piattà a barra d’attrezzi</string>
 
-    <!-- Preference for switching tabs by swiping horizontally on the toolbar -->
-    <string name="preference_gestures_swipe_toolbar_switch_tabs" moz:removedIn="129" tools:ignore="UnusedResources">Fà sfilà a barra d’attrezzi lateralmente per cambià d’unghjetta</string>
     <!-- Preference for showing the opened tabs by swiping up on the toolbar-->
     <string name="preference_gestures_swipe_toolbar_show_tabs">Fà sfilà a barra d’attrezzi insù per apre unghjette</string>
 
@@ -1135,8 +1119,6 @@
 
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Nome di a cullezzione</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Rinuminà</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Caccià</string>
 
@@ -1471,16 +1453,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">Chjode l’unghjette private</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">Indifferente</string>
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">Assai infelice</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">Infelice</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">Felice</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">Assai felice</string>
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
     <string name="notification_erase_title_android_14">Chjode l’unghjette private ?</string>
@@ -1561,8 +1533,6 @@
     <string name="tab_collection_dialog_message">Vulete veramente squassà %1$s ?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Squassà</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Modu di screnu sanu attivatu</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">Indirizzu web cupiatu</string>
     <!-- Sample text for accessibility font size -->
@@ -2233,8 +2203,6 @@
     <string name="shortcut_name_hint">Nome di l’accurtatoghju</string>
     <!-- Hint for editing URL of a shortcut. -->
     <string name="shortcut_url_hint">Indirizzu web di l’accurtatoghju</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">Vai</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Abbandunà</string>
 
@@ -2300,8 +2268,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Cliccu per sapene di più</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Navigà insù</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Chjode</string>
@@ -2469,8 +2435,6 @@
     <string name="review_quality_check_second_cfr_message">St’avisi serianu degni di cunfidenza ? Cuntrollà subitu per fighjà una valutazione rettificata.</string>
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" tools:ignore="UnusedResources">Apre u verificadore d’avisu</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">Apre u verificadore d’avisu</string>
     <!-- Content description (not visible, for screen readers etc.) for closing browser menu button to open review quality check bottom sheet. -->
@@ -2664,8 +2628,6 @@
     <string name="never_translate_site_dialog_cancel_preference">Abbandunà</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">Scaricà lingue</string>
     <!-- Title of the toolbar for the translation feature screen where users may download different languages for translation. -->
     <string name="download_languages_translations_toolbar_title_preference">Scaricà lingue</string>
     <!-- Screen header presenting the download language preference feature. It will appear under the toolbar.The first parameter is "Learn More," a clickable text with a link. Talkback will append this to say "Double tap to open link to learn more". -->
@@ -2689,8 +2651,6 @@
     <string name="download_language_all_languages_item_preference_to_delete">Squassà tutte e lingue</string>
     <!-- Content description (not visible, for screen readers etc.): For a language list item that was downloaded, the user can now delete it. -->
     <string name="download_languages_item_content_description_downloaded_state">Squassà</string>
-    <!-- Content description (not visible, for screen readers etc.): For a language list item, downloading is in progress. -->
-    <string name="download_languages_item_content_description_in_progress_state" moz:removedIn="129" tools:ignore="UnusedResources">In corsu</string>
     <!-- Content description (not visible, for screen readers etc.): For a language list item, deleting is in progress. -->
     <string name="download_languages_item_content_description_delete_in_progress_state">In corsu</string>
     <!-- Content description (not visible, for screen readers etc.): For a language list item, downloading is in progress.
@@ -2727,13 +2687,6 @@
     <!-- Button text on the dialog used by the translations feature to cancel deleting a language. -->
     <string name="delete_language_file_dialog_negative_button_text">Abbandunà</string>
 
-    <!-- Title for the dialog used by the translations feature to confirm canceling a download in progress for a language file.
-    The first parameter is the name of the language, for example, "Spanish". -->
-    <string name="cancel_download_language_file_dialog_title" moz:removedIn="130" tools:ignore="UnusedResources">Abbandunà u scaricamentu di %1$s ?</string>
-    <!-- Button text on the dialog used by the translations feature confirms canceling a download in progress for a language file. -->
-    <string name="cancel_download_language_file_dialog_positive_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Sì</string>
-    <!-- Button text on the dialog used by the translations feature to dismiss the dialog. -->
-    <string name="cancel_download_language_file_negative_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Nò</string>
 
     <!-- Title for the data saving mode warning dialog used by the translations feature.
     This dialog will be presented when the user attempts to download a language or perform
@@ -2742,8 +2695,6 @@
     <string name="download_language_file_dialog_title">Scaricà in modu di risparmiu di dati (%1$s) ?</string>
     <!-- Additional information for the data saving mode warning dialog used by the translations feature. This text explains the reason a download is required for a translation. -->
     <string name="download_language_file_dialog_message_all_languages">Scarichemu in a vostra impiatta certe parti di lingue per mantene private e vostre traduzzioni.</string>
-    <!-- Additional information for the data saving mode warning dialog used by the translations feature. This text explains the reason a download is required for a translation without mentioning the cache. -->
-    <string name="download_language_file_dialog_message_all_languages_no_cache" moz:removedIn="129" tools:ignore="UnusedResources">Scarichemu certe parti di lingue per mantene private e vostre traduzzioni.</string>
     <!-- Checkbox label text on the data saving mode warning dialog used by the translations feature. This checkbox allows users to ignore the data usage warnings. -->
     <string name="download_language_file_dialog_checkbox_text">Scaricà sempre in modu di risparmiu di dati</string>
     <!-- Button text on the data saving mode warning dialog used by the translations feature to allow users to confirm they wish to continue and download the language file. -->
@@ -2806,11 +2757,7 @@
     <string name="micro_survey_continue_button_label" tools:ignore="UnusedResources">Cuntinuà</string>
     <!-- Survey view -->
     <!-- The survey header -->
-    <string name="micro_survey_survey_header" moz:removedIn="129" tools:ignore="UnusedResources">Participà à l’inchiesta</string>
-    <!-- The survey header -->
     <string name="micro_survey_survey_header_2">Vi ringraziemu di risponde à l’inchiesta</string>
-    <!-- The privacy notice link -->
-    <string name="micro_survey_privacy_notice" moz:removedIn="129" tools:ignore="UnusedResources">Pulitica di cunfidenzialità</string>
     <!-- The privacy notice link -->
     <string name="micro_survey_privacy_notice_2">Pulitica di cunfidenzialità</string>
     <!-- The submit button label text -->
@@ -2833,8 +2780,6 @@
 
     <!-- Option for likert scale -->
     <string name="likert_scale_option_6" tools:ignore="UnusedResources">Ùn l’impiegu micca</string>
-    <!-- Text shown in prompt for homepage microsurvey. Note: The word "Firefox" should NOT be translated. -->
-    <string name="microsurvey_prompt_homepage_title" tools:ignore="UnusedResources" moz:removedIn="130">Site cuntenti di a vostra pagina d’accolta in Firefox ?</string>
     <!-- Text shown in prompt for printing microsurvey. "sec" It's an abbreviation for "second". Note: The word "Firefox" should NOT be translated. -->
     <string name="microsurvey_prompt_printing_title" tools:ignore="UnusedResources">Aiutateci à amendà a stampa in Firefox. Què piglia solu una stonda</string>
     <!-- Text shown in prompt for printing microsurvey. Note: The word "Firefox" should NOT be translated. -->
@@ -2846,8 +2791,6 @@
     <string name="microsurvey_app_icon_content_description">Logo Firefox</string>
     <!-- Content description for the survey feature icon. -->
     <string name="microsurvey_feature_icon_content_description">Icona di a funzione d’inchiesta</string>
-    <!-- Content description (not visible, for screen readers etc.) for opening microsurvey bottom sheet. -->
-    <string name="microsurvey_open_handle_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Apre l’inchiesta</string>
     <!-- Content description (not visible, for screen readers etc.) for closing microsurvey bottom sheet. -->
     <string name="microsurvey_close_handle_content_description">Chjode l’inchiesta</string>
     <!-- Content description for "X" button that is closing microsurvey. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-es-rMX/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-es-rMX/strings.xml
@@ -107,8 +107,6 @@
     <!-- Text for the title displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_title">Navegá más rápido con la nueva navegación</string>
 
-    <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-    <string name="navbar_cfr_message" moz:removedIn="130" tools:ignore="UnusedResources">Esta barra se oculta a medida que te desplazas hacia abajo para tener más espacio de navegación.</string>
 
     <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_message_2">En un sitio web, esta barra se oculta a medida que te desplazas hacia abajo para tener más espacio de navegación.</string>
@@ -219,8 +217,6 @@
     <!-- Content description (not visible, for screen readers etc.): Label for plus icon used to add extension.
       The first parameter is the name of the extension (for example: ClearURLs). -->
     <string name="browser_menu_extension_plus_icon_content_description_2">Agregar %1$s</string>
-    <!-- Content description (not visible, for screen readers etc.): Label for plus icon used to add extensions. -->
-    <string name="browser_menu_extension_plus_icon_content_description" moz:removedIn="124" tools:ignore="UnusedResources">Agregar extensión</string>
     <!-- Browser menu button that opens AMO in a tab -->
     <string name="browser_menu_discover_more_extensions">Descubrir más extensiones</string>
     <!-- Browser menu description that is shown when one or more extensions are disabled due to extension errors -->
@@ -433,16 +429,6 @@
     <string name="onboarding_home_content_description_close_button">Cerrar</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Las notificaciones te ayudan a hacer más con %s</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Sincroniza tus pestañas entre dispositivos, administra descargas, obtén consejos sobre cómo aprovechar al máximo la protección de privacidad de %s y más.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Continuar</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Ahora no</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -1138,8 +1124,6 @@
     <string name="collection_open_tabs">Abrir pestañas</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Nombre de la colección</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Renombrar</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Eliminar</string>
 
@@ -1289,8 +1273,6 @@
     <string name="bookmark_navigate_back_button_content_description">Regresar a la navegación</string>
     <!-- Content description for the bookmark list new folder navigation bar button -->
     <string name="bookmark_add_new_folder_button_content_description">Agregar una nueva carpeta</string>
-    <!-- Content description for the bookmark navigation bar close button -->
-    <string name="bookmark_close_button_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Cerrar marcadores</string>
     <!-- Content description for bookmark search floating action button -->
     <string name="bookmark_search_button_content_description">Buscar marcadores</string>
     <!-- Content description for the overflow menu for a bookmark item. Paramter will a folder name or bookmark title. -->
@@ -1497,16 +1479,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">Cerrar pestañas privadas</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">Neutral</string>
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">Muy insatisfecho</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">Insatisfecho</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">Satisfecho</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">Muy satisfecho</string>
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
     <string name="notification_erase_title_android_14">¿Cerrar pestañas privadas?</string>
@@ -1587,8 +1559,6 @@
     <string name="tab_collection_dialog_message">¿Seguro que quieres eliminar %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Eliminar</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Accediendo a pantalla completa</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL copiada</string>
     <!-- Sample text for accessibility font size -->
@@ -2257,8 +2227,6 @@
     <string name="shortcut_name_hint">Nombre del atajo</string>
     <!-- Hint for editing URL of a shortcut. -->
     <string name="shortcut_url_hint">URL del acceso directo</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">Aceptar</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Cancelar</string>
 
@@ -2324,8 +2292,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Clic para más detalles</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Navegar hacia arriba</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Cerrar</string>
@@ -2486,8 +2452,6 @@
     <string name="review_quality_check_second_cfr_message" moz:removedIn="132" tools:ignore="UnusedResources">¿Son confiables estas reseñas? Verifica ahora para ver una calificación ajustada.</string>
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" moz:removedIn="132" tools:ignore="UnusedResources">Abrir el verificador de reseñas</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">Abrir verificador de reseñas</string>
     <!-- Content description (not visible, for screen readers etc.) for closing browser menu button to open review quality check bottom sheet. -->
@@ -2674,8 +2638,6 @@
     <string name="never_translate_site_dialog_cancel_preference">Cancelar</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">Descargar Idiomas</string>
     <!-- Title of the toolbar for the translation feature screen where users may download different languages for translation. -->
     <string name="download_languages_translations_toolbar_title_preference">Descargar idiomas</string>
     <!-- Screen header presenting the download language preference feature. It will appear under the toolbar.The first parameter is "Learn More," a clickable text with a link. Talkback will append this to say "Double tap to open link to learn more". -->
@@ -2734,13 +2696,6 @@
     <!-- Button text on the dialog used by the translations feature to cancel deleting a language. -->
     <string name="delete_language_file_dialog_negative_button_text">Cancelar</string>
 
-    <!-- Title for the dialog used by the translations feature to confirm canceling a download in progress for a language file.
-    The first parameter is the name of the language, for example, "Spanish". -->
-    <string name="cancel_download_language_file_dialog_title" moz:removedIn="130" tools:ignore="UnusedResources">¿Cancelar la descarga de %1$s?</string>
-    <!-- Button text on the dialog used by the translations feature confirms canceling a download in progress for a language file. -->
-    <string name="cancel_download_language_file_dialog_positive_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Sí</string>
-    <!-- Button text on the dialog used by the translations feature to dismiss the dialog. -->
-    <string name="cancel_download_language_file_negative_button_text" moz:removedIn="130" tools:ignore="UnusedResources">No</string>
 
     <!-- Title for the data saving mode warning dialog used by the translations feature.
     This dialog will be presented when the user attempts to download a language or perform
@@ -2835,8 +2790,6 @@
     <string name="likert_scale_option_7" tools:ignore="BrandUsage,UnusedResources">No uso la búsqueda en Firefox</string>
     <!-- Option for likert scale -->
     <string name="likert_scale_option_8" tools:ignore="UnusedResources">No uso sincronización</string>
-    <!-- Text shown in prompt for homepage microsurvey. Note: The word "Firefox" should NOT be translated. -->
-    <string name="microsurvey_prompt_homepage_title" tools:ignore="BrandUsage,UnusedResources" moz:removedIn="130">¿Estás satisfecho con la página de inicio de Firefox?</string>
     <!-- Text shown in prompt for printing microsurvey. "sec" It's an abbreviation for "second". Note: The word "Firefox" should NOT be translated. -->
     <string name="microsurvey_prompt_printing_title" tools:ignore="BrandUsage,UnusedResources">Ayuda a mejorar la impresión en Firefox. Solo te llevará un segundo</string>
     <!-- Text shown in prompt for search microsurvey. Note: The word "Firefox" should NOT be translated. -->
@@ -2856,8 +2809,6 @@
     <string name="microsurvey_app_icon_content_description" tools:ignore="BrandUsage">Logo de Firefox</string>
     <!-- Content description for the survey feature icon. -->
     <string name="microsurvey_feature_icon_content_description">Ícono de la funcionalidad de encuesta</string>
-    <!-- Content description (not visible, for screen readers etc.) for opening microsurvey bottom sheet. -->
-    <string name="microsurvey_open_handle_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Abrir encuesta</string>
     <!-- Content description (not visible, for screen readers etc.) for closing microsurvey bottom sheet. -->
     <string name="microsurvey_close_handle_content_description">Cerrar encuesta</string>
     <!-- Content description for "X" button that is closing microsurvey. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-et/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-et/strings.xml
@@ -313,14 +313,6 @@
     <string name="onboarding_home_content_description_close_button">Sulge</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Teavitused aitavad %siga rohkem ära teha</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Sünkrooni kaarte seadmete vahel, halda allalaadimisi ning hangi näpunäiteid %si privaatsuskaitse maksimaalse kasutamise kohta ja palju muud.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Jätka</string>
 
     <!-- Search Widget -->
     <!-- Content description for searching with a widget. The first parameter is the name of the application.-->
@@ -399,8 +391,6 @@
     <string name="preferences_override_sync_tokenserver">Kohandatud sünkroonimise server</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">Konto</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">Tööriistariba</string>
     <!-- Preference for changing default theme to dark or light mode -->
     <string name="preferences_theme">Teema</string>
     <!-- Preference for customizing the home screen -->
@@ -600,8 +590,6 @@
     <!-- Preference for using the dynamic toolbar -->
     <string name="preference_gestures_dynamic_toolbar">Kerimisel tööriistariba peidetakse</string>
 
-    <!-- Preference for switching tabs by swiping horizontally on the toolbar -->
-    <string name="preference_gestures_swipe_toolbar_switch_tabs" moz:removedIn="129" tools:ignore="UnusedResources">Tööriistaribal küljele libistamisel vahetatakse kaarte</string>
     <!-- Preference for showing the opened tabs by swiping up on the toolbar-->
     <string name="preference_gestures_swipe_toolbar_show_tabs">Üles libistamisel avatakse kaarte</string>
 
@@ -764,8 +752,6 @@
     <string name="collection_open_tabs">Ava kaardid</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Kollektsiooni nimi</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Muuda nime</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Eemalda</string>
 
@@ -1121,8 +1107,6 @@
     <string name="tab_collection_dialog_message">Kas oled kindel, et soovid kustutada kollektsiooni %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Kustuta</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Täisekraanirežiimi sisenemine</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL kopeeritud</string>
     <!-- Sample text for accessibility font size -->
@@ -1670,8 +1654,6 @@
     <string name="top_sites_rename_dialog_title">Nimi</string>
     <!-- Hint for renaming title of a shortcut -->
     <string name="shortcut_name_hint">Otsetee nimi</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">Olgu</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Loobu</string>
     <!-- Text for the menu button to open the homepage settings. -->
@@ -1711,8 +1693,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Rohkema teabe jaoks puuduta</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Liigu üles</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Sulge</string>

--- a/mozilla-mobile/fenix/app/src/main/res/values-hr/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-hr/strings.xml
@@ -111,8 +111,6 @@
     <string name="navbar_cfr_title">Pregledavajte brže s novom navigacijom</string>
 
     <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-    <string name="navbar_cfr_message" moz:removedIn="130" tools:ignore="UnusedResources">Ova traka se uvlači dok se pomičete prema dolje kako biste imali više prostora za pregledavanje.</string>
-    <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_message_2">Kod pregledavanja web-stranica, ova traka se uvlači dok se pomičete prema dolje kako biste imali više prostora za pregledavanje.</string>
 
     <!-- Text for the message displayed for the popup promoting the long press of navigation in the navigation bar. -->
@@ -423,16 +421,6 @@
     <string name="onboarding_home_content_description_close_button">Zatvori</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Obavijesti ti pomažu uraditi više s aplikacijom %s</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Sinkroniziraj svoje kartice između uređaja, upravljaj preuzimanjima, dobivaj savjete o tome kako najbolje iskoristiti %s zaštitu privatnosti i još mnogo toga.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Nastavi</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Ne sada</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -1120,8 +1108,6 @@
 
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Naziv zbirke</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Preimenuj</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Ukloni</string>
 
@@ -1466,16 +1452,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">Zatvori privatne kartice</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">Neutralno</string>
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">Vrlo nezadovoljan/na</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">Nezadovoljan/na</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">Zadovoljan/na</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">Vrlo zadovoljan/na</string>
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
     <string name="notification_erase_title_android_14">Zatvoriti privatne kartice?</string>
@@ -1555,8 +1531,6 @@
     <string name="tab_collection_dialog_message">Sigurno želiš izbrisati %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Izbriši</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Pokretanje cjeloekranskog prikaza</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL je kopiran</string>
     <!-- Sample text for accessibility font size -->
@@ -2214,8 +2188,6 @@
     <string name="shortcut_name_hint">Ime prečaca</string>
     <!-- Hint for editing URL of a shortcut. -->
     <string name="shortcut_url_hint">URL prečaca</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">U redu</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Odustani</string>
 
@@ -2280,8 +2252,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Klikni za više informacija</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Navigiraj gore</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Zatvori</string>
@@ -2414,8 +2384,6 @@
     <string name="review_quality_check_second_cfr_message">Jesu li ove recenzije pouzdane? Provjeri sada za prikaz prilagođene ocjene.</string>
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" tools:ignore="UnusedResources">Otvori provjeru recenzija</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
 
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">Otvori provjeru recenzija</string>
@@ -2612,8 +2580,6 @@
     <string name="never_translate_site_dialog_cancel_preference">Odustani</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">Preuzmi jezike</string>
     <!-- Title of the toolbar for the translation feature screen where users may download different languages for translation. -->
     <string name="download_languages_translations_toolbar_title_preference">Preuzmi jezike</string>
 
@@ -2671,13 +2637,6 @@
     <!-- Button text on the dialog used by the translations feature to cancel deleting a language. -->
     <string name="delete_language_file_dialog_negative_button_text">Odustani</string>
 
-    <!-- Title for the dialog used by the translations feature to confirm canceling a download in progress for a language file.
-    The first parameter is the name of the language, for example, "Spanish". -->
-    <string name="cancel_download_language_file_dialog_title" moz:removedIn="130" tools:ignore="UnusedResources">Prekinuti preuzimanje za %1$s?</string>
-    <!-- Button text on the dialog used by the translations feature confirms canceling a download in progress for a language file. -->
-    <string name="cancel_download_language_file_dialog_positive_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Da</string>
-    <!-- Button text on the dialog used by the translations feature to dismiss the dialog. -->
-    <string name="cancel_download_language_file_negative_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Ne</string>
 
     <!-- Title for the data saving mode warning dialog used by the translations feature.
     This dialog will be presented when the user attempts to download a language or perform
@@ -2769,8 +2728,6 @@
     <string name="likert_scale_option_6" tools:ignore="UnusedResources">Ne koristim je</string>
     <!-- Option for likert scale. Note: The word "Firefox" should NOT be translated. -->
     <string name="likert_scale_option_7" tools:ignore="BrandUsage,UnusedResources">Ne koristim pretragu na Firefoxu</string>
-    <!-- Text shown in prompt for homepage microsurvey. Note: The word "Firefox" should NOT be translated. -->
-    <string name="microsurvey_prompt_homepage_title" tools:ignore="BrandUsage,UnusedResources" moz:removedIn="130">Koliko si zadovoljan/na sa svojom početnom Firefox stranicom?</string>
     <!-- Text shown in prompt for printing microsurvey. "sec" It's an abbreviation for "second". Note: The word "Firefox" should NOT be translated. -->
     <string name="microsurvey_prompt_printing_title" tools:ignore="BrandUsage,UnusedResources">Pomogni nam poboljšati Firefox. Traje samo jednu sekundu</string>
     <!-- Text shown in the survey title for printing microsurvey. Note: The word "Firefox" should NOT be translated. -->
@@ -2784,8 +2741,6 @@
     <string name="microsurvey_app_icon_content_description" tools:ignore="BrandUsage">Firefox logotip</string>
     <!-- Content description for the survey feature icon. -->
     <string name="microsurvey_feature_icon_content_description">Ikona funkcije ankete</string>
-    <!-- Content description (not visible, for screen readers etc.) for opening microsurvey bottom sheet. -->
-    <string name="microsurvey_open_handle_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Otvori anketu</string>
     <!-- Content description (not visible, for screen readers etc.) for closing microsurvey bottom sheet. -->
     <string name="microsurvey_close_handle_content_description">Zatvori anketu</string>
     <!-- Content description for "X" button that is closing microsurvey. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-in/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-in/strings.xml
@@ -110,8 +110,6 @@
     <!-- Text for the title displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_title">Jelajahi lebih cepat dengan navigasi baru</string>
     <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-    <string name="navbar_cfr_message" moz:removedIn="130" tools:ignore="UnusedResources">Bilah ini terselip saat Anda menggulir ke bawah untuk ruang penjelajahan ekstra.</string>
-    <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_message_2">Di situs web, bilah ini terselip saat Anda menggulir ke bawah untuk ruang penjelajahan tambahan.</string>
     <!-- Text for the message displayed for the popup promoting the long press of navigation in the navigation bar. -->
     <string name="navbar_navigation_buttons_cfr_message">Ketuk dan tahan panah untuk berpindah antar laman dalam riwayat tab ini.</string>
@@ -334,16 +332,6 @@
     <string name="onboarding_home_content_description_close_button">Tutup</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Notifikasi membantu Anda lakukan lebih banyak hal dengan %s</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Sinkronkan tab Anda antar perangkat, kelola unduhan, dapatkan kiat tentang memanfaatkan perlindungan privasi %s, dan banyak lagi.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Lanjutkan</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Jangan sekarang</string>
 
     <!-- Description for set firefox as default browser screen used by Nimbus experiments. -->
     <string name="juno_onboarding_default_browser_description_nimbus_5" tools:ignore="UnusedResources">Pelacak yang dikenal? Diblokir secara otomatis. Ekstensi? Coba semua 700. PDF? Pembaca bawaan kami membuatnya mudah dikelola.</string>
@@ -527,8 +515,6 @@
     <string name="preferences_override_sync_tokenserver">Penyedia Sync khusus</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">Akun</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">Bilah alat</string>
     <!-- Preference for changing default theme to dark or light mode -->
     <string name="preferences_theme">Tema</string>
     <!-- Preference for customizing the home screen -->
@@ -769,8 +755,6 @@
     <string name="preference_gestures_website_pull_to_refresh">Tarik untuk menyegarkan</string>
     <!-- Preference for using the dynamic toolbar -->
     <string name="preference_gestures_dynamic_toolbar">Gulir untuk menyembunyikan bilah alat</string>
-    <!-- Preference for switching tabs by swiping horizontally on the toolbar -->
-    <string name="preference_gestures_swipe_toolbar_switch_tabs" moz:removedIn="129" tools:ignore="UnusedResources">Geser bilah alat ke samping untuk beralih tab</string>
     <!-- Preference for showing the opened tabs by swiping up on the toolbar-->
     <string name="preference_gestures_swipe_toolbar_show_tabs">Geser bilah alat ke atas untuk membuka tab</string>
 
@@ -957,8 +941,6 @@
 
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Nama koleksi</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Ubah nama</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Hapus</string>
 
@@ -1359,8 +1341,6 @@
     <string name="tab_collection_dialog_message">Yakin ingin menghapus %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Hapus</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Memasuki mode layar penuh</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL disalin</string>
     <!-- Sample text for accessibility font size -->
@@ -1925,8 +1905,6 @@
     <string name="top_sites_rename_dialog_title">Nama</string>
     <!-- Hint for renaming title of a shortcut -->
     <string name="shortcut_name_hint">Nama pintasan</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">OK</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Batal</string>
 
@@ -1977,8 +1955,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Klik untuk lebih jelasnya</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Arahkan ke atas</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Tutup</string>

--- a/mozilla-mobile/fenix/app/src/main/res/values-ka/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ka/strings.xml
@@ -290,16 +290,6 @@
     <string name="onboarding_home_content_description_close_button">დახურვა</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">შეტყობინებებით შეძლებთ, უკეთ გამოიყენოთ %s</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">დაასინქრონეთ ჩანართები მოწყობილობებს შორის, მართეთ ჩამოტვირთვები, მიიღეთ რჩევები, როგორ გამოიყენოთ %s სრულყოფილად პირადულობის დაცვით და ა.შ.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">განაგრძეთ</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">ახლა არა</string>
 
     <!-- Title for set firefox as default browser screen used by Nimbus experiments. -->
     <string name="juno_onboarding_default_browser_title_nimbus_2">ჩვენ ვზრუნავთ თქვენს უსაფრთხოებაზე</string>
@@ -481,8 +471,6 @@
     <string name="toast_override_account_sync_server_done">Mozilla-ანგარიშის/სინქრონიზაციის სერვერი შეიცვალა. პროგრამა დაიხურება ცვლილებების ასახვისთვის…</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">ანგარიში</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">ხელსაწყოთა ზოლი</string>
     <!-- Preference for changing default theme to dark or light mode -->
     <string name="preferences_theme">თემა</string>
     <!-- Preference for customizing the home screen -->
@@ -727,8 +715,6 @@
     <!-- Preference for using the dynamic toolbar -->
     <string name="preference_gestures_dynamic_toolbar">გადაადგილებისას ხელსაწყოთა დამალვა</string>
 
-    <!-- Preference for switching tabs by swiping horizontally on the toolbar -->
-    <string name="preference_gestures_swipe_toolbar_switch_tabs" moz:removedIn="129" tools:ignore="UnusedResources">ხელსაწყოთა ზოლზე გასმით, ჩანართებზე გადასვლა</string>
     <!-- Preference for showing the opened tabs by swiping up on the toolbar-->
     <string name="preference_gestures_swipe_toolbar_show_tabs">აუსვით ხელსაწყოთა ზოლზე ჩანართების გახსნისთვის</string>
 
@@ -1310,8 +1296,6 @@
     <string name="tab_collection_dialog_message">ნამდვილად გსურთ, წაიშალოს %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">წაშლა</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">სრულ ეკრანზე გაშლა</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL-ს ასლი აღებულია</string>
     <!-- Sample text for accessibility font size -->
@@ -1936,8 +1920,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">დაწკაპეთ ვრცლად სანახავად</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">ზემოთ გადასვლა</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">დახურვა</string>

--- a/mozilla-mobile/fenix/app/src/main/res/values-kn/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-kn/strings.xml
@@ -340,8 +340,6 @@
     <string name="history_delete_multiple_items_snackbar">ಇತಿಹಾಸವನ್ನು ಅಳಿಸಲಾಗಿದೆ</string>
     <!-- Text for the snackbar to confirm that a single browsing history item has been deleted. The first parameter is the shortened URL of the deleted history item. -->
     <string name="history_delete_single_item_snackbar">%1$s ಅಳಿಸಲಾಗಿದೆ</string>
-    <!-- Text for the button to delete a single history item -->
-    <string moz:removedIn="94" name="history_delete_item" tools:ignore="UnusedResources">ಅಳಿಸು</string>
     <!-- History multi select title in app bar
     The first parameter is the number of bookmarks selected -->
     <string name="history_multi_select_title">%1$d ಆಯ್ಕೆ ಮಾಡಲಾಗಿದೆ</string>

--- a/mozilla-mobile/fenix/app/src/main/res/values-meh/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-meh/strings.xml
@@ -358,13 +358,6 @@
     <string name="onboarding_home_content_description_close_button">Nakasɨ</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Daa notificaciones chineí sá´ánu kue\'eka jíí %s</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Kɨ´ɨ</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Nkuvi ntañu´u</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -523,8 +516,6 @@
     <string name="preferences_override_sync_tokenserver">Servidor personalizado de Sync</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">Cuenta</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">Barra daa ka̱a̱</string>
     <!-- Preference for changing default theme to dark or light mode -->
     <string name="preferences_theme">Tema</string>
     <!-- Preference for customizing the home screen -->
@@ -983,8 +974,6 @@
     <string name="collection_open_tabs">Síne pestañas</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Sivɨ colección</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Natee</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Xita</string>
     <!-- Text for the menu button to delete a top site from history -->
@@ -1309,8 +1298,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">Nakasɨ daa pestañas yu´u</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">Neutral</string>
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
     <string name="notification_erase_title_android_14">Nakasɨ daa pestañas yu´u?</string>
@@ -1388,8 +1375,6 @@
     <string name="tab_collection_dialog_message">¿A mana kuvinu xitanu %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Xita</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Kivunɨ nu pantalla ka´nu</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL ntɨɨn</string>
     <!-- Sample text for accessibility font size -->
@@ -1993,8 +1978,6 @@
     <string name="shortcut_name_hint">Sivɨ acceso ñama</string>
     <!-- Hint for editing URL of a shortcut. -->
     <string name="shortcut_url_hint">Da acceso ñama</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">Kuvi</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Nkuvi-ka</string>
     <!-- Text for the menu button to open the homepage settings. -->
@@ -2052,8 +2035,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Kaxin sa kuninu detalles</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Kaka íchi sikɨ</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Nakasɨ</string>
@@ -2165,8 +2146,6 @@
     <string name="review_quality_check_second_cfr_message">¿A kanijianu da revisiones ya\'a? Kune\'ya ntañu\'u sa kuninu iin calificación ajustada.</string>
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" tools:ignore="UnusedResources">Síne verificador reseñas</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">Síne verificador reseñas</string>
     <!-- Content description (not visible, for screen readers etc.) for closing browser menu button to open review quality check bottom sheet. -->
@@ -2253,8 +2232,6 @@
     <string name="never_translate_site_dialog_cancel_preference">Nkuvi-ka</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">Xinuu daa tu\'un</string>
     <!-- Title of the toolbar for the translation feature screen where users may download different languages for translation. -->
     <string name="download_languages_translations_toolbar_title_preference">Xinuu daa tu\'un</string>
     <!-- Clickable text from the screen header that links to a website. -->
@@ -2292,10 +2269,6 @@
     <!-- Button text on the dialog used by the translations feature to cancel deleting a language. -->
     <string name="delete_language_file_dialog_negative_button_text">Nkuvi-ka</string>
 
-    <!-- Button text on the dialog used by the translations feature confirms canceling a download in progress for a language file. -->
-    <string name="cancel_download_language_file_dialog_positive_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Kuvi</string>
-    <!-- Button text on the dialog used by the translations feature to dismiss the dialog. -->
-    <string name="cancel_download_language_file_negative_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Nkuvi</string>
 
     <!-- Button text on the data saving mode warning dialog used by the translations feature to allow users to confirm they wish to continue and download the language file. -->
     <string name="download_language_file_dialog_positive_button_text">Xinuu</string>
@@ -2327,8 +2300,6 @@
 
     <!-- The continue button label -->
     <string name="micro_survey_continue_button_label" tools:ignore="UnusedResources">Kɨ´ɨ</string>
-    <!-- The privacy notice link -->
-    <string name="micro_survey_privacy_notice" moz:removedIn="129" tools:ignore="UnusedResources">Tu´un xitu a nejika kumio</string>
 
     <!-- The submit button label text -->
     <string name="micro_survey_submit_button_label">Chu\'un íchi</string>
@@ -2338,8 +2309,6 @@
     <!-- Accessibility -->
     <!-- Content description for the survey application icon. Note: The word "Firefox" should NOT be translated.  -->
     <string name="microsurvey_app_icon_content_description">Logo de Firefox</string>
-    <!-- Content description (not visible, for screen readers etc.) for opening microsurvey bottom sheet. -->
-    <string name="microsurvey_open_handle_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Síne encuesta</string>
     <!-- Content description (not visible, for screen readers etc.) for closing microsurvey bottom sheet. -->
     <string name="microsurvey_close_handle_content_description">Nakasɨ encuesta</string>
     <!-- Content description for "X" button that is closing microsurvey. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-nb-rNO/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-nb-rNO/strings.xml
@@ -108,8 +108,6 @@
     <!-- Text for the title displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_title">Surf raskere med ny navigasjon</string>
 
-    <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-    <string name="navbar_cfr_message" moz:removedIn="130" tools:ignore="UnusedResources">Denne linjen skjules når du ruller nedover for å gi ekstra visningsplass.</string>
 
     <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_message_2">På et nettsted skjules denne linjen når du ruller nedover for å gi ekstra visningsplass.</string>
@@ -428,17 +426,7 @@
     <string name="onboarding_home_content_description_close_button">Lukk</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Varsler hjelper deg å gjøre mer med %s</string>
 
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Synkroniser fanene dine mellom enheter, behandle nedlastinger, få tips om hvordan du får mest mulig ut av %s sitt personvern, og mer.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Fortsett</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Ikke nå</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -1131,8 +1119,6 @@
     <string name="collection_open_tabs">Åpne faner</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Samlingsnavn</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Endre navn</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Fjern</string>
 
@@ -1280,8 +1266,6 @@
     <string name="bookmark_navigate_back_button_content_description">Naviger tilbake</string>
     <!-- Content description for the bookmark list new folder navigation bar button -->
     <string name="bookmark_add_new_folder_button_content_description">Legg til en ny mappe</string>
-    <!-- Content description for the bookmark navigation bar close button -->
-    <string name="bookmark_close_button_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Lukk bokmerker</string>
     <!-- Content description for bookmark search floating action button -->
     <string name="bookmark_search_button_content_description">Søk i bokmerker</string>
     <!-- Content description for the overflow menu for a bookmark item. Paramter will a folder name or bookmark title. -->
@@ -1486,16 +1470,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">Lukk private faner</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">Nøytral</string>
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">Veldig misfornøyd</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">Misfornøyd</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">Fornøyd</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">Veldig fornøyd</string>
 
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
@@ -1576,8 +1550,6 @@
     <string name="tab_collection_dialog_message">Er du sikker på at du vil slette %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Slett</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Starter fullskjermmodus</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL kopiert</string>
 
@@ -2251,8 +2223,6 @@
     <string name="shortcut_name_hint">Navn på snarvei</string>
     <!-- Hint for editing URL of a shortcut. -->
     <string name="shortcut_url_hint">URL for snarvei</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">OK</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Avbryt</string>
 
@@ -2317,8 +2287,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Trykk her for mer informasjon</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Naviger opp</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Lukk</string>
@@ -2480,8 +2448,6 @@
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" moz:removedIn="132" tools:ignore="UnusedResources">Åpne vurderingskontrollør</string>
 
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">Åpne vurderingskontrolløren</string>
     <!-- Content description (not visible, for screen readers etc.) for closing browser menu button to open review quality check bottom sheet. -->
@@ -2671,8 +2637,6 @@
     <string name="never_translate_site_dialog_cancel_preference">Avbryt</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">Last ned språk</string>
     <!-- Title of the toolbar for the translation feature screen where users may download different languages for translation. -->
     <string name="download_languages_translations_toolbar_title_preference">Last ned språk</string>
     <!-- Screen header presenting the download language preference feature. It will appear under the toolbar.The first parameter is "Learn More," a clickable text with a link. Talkback will append this to say "Double tap to open link to learn more". -->
@@ -2730,14 +2694,7 @@
     <!-- Button text on the dialog used by the translations feature to cancel deleting a language. -->
     <string name="delete_language_file_dialog_negative_button_text">Avbryt</string>
 
-    <!-- Title for the dialog used by the translations feature to confirm canceling a download in progress for a language file.
-    The first parameter is the name of the language, for example, "Spanish". -->
-    <string name="cancel_download_language_file_dialog_title" moz:removedIn="130" tools:ignore="UnusedResources">Avbryte nedlastingen av %1$s?</string>
-    <!-- Button text on the dialog used by the translations feature confirms canceling a download in progress for a language file. -->
-    <string name="cancel_download_language_file_dialog_positive_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Ja</string>
 
-    <!-- Button text on the dialog used by the translations feature to dismiss the dialog. -->
-    <string name="cancel_download_language_file_negative_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Nei</string>
 
     <!-- Title for the data saving mode warning dialog used by the translations feature.
     This dialog will be presented when the user attempts to download a language or perform
@@ -2834,8 +2791,6 @@
     <string name="likert_scale_option_7" tools:ignore="BrandUsage,UnusedResources">Jeg bruker ikke søk på Firefox</string>
     <!-- Option for likert scale -->
     <string name="likert_scale_option_8" tools:ignore="UnusedResources">Jeg bruker ikke synkronisering</string>
-    <!-- Text shown in prompt for homepage microsurvey. Note: The word "Firefox" should NOT be translated. -->
-    <string name="microsurvey_prompt_homepage_title" tools:ignore="BrandUsage,UnusedResources" moz:removedIn="130">Hvor fornøyd er du med din Firefox-startside?</string>
     <!-- Text shown in prompt for printing microsurvey. "sec" It's an abbreviation for "second". Note: The word "Firefox" should NOT be translated. -->
     <string name="microsurvey_prompt_printing_title" tools:ignore="BrandUsage,UnusedResources">Bidra til å gjøre utskrifter i Firefox bedre. Det tar bare et sekund</string>
     <!-- Text shown in the survey title for printing microsurvey. Note: The word "Firefox" should NOT be translated. -->
@@ -2851,8 +2806,6 @@
     <string name="microsurvey_app_icon_content_description" tools:ignore="BrandUsage">Firefox-logo</string>
     <!-- Content description for the survey feature icon. -->
     <string name="microsurvey_feature_icon_content_description">Ikon for undersøkelsesfunksjon</string>
-    <!-- Content description (not visible, for screen readers etc.) for opening microsurvey bottom sheet. -->
-    <string name="microsurvey_open_handle_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Åpen undersøkelse</string>
     <!-- Content description (not visible, for screen readers etc.) for closing microsurvey bottom sheet. -->
     <string name="microsurvey_close_handle_content_description">Lukk undersøkelse</string>
     <!-- Content description for "X" button that is closing microsurvey. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-pa-rPK/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-pa-rPK/strings.xml
@@ -114,8 +114,6 @@
     <string name="navbar_cfr_title">نویں نیویگیشن نال ودھ تیزی نال براؤز کرو</string>
 
     <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-    <string name="navbar_cfr_message" moz:removedIn="130" tools:ignore="UnusedResources">وادھو براؤز کرن لئی تھاں بݨاوݨ واسطے سکرول کرن دے دوران ایہہ پٹی پاسے کر دتی جاندی اے۔</string>
-    <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_message_2">ویب‌سائیٹ تے وادھو براؤز کرن لئی تھاں بݨاوݨ واسطے سکرول کرن دے دوران ایس پٹی نوں پاسے کر دتا جاندا اے۔</string>
     <!-- Text for the message displayed for the popup promoting the long press of navigation in the navigation bar. -->
     <string name="navbar_navigation_buttons_cfr_message">ایس ٹیب دے واسطے وچلے صفحیاں چ جاݨ لئی تیر دے نشاناں نوں چھوہ کے رکھو۔</string>
@@ -414,16 +412,6 @@
     <string name="onboarding_home_content_description_close_button">بند کرو</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">اطلاعواں تہانوں %s نال ہور کرن دی مدد کردے ہن</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">ڈوائیساں وچالے آپݨیاں ٹیباں نوں ہم وقت کرو، ڈاؤن‌لوڈ دا انتظام کرو، %s  ایپ دی پردہ داری سرکھیا دا پورا فائدہ لیݨ لئی گر لوو تے ہور۔</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">جاری رکھو</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">ہݨے نہیں</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -626,8 +614,6 @@
     <string name="toast_override_account_sync_server_done">موزیلا کھاتا/سنک سرور نوں سودھیا گیا اے۔ تبدیلیاں لاگو کرن واسطے ایپلیکیشن نوں بند کیتا جا رہا اے…</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">کھاتہ</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">سند پٹی</string>
     <!-- Preference for changing where the AddressBar is positioned -->
     <string name="preferences_toolbar_2">سرناواں پٹی دا ٹکاݨا</string>
     <!-- Preference for changing default theme to dark or light mode -->
@@ -935,8 +921,6 @@
     <string name="preference_gestures_website_pull_to_refresh">تازہ کرن لئی کھچو</string>
     <!-- Preference for using the dynamic toolbar -->
     <string name="preference_gestures_dynamic_toolbar">ٹول‌بار لکاوݨ لئی سکرول کرو</string>
-    <!-- Preference for switching tabs by swiping horizontally on the toolbar -->
-    <string name="preference_gestures_swipe_toolbar_switch_tabs" moz:removedIn="129" tools:ignore="UnusedResources">ٹیباں چ بدلݨ لئی ٹول‌بار نوں پاسے ول سرکاؤ</string>
     <!-- Preference for showing the opened tabs by swiping up on the toolbar-->
     <string name="preference_gestures_swipe_toolbar_show_tabs">ٹیباں کھولھݨ لئی ٹول‌بار تے ول سرکاؤ</string>
     <!-- Preference for using the dynamic toolbars -->
@@ -1133,8 +1117,6 @@
     <string name="collection_open_tabs">ساریاں کھولھو</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">بھنڈار دا ناں</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">ناں بدلو</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">ہٹاؤ</string>
 
@@ -1472,18 +1454,8 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">نجی ٹیباں نوں بند کرو</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">غیر جانبدار
 </string>
 
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">ڈاڈھا غیرتسلی بخش</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">غیرتسلی بخش</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">تسلی بخش</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">ڈاڈھا تسلی بخش</string>
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
     <string name="notification_erase_title_android_14">نجی ٹیباں نوں بند کرنا اے؟</string>
@@ -1766,8 +1738,6 @@
 
     <!-- Title text displayed in the rename top site dialog. -->
     <string name="top_sites_rename_dialog_title">ناں</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">ٹھیک اے</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">رد کرو</string>
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-ro/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ro/strings.xml
@@ -280,8 +280,6 @@
     <string name="preferences_override_sync_tokenserver">Server personalizat de sincronizare</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">Cont</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">Bară de unelte</string>
     <!-- Preference for changing default theme to dark or light mode -->
     <string name="preferences_theme">Temă</string>
     <!-- Preference for customizing the home screen -->
@@ -325,8 +323,6 @@
     <!-- Hint displayed on input field for custom collection name -->
     <string name="customize_addon_collection_hint">Numele colecției</string>
 
-    <!-- Title for the customize home screen section with recently saved bookmarks. -->
-    <string name="customize_toggle_recent_bookmarks" moz:removedIn="127" tools:ignore="UnusedResources">Marcaje recente</string>
     <!-- Title for the customize home screen section with recently visited. Recently visited is
     a section where users see a list of tabs that they have visited in the past few days -->
     <string name="customize_toggle_recently_visited">Vizitate recent</string>

--- a/mozilla-mobile/fenix/app/src/main/res/values-sc/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-sc/strings.xml
@@ -380,10 +380,6 @@
     <!-- Content description (not visible, for screen readers etc.): Close button for the home onboarding dialog -->
     <string name="onboarding_home_content_description_close_button">Serra</string>
 
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Sighi</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Immoe nono</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -1007,8 +1003,6 @@
     <string name="collection_open_tabs">Aberi is ischedas</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Nòmine de sa colletzione</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Torra a nominare</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Boga</string>
     <!-- Text for the menu button to delete a top site from history -->
@@ -1325,16 +1319,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">Serra is ischedas privadas</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">Indiferente</string>
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">Discuntentesa arta</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">Discuntentesa</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">Satisfatzione mèdia</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">Satisfatzione arta</string>
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
     <string name="notification_erase_title_android_14">Boles serrare is ischedas privadas?</string>
@@ -1397,8 +1381,6 @@
     <string name="tab_collection_dialog_message">Seguru chi boles cantzellare %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Cantzella</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Intrende a sa modalidade de ischermu cumpletu</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL copiadu</string>
     <!-- Title for Accessibility Text Size Scaling Preference -->
@@ -1946,8 +1928,6 @@
     <string name="shortcut_name_hint">Nòmine de su curtzadòrgiu</string>
     <!-- Hint for editing URL of a shortcut. -->
     <string name="shortcut_url_hint">URL de su curtzadòrgiu</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">AB</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Annulla</string>
     <!-- Text for the menu button to open the homepage settings. -->
@@ -2009,8 +1989,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Incarca inoghe pro àteros detàllios</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Nàviga in artu</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Serra</string>
@@ -2128,8 +2106,6 @@
     <string name="review_quality_check_first_cfr_action" tools:ignore="UnusedResources">Proa su verificadore de retzensiones</string>
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" tools:ignore="UnusedResources">Aberi su verificadore de retzensiones</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">Aberi su verificadore de retzensiones</string>
     <!-- Content description (not visible, for screen readers etc.) for closing browser menu button to open review quality check bottom sheet. -->
@@ -2247,8 +2223,6 @@
     <string name="never_translate_site_dialog_cancel_preference">Annulla</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">Iscàrriga lìnguas</string>
     <!-- Clickable text from the screen header that links to a website. -->
     <string name="download_languages_header_learn_more_preference">Àteras informatziones</string>
     <!-- The subhead of the download language preference screen will appear above the pivot language. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-si/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-si/strings.xml
@@ -371,16 +371,6 @@
     <string name="onboarding_home_content_description_close_button">වසන්න</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">%s සමඟ බොහෝ දෑ කිරීමට දැනුම්දීම් උපකාරී වේ</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">උපාංග අතර පටිති සමමුහූර්තය, බාගැනීම් කළමනාකරණය, %s පෞද්ගලිකත්‍ව රැකවරණයෙන් උපරිම ප්‍රයෝජන ගැනීමට ඉඟි, සහ තවත් බොහෝ දෑ.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">ඉදිරියට</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">දැන් නොවේ</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -558,8 +548,6 @@
     <string name="toast_override_account_sync_server_done">මොසිල්ලා ගිණුම / සමමුහූර්ත සේවාදායකය වෙනස් කර ඇත. වෙනස්කම් යෙදීමට යෙදුමෙන් ඉවත් වෙමින්…</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">ගිණුම</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">මෙවලම් තීරුව</string>
     <!-- Preference for changing where the AddressBar is positioned -->
     <string name="preferences_toolbar_2">ලිපින තීරුවේ පිහිටීම</string>
     <!-- Preference for changing default theme to dark or light mode -->
@@ -853,8 +841,6 @@
     <!-- Preference for using the dynamic toolbar -->
     <string name="preference_gestures_dynamic_toolbar">මෙවලම් තීරුව සැඟවීමට අනුචලනය</string>
 
-    <!-- Preference for switching tabs by swiping horizontally on the toolbar -->
-    <string name="preference_gestures_swipe_toolbar_switch_tabs" moz:removedIn="129" tools:ignore="UnusedResources">පටිති අතර මාරුවට මෙවලම් තීරුව පැත්තට තල්ලු කිරීම</string>
     <!-- Preference for showing the opened tabs by swiping up on the toolbar-->
     <string name="preference_gestures_swipe_toolbar_show_tabs">පටිති ඇරීමට තීරුව ඉහළට තල්ලු කරන්න</string>
 
@@ -1045,8 +1031,6 @@
     <string name="collection_open_tabs">පටිති අරින්න</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">එකතුවෙහි නම</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">නම් කරන්න</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">ඉවත් කරන්න</string>
     <!-- Text for the menu button to delete a top site from history -->
@@ -1446,8 +1430,6 @@
     <string name="tab_collection_dialog_message">%1$s මකා දැමීමට වුවමනා ද?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">මකන්න</string>
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">පූර්ණ තිර ප්‍රකාරයට ඇතුල් වෙමින්</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">ඒ.ස.නි. පිටපත් විය</string>
     <!-- Sample text for accessibility font size -->
@@ -2057,8 +2039,6 @@
     <string name="top_sites_rename_dialog_title">නම</string>
     <!-- Hint for renaming title of a shortcut -->
     <string name="shortcut_name_hint">කෙටිමඟ නාමය</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">හරි</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">අවලංගු</string>
     <!-- Text for the menu button to open the homepage settings. -->
@@ -2108,8 +2088,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">වැඩි විස්තර සඳහා ඔබන්න</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">ඉහළට යාත්‍රණය</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">වසන්න</string>
@@ -2208,8 +2186,6 @@
     <string name="review_quality_check_first_cfr_action" tools:ignore="UnusedResources">සමාලෝචන සෝදිසිකරු බලන්න</string>
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" tools:ignore="UnusedResources">සමාලෝචන සෝදිසිකරු අරින්න</string>
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">සමාලෝචන සෝදිසිකරු අරින්න</string>
     <!-- Content description (not visible, for screen readers etc.) for closing browser menu button to open review quality check bottom sheet. -->
@@ -2304,8 +2280,6 @@
     <string name="never_translate_site_dialog_cancel_preference">අවලංගු</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">භාෂා බාගන්න</string>
     <!-- Clickable text from the screen header that links to a website. -->
     <string name="download_languages_header_learn_more_preference">තව දැනගන්න</string>
     <!-- The subhead of the download language preference screen will appear above the pivot language. -->
@@ -2388,11 +2362,7 @@
     <string name="micro_survey_continue_button_label" tools:ignore="UnusedResources">ඉදිරියට</string>
     <!-- Survey view -->
     <!-- The survey header -->
-    <string name="micro_survey_survey_header" moz:removedIn="129" tools:ignore="UnusedResources">මෙම සමීක්ෂණය සම්පූර්ණ කරන්න</string>
-    <!-- The survey header -->
     <string name="micro_survey_survey_header_2">කරුණාකර සමීක්ෂණය සම්පූර්ණ කරන්න</string>
-    <!-- The privacy notice link -->
-    <string name="micro_survey_privacy_notice" moz:removedIn="129" tools:ignore="UnusedResources">පෞද්ගලිකත්‍ව දැන්වීම</string>
     <!-- The privacy notice link -->
     <string name="micro_survey_privacy_notice_2">පෞද්ගලිකත්‍ව දැන්වීම</string>
     <!-- The submit button label text -->
@@ -2406,8 +2376,6 @@
     <string name="microsurvey_app_icon_content_description">ෆයර්ෆොක්ස් ලාංඡනය</string>
     <!-- Content description for the survey feature icon. -->
     <string name="microsurvey_feature_icon_content_description">සමීක්ෂණ විශේෂාංගයේ නිරූපකය</string>
-    <!-- Content description (not visible, for screen readers etc.) for opening microsurvey bottom sheet. -->
-    <string name="microsurvey_open_handle_content_description" tools:ignore="UnusedResources" moz:removedIn="130">සමීක්ෂණය අරින්න</string>
     <!-- Content description (not visible, for screen readers etc.) for closing microsurvey bottom sheet. -->
     <string name="microsurvey_close_handle_content_description">සමීක්ෂණය වසන්න</string>
     <!-- Content description for "X" button that is closing microsurvey. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-su/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-su/strings.xml
@@ -107,8 +107,6 @@
     <!-- Text for the title displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_title">Kotéktak leuwih gancang ku navigasi anyar</string>
     <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-    <string name="navbar_cfr_message" moz:removedIn="130" tools:ignore="UnusedResources">Papan ieu bakal ngagulung nalika disorolokkeun ku anjeun pikeun nambahan widang panyungsian.</string>
-    <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
     <string name="navbar_cfr_message_2">Dina situs wéb, papan ieu ngagulung nalika anjeun nyorolokkeun ka handap pikeun nambahan widang panyungsian.</string>
     <!-- Text for the message displayed for the popup promoting the long press of navigation in the navigation bar. -->
     <string name="navbar_navigation_buttons_cfr_message">Ketok jeung tahan panah pikeun luncat antara kaca dina jujutan tab ieu.</string>
@@ -433,16 +431,6 @@
     <string name="onboarding_home_content_description_close_button">Tutup</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Iber mantuan anjeun barang gawé jeung %s</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Singkronkeun tab antarpiranti anjeun, kokolakeun undeuran, baca cara nyieun panyalindungan pripasi %s, jst.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Tuluykeun</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Moal waka</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -1146,8 +1134,6 @@
     <string name="collection_open_tabs">Buka tab</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Ngaran koléksi</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Ganti ngaran</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Piceun</string>
     <!-- Text for the menu button to delete a top site from history -->
@@ -1299,8 +1285,6 @@
     <string name="bookmark_navigate_back_button_content_description">Mundur</string>
     <!-- Content description for the bookmark list new folder navigation bar button -->
     <string name="bookmark_add_new_folder_button_content_description">Tambahkeun map anyar</string>
-    <!-- Content description for the bookmark navigation bar close button -->
-    <string name="bookmark_close_button_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Tutup tetengger</string>
     <!-- Content description for bookmark search floating action button -->
     <string name="bookmark_search_button_content_description">Paluruh tetengger</string>
     <!-- Content description for the overflow menu for a bookmark item. Paramter will a folder name or bookmark title. -->
@@ -1508,16 +1492,6 @@
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active. -->
     <string name="notification_pbm_delete_text_2">Tutup tab nyamuni</string>
 
-    <!-- Text for option one, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_0" tools:ignore="UnusedResources" moz:removedIn="130">Nétral</string>
-    <!-- Text for option two, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_1" tools:ignore="UnusedResources" moz:removedIn="130">Kacida teu sugema</string>
-    <!-- Text for option three, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_2" tools:ignore="UnusedResources" moz:removedIn="130">Teu sugema</string>
-    <!-- Text for option four, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_3" tools:ignore="UnusedResources" moz:removedIn="130">Sugema</string>
-    <!-- Text for option five, shown in microsurvey.-->
-    <string name="microsurvey_survey_5_point_option_4" tools:ignore="UnusedResources" moz:removedIn="130">Puas pisan</string>
 
 
     <!-- Text shown in the notification that pops up to remind the user that a private browsing session is active for Android 14+ -->
@@ -1601,8 +1575,6 @@
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Pupus</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Asup ka mode layar pinuh</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL ditiron</string>
     <!-- Sample text for accessibility font size -->
@@ -2281,8 +2253,6 @@
     <string name="shortcut_name_hint">Ngaran takulan</string>
     <!-- Hint for editing URL of a shortcut. -->
     <string name="shortcut_url_hint">Panarabas URL</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">Heug</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Bolay</string>
 
@@ -2348,8 +2318,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Pencét sangkan leuwih écés</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Pindah ka luhur</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Tutup</string>
@@ -2511,8 +2479,6 @@
     <!-- Text displayed in the second CFR presenting the review quality check feature that opens the review checker when clicked. -->
     <string name="review_quality_check_second_cfr_action" tools:ignore="UnusedResources">Buka pamariksa ténjoan</string>
 
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
 
     <!-- Content description (not visible, for screen readers etc.) for opening browser menu button to open review quality check bottom sheet. -->
     <string name="review_quality_check_open_handle_content_description">Buka pamariksa ténjoan</string>
@@ -2700,8 +2666,6 @@
     <string name="never_translate_site_dialog_cancel_preference">Bolay</string>
 
     <!-- Download languages preference screen -->
-    <!-- Title of the download languages preference screen toolbar.-->
-    <string name="download_languages_toolbar_title_preference" moz:removedIn="130" tools:ignore="UnusedResources">Undeur Basa-basa</string>
     <!-- Title of the toolbar for the translation feature screen where users may download different languages for translation. -->
     <string name="download_languages_translations_toolbar_title_preference">Undeur basa-basa</string>
     <!-- Screen header presenting the download language preference feature. It will appear under the toolbar.The first parameter is "Learn More," a clickable text with a link. Talkback will append this to say "Double tap to open link to learn more". -->
@@ -2760,13 +2724,6 @@
     <!-- Button text on the dialog used by the translations feature to cancel deleting a language. -->
     <string name="delete_language_file_dialog_negative_button_text">Bolay</string>
 
-    <!-- Title for the dialog used by the translations feature to confirm canceling a download in progress for a language file.
-    The first parameter is the name of the language, for example, "Spanish". -->
-    <string name="cancel_download_language_file_dialog_title" moz:removedIn="130" tools:ignore="UnusedResources">Bolaykeun %1$s ngundeur?</string>
-    <!-- Button text on the dialog used by the translations feature confirms canceling a download in progress for a language file. -->
-    <string name="cancel_download_language_file_dialog_positive_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Enya</string>
-    <!-- Button text on the dialog used by the translations feature to dismiss the dialog. -->
-    <string name="cancel_download_language_file_negative_button_text" moz:removedIn="130" tools:ignore="UnusedResources">Ulah</string>
 
     <!-- Title for the data saving mode warning dialog used by the translations feature.
     This dialog will be presented when the user attempts to download a language or perform
@@ -2864,8 +2821,6 @@
     <string name="likert_scale_option_7" tools:ignore="BrandUsage,UnusedResources">Kuring teu maké panyungsi dina Firefox</string>
     <!-- Option for likert scale -->
     <string name="likert_scale_option_8" tools:ignore="UnusedResources">Kuring teu maké singkronisasi</string>
-    <!-- Text shown in prompt for homepage microsurvey. Note: The word "Firefox" should NOT be translated. -->
-    <string name="microsurvey_prompt_homepage_title" tools:ignore="BrandUsage,UnusedResources" moz:removedIn="130">Kumaha kasugemaan anjeun kana kaca utama Firefox?</string>
     <!-- Text shown in prompt for printing microsurvey. "sec" It's an abbreviation for "second". Note: The word "Firefox" should NOT be translated. -->
     <string name="microsurvey_prompt_printing_title" tools:ignore="BrandUsage,UnusedResources">Bantuan sangkan Firefox bisa nyitak leuwih hadé. Ngan perlu sakolépat</string>
     <!-- Text shown in prompt for search microsurvey. Note: The word "Firefox" should NOT be translated. -->
@@ -2885,8 +2840,6 @@
     <string name="microsurvey_app_icon_content_description" tools:ignore="BrandUsage">Logo Firefox</string>
     <!-- Content description for the survey feature icon. -->
     <string name="microsurvey_feature_icon_content_description">Ikon fitur survéy</string>
-    <!-- Content description (not visible, for screen readers etc.) for opening microsurvey bottom sheet. -->
-    <string name="microsurvey_open_handle_content_description" tools:ignore="UnusedResources" moz:removedIn="130">Buka survéy</string>
     <!-- Content description (not visible, for screen readers etc.) for closing microsurvey bottom sheet. -->
     <string name="microsurvey_close_handle_content_description">Tutup Survéy</string>
     <!-- Content description for "X" button that is closing microsurvey. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-te/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-te/strings.xml
@@ -213,10 +213,6 @@
     <!-- Content description (not visible, for screen readers etc.): Close button for the home onboarding dialog -->
     <string name="onboarding_home_content_description_close_button">మూసివేయి</string>
 
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">కొనసాగించు</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">ఇప్పుడు కాదు</string>
 
     <!-- Text for the button dismiss the screen and move on with the flow -->
     <string name="juno_onboarding_default_browser_negative_button" tools:ignore="UnusedResources">ఇప్పుడు కాదు</string>
@@ -618,8 +614,6 @@
     <string name="collection_open_tabs">ట్యాబులను తెరువు</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">సేకరణ పేరు</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">పేరుమార్చు</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">తీసివేయి</string>
 
@@ -957,8 +951,6 @@
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">తొలగించు</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">నిండు తెర రీతిలోకి వెళ్తున్నారు</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL కాపీ అయ్యింది</string>
     <!-- Sample text for accessibility font size -->
@@ -1435,8 +1427,6 @@
 
     <!-- Title text displayed in the rename top site dialog. -->
     <string name="top_sites_rename_dialog_title">పేరు</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">సరే</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">రద్దుచేయి</string>
 
@@ -1483,8 +1473,6 @@
     <!-- Text for opt-out button from the review quality check contextual onboarding card. -->
     <string name="review_quality_check_contextual_onboarding_secondary_button_text">ఇప్పుడు కాదు</string>
 
-    <!-- Flag showing that the review quality check feature is work in progress. -->
-    <string name="review_quality_check_beta_flag" moz:removedIn="130" tools:ignore="UnusedResources">Beta</string>
     <!-- Text for minimize button from highlights card. When clicked the highlights card should reduce its size. -->
     <string name="review_quality_check_highlights_show_less">కొన్నే చూపించు</string>
     <!-- Text for maximize button from highlights card. When clicked the highlights card should expand to its full size. -->
@@ -1551,10 +1539,6 @@
     <!-- Button text on the dialog used by the translations feature to cancel deleting a language. -->
     <string name="delete_language_file_dialog_negative_button_text">రద్దుచేయి</string>
 
-    <!-- Button text on the dialog used by the translations feature confirms canceling a download in progress for a language file. -->
-    <string name="cancel_download_language_file_dialog_positive_button_text" moz:removedIn="130" tools:ignore="UnusedResources">అవును</string>
-    <!-- Button text on the dialog used by the translations feature to dismiss the dialog. -->
-    <string name="cancel_download_language_file_negative_button_text" moz:removedIn="130" tools:ignore="UnusedResources">కాదు</string>
 
     <!-- Button text on the data saving mode warning dialog used by the translations feature to allow users to cancel the action and not perform a download of the language file. -->
     <string name="download_language_file_dialog_negative_button_text">రద్దుచేయి</string>

--- a/mozilla-mobile/fenix/app/src/main/res/values-trs/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-trs/strings.xml
@@ -276,16 +276,6 @@
     <string name="onboarding_home_content_description_close_button">Nārán</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Gā’hue rūgûñu’ūnj nej nuguan’ rugui’ nan da’ nūtà’t doj sa gī’hiát riña %s</string>
-    <!-- Enable notification pre permission dialog description with rationale
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_description" moz:removedIn="124" tools:ignore="UnusedResources">Nāgi’hiaj nūguan’àn nej rakïj ñanj huā riña nej si āgâ’t, ni’hiāj nej nuguan’ huāa da’ gā’hue gāchē nu huìt riña %s’ nī nej doj sa huaa.</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Guij ne\' ñaan</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Sī ga\'hue akuan\' nïn</string>
 
     <!-- Text for the link to the privacy notice webpage for set as firefox default browser screen.
     This is part of the string with the key "juno_onboarding_default_browser_description". -->
@@ -412,8 +402,6 @@
     <string name="preferences_override_sync_tokenserver">Servidor nagi\'iaj man\'ânt riña Sync</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">Kuênta</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">Dukuán nikāj sa gārāsun\'</string>
 
     <!-- Preference for changing default theme to dark or light mode -->
     <string name="preferences_theme">Têma</string>
@@ -648,8 +636,6 @@
 
     <!-- Preference for using the dynamic toolbar -->
     <string name="preference_gestures_dynamic_toolbar">Dūsiki’ da’ nāhuin huì dukuán sa màn rasūun</string>
-    <!-- Preference for switching tabs by swiping horizontally on the toolbar -->
-    <string name="preference_gestures_swipe_toolbar_switch_tabs" moz:removedIn="129" tools:ignore="UnusedResources">Dūguaché ānèj ané dukuán màn rasūun da’ gā’hue nādunā rakïj ñanj</string>
     <!-- Preference for showing the opened tabs by swiping up on the toolbar-->
     <string name="preference_gestures_swipe_toolbar_show_tabs">Dūguaché nāhuī dukuán màn rasūun da’ gā’hue nā’nï̄nt rakïj ñanj</string>
 
@@ -1238,8 +1224,6 @@
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Nādūre\'</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Hiàj nanunj da\' huā ngè riña aga\'a</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">Ngà naka URL</string>
     <!-- Sample text for accessibility font size -->
@@ -1879,8 +1863,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Gā’huì’ klik da’ gīni’înt doj sa huāa</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Gāchē nun gan’ānj nāhuīt</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Nārán</string>

--- a/mozilla-mobile/fenix/app/src/main/res/values-tt/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-tt/strings.xml
@@ -316,13 +316,6 @@
     <string name="onboarding_home_content_description_close_button">Ябу</string>
 
     <!-- Notification pre-permission dialog -->
-    <!-- Enable notification pre permission dialog title
-        The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="onboarding_home_enable_notifications_title" moz:removedIn="124" tools:ignore="UnusedResources">Искәртүләр Сезгә %s ярдәмендә күбрәк эш эшләргә ярдәм итә</string>
-    <!-- Text for the button to request notification permission on the device -->
-    <string name="onboarding_home_enable_notifications_positive_button" moz:removedIn="124" tools:ignore="UnusedResources">Дәвам итү</string>
-    <!-- Text for the button to not request notification permission on the device and dismiss the dialog -->
-    <string name="onboarding_home_enable_notifications_negative_button" moz:removedIn="124" tools:ignore="UnusedResources">Хәзер түгел</string>
 
     <!-- Juno first user onboarding flow experiment, strings are marked unused as they are only referenced by Nimbus experiments. -->
     <!-- Description for learning more about our privacy notice. -->
@@ -453,8 +446,6 @@
     <string name="preferences_override_sync_tokenserver">Үзгә Синхронлау серверы</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">Хисап язмасы</string>
-    <!-- Preference for changing where the toolbar is positioned -->
-    <string name="preferences_toolbar" moz:removedIn="129" tools:ignore="UnusedResources">Кораллар панеле</string>
     <!-- Preference for changing default theme to dark or light mode -->
     <string name="preferences_theme">Тема</string>
     <!-- Preference for customizing the home screen -->
@@ -682,8 +673,6 @@
 
     <!-- Preference for using the dynamic toolbar -->
     <string name="preference_gestures_dynamic_toolbar">Кораллар панелен яшерү өчен әйләндерегез</string>
-    <!-- Preference for switching tabs by swiping horizontally on the toolbar -->
-    <string name="preference_gestures_swipe_toolbar_switch_tabs" moz:removedIn="129" tools:ignore="UnusedResources">Табларны алыштыру өчен кораллар панелен кырыйга сөйрәгез</string>
     <!-- Preference for showing the opened tabs by swiping up on the toolbar-->
     <string name="preference_gestures_swipe_toolbar_show_tabs">Табларны ачу өчен кораллар панелен өскә таба сөйрәгез</string>
 
@@ -845,8 +834,6 @@
     <string name="collection_open_tabs">Табларны ачу</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Җыентык исеме</string>
-    <!-- Text for the menu button to rename a top site -->
-    <string name="rename_top_site" moz:removedIn="130" tools:ignore="UnusedResources">Исемен үзгәртү</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Бетерү</string>
     <!-- Text for the menu button to delete a top site from history -->
@@ -1179,8 +1166,6 @@
     <!-- Tab collection deletion prompt dialog option to delete the collection -->
     <string name="tab_collection_dialog_positive">Бетерү</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Тулы экран режимына күчү</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL копияләнде</string>
     <!-- Summary for Accessibility Text Size Scaling Preference -->
@@ -1596,8 +1581,6 @@
     <string name="top_sites_toggle_top_recent_sites_4">Ярлыклар</string>
     <!-- Title text displayed in the rename top site dialog. -->
     <string name="top_sites_rename_dialog_title">Исем</string>
-    <!-- Button caption to confirm the renaming of the top site. -->
-    <string name="top_sites_rename_dialog_ok" moz:removedIn="130" tools:ignore="UnusedResources">ОК</string>
     <!-- Dialog button text for canceling the rename top site prompt. -->
     <string name="top_sites_rename_dialog_cancel">Баш тарту</string>
 
@@ -1634,8 +1617,6 @@
     <!-- Content description radio buttons with a link to more information -->
     <string name="radio_preference_info_content_description">Күбрәк белү өчен басыгыз</string>
 
-    <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Югарыга</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Ябу</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-ar/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-ar/strings.xml
@@ -924,8 +924,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">انتقل</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">الدخول في وضع ملء الشاشة</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">انتقل إلى الرابط في اللسان حالا</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-bg/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-bg/strings.xml
@@ -926,8 +926,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Превключване</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Режим на цял екран</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Превключване веднага към новия раздел на препратка</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-ca/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-ca/strings.xml
@@ -920,8 +920,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Vés-hi</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Esteu en mode de pantalla completa</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">En obrir un enllaç en una pestanya nova, vés-hi immediatament</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-co/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-co/strings.xml
@@ -933,8 +933,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Affissà</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Modu di screnu sanu attivatu</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Affissà subitu ogni liame apertu in un’unghjetta nova</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-cy/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-cy/strings.xml
@@ -931,8 +931,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Newid</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Mynd i’r sgrin lawn</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Newid i ddolen mewn tab newydd ar unwaith</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-da/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-da/strings.xml
@@ -930,8 +930,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Skift</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Fuldskærmstilstand aktiveret</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Skift straks til link i nyt faneblad</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-de/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-de/strings.xml
@@ -929,8 +929,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Umschalten</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Vollbildmodus wird gestartet</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Sofort zum Link im neuen Tab wechseln</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-dsb/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-dsb/strings.xml
@@ -930,8 +930,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Pśešaltowaś</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Połna wobrazowka se pokazujo</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Ned k wótkazoju w nowem rejtariku pśejś</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-el/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-el/strings.xml
@@ -938,8 +938,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Εναλλαγή</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Είσοδος σε λειτουργία πλήρους οθόνης</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Άμεση αλλαγή στον σύνδεσμο νέας καρτέλας</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-en-rCA/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-en-rCA/strings.xml
@@ -929,8 +929,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Switch</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Entering full screen mode</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Switch to link in new tab immediately</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-en-rGB/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-en-rGB/strings.xml
@@ -902,8 +902,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Switch</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Entering full screen mode</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Switch to link in new tab immediately</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-es-rAR/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-es-rAR/strings.xml
@@ -930,8 +930,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Cambiar</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Cambiando a pantalla completa</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Cambiar a enlazar en nueva pestaña inmediatamente</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-es-rCL/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-es-rCL/strings.xml
@@ -928,8 +928,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Cambiar</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Pasando a modo de pantalla completa</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Cambiar al enlace en la nueva pestaña inmediatamente</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-es-rES/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-es-rES/strings.xml
@@ -926,8 +926,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Cambiar</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Accediendo a pantalla completa</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Cambie a un enlace en una nueva pestaña inmediatamente</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-es-rMX/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-es-rMX/strings.xml
@@ -927,8 +927,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Cambiar</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Accediendo a pantalla completa</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Cambiar a un enlace en una nueva pestaña inmediatamente</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-eu/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-eu/strings.xml
@@ -926,8 +926,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Aldatu</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Pantaila osoko moduan sartzen</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Aldatu berehala loturara fitxa berrian</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-fi/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-fi/strings.xml
@@ -929,8 +929,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Vaihda</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Siirrytään koko näytön tilaan</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Siirry välilehteen heti linkin avaamisen jälkeen</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-fr/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-fr/strings.xml
@@ -931,8 +931,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Afficher</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Mode plein écran activé</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Afficher immédiatement les liens ouverts dans de nouveaux onglets</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-fy-rNL/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-fy-rNL/strings.xml
@@ -930,8 +930,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Wikselje</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Folslein skerm wurdt iepene</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Wikselje daliks nei keppeling yn nij ljepblêd</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-hr/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-hr/strings.xml
@@ -923,8 +923,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Prebaci</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Pokretanje cjeloekranskog prikaza</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Odmah prebaci na poveznicu u novoj kartici</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-hsb/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-hsb/strings.xml
@@ -928,8 +928,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Přepinać</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Połna wobrazowka so pokazuje</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Hnydom k wotkazej w nowym rajtarku přeńć</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-hu/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-hu/strings.xml
@@ -930,8 +930,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Átváltás</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Belépés a teljes képernyős módba</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Azonnali átváltás az új fülre</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-is/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-is/strings.xml
@@ -910,8 +910,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Skipta</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Fara í fullan skjá</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Skipta strax yfir í tengil í nýjum flipa</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-it/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-it/strings.xml
@@ -930,8 +930,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Passa a</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Passato a schermo intero</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Passa direttamente al link nella nuova scheda</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-iw/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-iw/strings.xml
@@ -904,8 +904,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">מעבר</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">עברת למצב מסך מלא</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">מעבר לקישור בלשונית החדשה מיידית</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-ixl/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-ixl/strings.xml
@@ -933,8 +933,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Jalpu</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">La eel kaajayil chitu’</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Oora kuxh la jalpu tatinb’al tu uma’t ilb’al tetz</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-kab/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-kab/strings.xml
@@ -933,8 +933,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Nṭew</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Askar n ugdil ačaran yermed</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Nṭew ɣer useɣwen deg iccer amaynut</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-kk/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-kk/strings.xml
@@ -926,8 +926,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Ауысу</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Толық экран режиміне өту</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Жаңа бетке тура ауысу</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-ko/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-ko/strings.xml
@@ -925,8 +925,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">전환</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">전체 화면 모드로 들어가기</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">새탭의 링크로 즉시 전환</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-lo/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-lo/strings.xml
@@ -929,8 +929,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">ສະລັບ</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">ເຂົ້າສູ່ໂມດເຕັມຫນ້າຈໍ</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">ສະລັບໄປຫາແທັບໃຫມ່ທັນທີ</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-meh/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-meh/strings.xml
@@ -924,8 +924,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Sama</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Kivunɨ nu pantalla ka´nu</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Sama kuvi chunta´a pestaña jíía ñama</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-mix/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-mix/strings.xml
@@ -925,8 +925,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Sama</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Sama pantalla kanu</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Sama  enlazar nu xikua  tsaa vityi</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-nb-rNO/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-nb-rNO/strings.xml
@@ -928,8 +928,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Bytt</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Starter fullskjermmodus</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Bytt til lenke i ny fane med en gang</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-nl/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-nl/strings.xml
@@ -930,8 +930,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Wisselen</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Volledig scherm wordt geopend</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Onmiddellijk naar koppeling in nieuw tabblad wisselen</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-oc/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-oc/strings.xml
@@ -922,8 +922,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Mostrar</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Mòde plen ecran actiu</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Mostrar sulcòp los ligams dobèrts</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-pa-rIN/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-pa-rIN/strings.xml
@@ -927,8 +927,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">ਬਦਲੋ</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">ਪੂਰੀ ਸਕਰੀਨ ਢੰਗ ਵਿੱਚ ਜਾ ਰਿਹਾ ਹੈ</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">ਲਿੰਕ ਨੂੰ ਤੁਰੰਤ ਨੂੰ ਨਵੀਂ ਟੈਬ ਵਿੱਚ ਬਦਲੋ</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-pt-rBR/strings.xml
@@ -929,8 +929,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Alternar</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Entrando no modo de tela inteira</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Mudar imediatamente para link em nova aba</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-ru/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-ru/strings.xml
@@ -931,8 +931,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Перейти</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Вход в полноэкранный режим</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Сразу переходить на новую вкладку</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-sk/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-sk/strings.xml
@@ -930,8 +930,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Prepnúť</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Bol spustený režim celej obrazovky</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Prepnúť na odkaz na novej karte okamžite</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-skr/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-skr/strings.xml
@@ -921,8 +921,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">سوئچ کرو</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">پوری سکرین موڈ وچ داخل تھیندا پئے</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">فوری طور تے نویں ٹیب وچ لنک تے سوئچ کرو</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-sl/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-sl/strings.xml
@@ -931,8 +931,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Preklopi</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Vstopanje v celozaslonski način</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Takoj preklopi na povezavo v novem zavihku</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-sq/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-sq/strings.xml
@@ -935,8 +935,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Kalo në të</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Po hyhet në mënyrën “Sa krejt ekrani”</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Kalo menjëherë te lidhja në skedën e re</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-su/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-su/strings.xml
@@ -925,8 +925,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Gilir</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Asup ka mode layar pinuh</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Geuwat gilir ka tutumbu di tab anyar</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-sv-rSE/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-sv-rSE/strings.xml
@@ -929,8 +929,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Växla</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Startar fullskärmsläge</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Växla till länk i ny flik omedelbart</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-tg/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-tg/strings.xml
@@ -914,8 +914,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Қатъу васл кардан</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Ба реҷаи экрани пурра ворид шуда истодааст</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Гузариши фаврӣ ба пайванди кушодашуда дар варақаи нав</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-th/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-th/strings.xml
@@ -929,8 +929,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">สลับ</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">เข้าสู่โหมดเต็มหน้าจอ</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">สลับไปยังลิงก์ในแท็บใหม่ทันที</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-tr/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-tr/strings.xml
@@ -936,8 +936,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Geç</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Tam ekran moduna geçiliyor</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Hemen yeni sekmedeki bağlantıya geç</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-uk/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-uk/strings.xml
@@ -929,8 +929,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Перемкнути</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Вхід у повноекранний режим</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">Негайно перемикати на посилання в новій вкладці</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-yua/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-yua/strings.xml
@@ -931,8 +931,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">Tuupub</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">Táan u yokol ti\' modo pantalla completa</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">K\'eexbil ka nuupuk ich túumben nu\'ukbesaj séebanil</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-zh-rCN/strings.xml
@@ -935,8 +935,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">切换</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">进入全屏模式</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">立即显示新建打开的链接</string>

--- a/mozilla-mobile/focus-android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/mozilla-mobile/focus-android/app/src/main/res/values-zh-rTW/strings.xml
@@ -936,8 +936,6 @@
     <!-- Label for the button in the snackbar that switches to the newly opened tab -->
     <string name="open_new_tab_snackbar">切換</string>
 
-    <!-- Text displayed in a notification when the user enters full screen mode -->
-    <string name="full_screen_notification" moz:removedIn="130" tools:ignore="UnusedResources">進入全螢幕模式</string>
 
     <!-- Preference for switching to a new tab immediately after opening -->
     <string name="preference_open_new_tab">開啟鏈結後，立即切換到該分頁</string>


### PR DESCRIPTION
Remove unused strings that are marked `moz:removedIn` with version number lower than v132. 

Note that the diff looks like some comments below the removed string is removed.  However, these are not issue since the comment above is the same as the comment below so it's the diff, the correct comment was removed.