### PR TITLE
Fix double-escaped " characters

### DIFF
--- a/mozilla-mobile/fenix/app/src/main/res/values-bqi/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-bqi/strings.xml
@@ -1673,7 +1673,7 @@
   <!-- Title for the Delete browsing data on quit preference -->
   <string name="preferences_delete_browsing_data_on_quit">داده یل گشتن ن مجال و در زیڌن پاک کۊنین</string>
   <!-- Summary for the Delete browsing data on quit preference. "Quit" translation should match delete_browsing_data_on_quit_action translation. -->
-  <string name="preference_summary_delete_browsing_data_on_quit_2">مجال پسند \\\"و در زیڌن\\\" ز نومگه ٱسلی، داده یل گشتن ن و جۊر خوتکار پاک اکونه</string>
+  <string name="preference_summary_delete_browsing_data_on_quit_2">مجال پسند \"و در زیڌن\" ز نومگه ٱسلی، داده یل گشتن ن و جۊر خوتکار پاک اکونه</string>
   <!-- Action item in menu for the Delete browsing data on quit feature -->
   <string name="delete_browsing_data_on_quit_action">و در زیڌن</string>
   <!-- Radio button in the delete browsing data dialog to delete history items for the last hour. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-da/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-da/strings.xml
@@ -1012,9 +1012,9 @@
   <!-- Text for artist series wallpapers title. "Artist series" represents a collection of artist collaborated wallpapers. -->
   <string name="wallpaper_artist_series_title">Kunstnerserie</string>
   <!-- Description text for the artist series wallpapers with learn more link. %s is a learn more link using wallpaper_learn_more as text. "Independent voices" is the name of the wallpaper collection -->
-  <string name="wallpaper_artist_series_description_with_learn_more">Kollektionen \\\"Uafhængige stemmer\\\". %s</string>
+  <string name="wallpaper_artist_series_description_with_learn_more">Kollektionen \"Uafhængige stemmer\". %s</string>
   <!-- Description text for the artist series wallpapers. "Independent voices" is the name of the wallpaper collection -->
-  <string name="wallpaper_artist_series_description">Kollektionen \\\"Uafhængige stemmer\\\".</string>
+  <string name="wallpaper_artist_series_description">Kollektionen \"Uafhængige stemmer\".</string>
   <!-- Wallpaper onboarding dialog header text. -->
   <string name="wallpapers_onboarding_dialog_title_text">Tilføj lidt farve</string>
   <!-- Wallpaper onboarding dialog body text. -->
@@ -2159,7 +2159,7 @@
   <!-- Title for the Delete browsing data on quit preference -->
   <string name="preferences_delete_browsing_data_on_quit">Slet browserdata, når programmet afsluttes</string>
   <!-- Summary for the Delete browsing data on quit preference. "Quit" translation should match delete_browsing_data_on_quit_action translation. -->
-  <string name="preference_summary_delete_browsing_data_on_quit_2">Sletter automatisk browserdata, når du vælger \\\"Afslut\\\" i hovedmenuen</string>
+  <string name="preference_summary_delete_browsing_data_on_quit_2">Sletter automatisk browserdata, når du vælger \"Afslut\" i hovedmenuen</string>
   <!-- Action item in menu for the Delete browsing data on quit feature -->
   <string name="delete_browsing_data_on_quit_action">Afslut</string>
   <!-- Title text of a delete browsing data dialog. -->
@@ -3122,7 +3122,7 @@
   -->
   <string name="never_translate_site_toolbar_title_preference">Oversæt aldrig disse websteder</string>
   <!-- Screen header presenting the never translate site preference feature. It will appear under the toolbar. -->
-  <string name="never_translate_site_header_preference">For at tilføje et nyt websted: Besøg webstedet og vælg \\\"Oversæt aldrig dette websted\\\" fra oversættelsesmenuen.</string>
+  <string name="never_translate_site_header_preference">For at tilføje et nyt websted: Besøg webstedet og vælg \"Oversæt aldrig dette websted\" fra oversættelsesmenuen.</string>
   <!--
     Content description (not visible, for screen readers etc.): For a never-translated site list item that is selected.
     %1$s is web site url (for example:"wikipedia.com")

--- a/mozilla-mobile/fenix/app/src/main/res/values-en-rGB/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-en-rGB/strings.xml
@@ -2159,7 +2159,7 @@
   <!-- Title for the Delete browsing data on quit preference -->
   <string name="preferences_delete_browsing_data_on_quit">Delete browsing data on quit</string>
   <!-- Summary for the Delete browsing data on quit preference. "Quit" translation should match delete_browsing_data_on_quit_action translation. -->
-  <string name="preference_summary_delete_browsing_data_on_quit_2">Automatically deletes browsing data when you select \\\"Quit\\\" from the main menu</string>
+  <string name="preference_summary_delete_browsing_data_on_quit_2">Automatically deletes browsing data when you select \"Quit\" from the main menu</string>
   <!-- Action item in menu for the Delete browsing data on quit feature -->
   <string name="delete_browsing_data_on_quit_action">Quit</string>
   <!-- Title text of a delete browsing data dialog. -->
@@ -2812,7 +2812,7 @@
   <!-- This is the hint text that is shown inline on the hostname field of the create new login page. 'https://www.example.com' intentionally hardcoded here -->
   <string name="add_login_hostname_hint_text">https://www.example.com</string>
   <!-- This is an error message shown below the hostname field of the add login page when a hostname does not contain http or https. -->
-  <string name="add_login_hostname_invalid_text_3">Web address must contain \\\"https://\\\" or \\\"http://\\\"</string>
+  <string name="add_login_hostname_invalid_text_3">Web address must contain \"https://\" or \"http://\"</string>
   <!-- This is an error message shown below the hostname field of the add login page when a hostname is invalid. -->
   <string name="add_login_hostname_invalid_text_2">Valid hostname required</string>
   <!--

--- a/mozilla-mobile/fenix/app/src/main/res/values-es-rCL/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-es-rCL/strings.xml
@@ -1507,7 +1507,7 @@
   <!-- Text for the snackbar to confirm that a single download item has been removed. %1$s is the name of the download item. -->
   <string name="download_delete_single_item_snackbar" moz:removedIn="138" tools:ignore="UnusedResources">%1$s removido</string>
   <!-- Text for the snackbar to confirm that a single download item has been removed. %1$s is the name of the download item. -->
-  <string name="download_delete_single_item_snackbar_2">\\\"%1$s\\\" eliminado</string>
+  <string name="download_delete_single_item_snackbar_2">\"%1$s\" eliminado</string>
   <!-- Text for the snackbar to confirm that downloads are in progress. -->
   <string name="download_in_progress_snackbar" tools:ignore="UnusedResources">Descarga en proceso…</string>
   <!-- Text for the snackbar action button to view in progress download details. -->
@@ -2159,7 +2159,7 @@
   <!-- Title for the Delete browsing data on quit preference -->
   <string name="preferences_delete_browsing_data_on_quit">Eliminar datos de navegación al salir</string>
   <!-- Summary for the Delete browsing data on quit preference. "Quit" translation should match delete_browsing_data_on_quit_action translation. -->
-  <string name="preference_summary_delete_browsing_data_on_quit_2">Elimina automáticamente los datos de navegación cuando seleccionas \\\"Salir\\\" en el menú principal</string>
+  <string name="preference_summary_delete_browsing_data_on_quit_2">Elimina automáticamente los datos de navegación cuando seleccionas \"Salir\" en el menú principal</string>
   <!-- Action item in menu for the Delete browsing data on quit feature -->
   <string name="delete_browsing_data_on_quit_action">Salir</string>
   <!-- Title text of a delete browsing data dialog. -->
@@ -2419,7 +2419,7 @@
   <!-- Text displayed above provider textfield under "DNS over HTTPS" -->
   <string name="preference_doh_provider_custom_dialog_textfield">Proveedor</string>
   <!-- Error text displayed for provider textfield under "DNS over HTTPS" if the URL does not start with "https://" or its scheme is not "https" -->
-  <string name="preference_doh_provider_custom_dialog_error_https">URL debe comenzar con \\\"https://\\\"</string>
+  <string name="preference_doh_provider_custom_dialog_error_https">URL debe comenzar con \"https://\"</string>
   <!-- Error text displayed for provider textfield under "DNS over HTTPS" if the URL is invalid -->
   <string name="preference_doh_provider_custom_dialog_error_invalid">URL inválida</string>
   <!-- Cancel button text for provider textfield under "DNS over HTTPS" -->
@@ -2717,7 +2717,7 @@
   <!-- Placeholder text shown in the Search Suggestion String TextField before a user enters text -->
   <string name="search_add_custom_engine_suggest_string_hint">URL de la API de sugerencias de búsqueda</string>
   <!-- Description text for the Search Suggestion String TextField. The %s is part of the string -->
-  <string name="search_add_custom_engine_suggest_string_example_2" formatted="false">Reemplace la consulta con \\\"%s\\\". Por ejemplo:\\nhttps://suggestqueries.google.com/complete/search?client=firefox&amp;q=%s</string>
+  <string name="search_add_custom_engine_suggest_string_example_2" formatted="false">Reemplace la consulta con \"%s\". Por ejemplo:\\nhttps://suggestqueries.google.com/complete/search?client=firefox&amp;q=%s</string>
   <!-- The text for the "Save" button for saving a custom search engine -->
   <string name="search_custom_engine_save_button">Guardar</string>
   <!-- Text shown when a user leaves the name field empty -->
@@ -2812,7 +2812,7 @@
   <!-- This is the hint text that is shown inline on the hostname field of the create new login page. 'https://www.example.com' intentionally hardcoded here -->
   <string name="add_login_hostname_hint_text">https://www.example.com</string>
   <!-- This is an error message shown below the hostname field of the add login page when a hostname does not contain http or https. -->
-  <string name="add_login_hostname_invalid_text_3">La dirección web debe contener \\\"https://\\\" o \\\"http://\\\"</string>
+  <string name="add_login_hostname_invalid_text_3">La dirección web debe contener \"https://\" o \"http://\"</string>
   <!-- This is an error message shown below the hostname field of the add login page when a hostname is invalid. -->
   <string name="add_login_hostname_invalid_text_2">Nombre de servidor válido requerido</string>
   <!--

--- a/mozilla-mobile/fenix/app/src/main/res/values-iw/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-iw/strings.xml
@@ -2806,7 +2806,7 @@
   <!-- This is the hint text that is shown inline on the hostname field of the create new login page. 'https://www.example.com' intentionally hardcoded here -->
   <string name="add_login_hostname_hint_text">https://www.example.com</string>
   <!-- This is an error message shown below the hostname field of the add login page when a hostname does not contain http or https. -->
-  <string name="add_login_hostname_invalid_text_3">כתובת האתר חייבת להכיל \\\"https://‎\\\" או \\\"http://‎\\\"</string>
+  <string name="add_login_hostname_invalid_text_3">כתובת האתר חייבת להכיל \"https://‎\" או \"http://‎\"</string>
   <!-- This is an error message shown below the hostname field of the add login page when a hostname is invalid. -->
   <string name="add_login_hostname_invalid_text_2">דרוש שם מארח תקין</string>
   <!--

--- a/mozilla-mobile/fenix/app/src/main/res/values-tr/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-tr/strings.xml
@@ -2159,7 +2159,7 @@
   <!-- Title for the Delete browsing data on quit preference -->
   <string name="preferences_delete_browsing_data_on_quit">Çıkarken gezinti verilerini sil</string>
   <!-- Summary for the Delete browsing data on quit preference. "Quit" translation should match delete_browsing_data_on_quit_action translation. -->
-  <string name="preference_summary_delete_browsing_data_on_quit_2">Ana menüden \\\"Çık\\\"ı seçtiğinizde gezinti verilerini otomatik olarak siler</string>
+  <string name="preference_summary_delete_browsing_data_on_quit_2">Ana menüden \"Çık\"ı seçtiğinizde gezinti verilerini otomatik olarak siler</string>
   <!-- Action item in menu for the Delete browsing data on quit feature -->
   <string name="delete_browsing_data_on_quit_action">Çık</string>
   <!-- Title text of a delete browsing data dialog. -->
@@ -2812,7 +2812,7 @@
   <!-- This is the hint text that is shown inline on the hostname field of the create new login page. 'https://www.example.com' intentionally hardcoded here -->
   <string name="add_login_hostname_hint_text">https://www.example.com</string>
   <!-- This is an error message shown below the hostname field of the add login page when a hostname does not contain http or https. -->
-  <string name="add_login_hostname_invalid_text_3">Web adresi \\\"https://\\\" veya \\\"http://\\\" içermelidir</string>
+  <string name="add_login_hostname_invalid_text_3">Web adresi \"https://\" veya \"http://\" içermelidir</string>
   <!-- This is an error message shown below the hostname field of the add login page when a hostname is invalid. -->
   <string name="add_login_hostname_invalid_text_2">Geçerli bir sunucu gerekli</string>
   <!--


### PR DESCRIPTION
The fix in mozilla/pontoon#3650 did not account for translations that managed to already get written in the repo with the doubled `\` escapes; fixing the affected strings directly should be the cleanest way to get everything back in order.