### PR TITLE
Fix `\u` escaped characters to use hexadecimal rather than decimal values

### DIFF
--- a/mozilla-mobile/fenix/app/src/main/res/values-ab/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ab/strings.xml
@@ -61,7 +61,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s иаԥнахуеит уԥшаарақәеи уԥшаарақәеи рҭоурых хатә ҭаӡҩырақәа рҿы урҭ аныркыло ма апрограма уаналҵуа. Уи асаитқәа рҿы ма уи-интернет-провайдер рҿаԥхьа анонимны уҟанаҵом, аха уара узы еиҳа имариахоит уара уинтернеттә усура егьырҭ ауаа рҟынтәи уи маӡаны рыхьчара.</string>
-  <string name="private_browsing_common_myths">\u0032Ахатә ԥшаара иазку еицырзеиԥшу амифқәа\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Ахатә ԥшаара иазку еицырзеиԥшу амифқәа\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-am/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-am/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s ሲዘጉ ወይም መተግበሪያውን ሲያቆሙ የፍለጋ እና የአሰሳ ታሪክዎን ከግል ትሮች ያጸዳል። ይህ እርስዎን ለድር ጣቢያዎች ወይም የበይነመረብ አገልግሎት አቅራቢዎ ስም-አልባ ባያደርግም፣ በመስመር ላይ የሚያደርጉትን ይህን መሳሪያ ከሚጠቀም ከማንኛውም ሰው የግል ማድረግን ቀላል ያደርገዋል።</string>
-  <string name="private_browsing_common_myths">\u0032ስለግል አሰሳ የተለመዱ አፈ ታሪኮች\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s ሲዘጉ ወይም መተግበሪያውን ሲያቆሙ የፍለጋ እና የአሰሳ ታሪክዎን ከግል ትሮች ያጸዳል። ይህ እርስዎን ለድር ጣቢያዎች ወይም የበይነመረብ አገልግሎት አቅራቢዎ ስም-አልባ ባያደርግም፣ በመስመር ላይ የሚያደርጉትን ይህን መሳሪያ ከሚጠቀም ከማንኛውም ሰው የግል ማድረግን ቀላል ያደርገዋል።</string>
+  <string name="private_browsing_common_myths">\u0020ስለግል አሰሳ የተለመዱ አፈ ታሪኮች\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2427,7 +2427,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">የተቀመጡ የይለፍ ቃላት</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">ከ%s ጋር ያስቀመጧቸው ወይም ያሰናሰሏቸው የይለፍ ቃሎች እዚህ ይዘረዘራሉ። የሚያስቀምጡት ሁሉም የይለፍ ቃሎች የተመሰጠሩ ናቸው።\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">ከ%s ጋር ያስቀመጧቸው ወይም ያሰናሰሏቸው የይለፍ ቃሎች እዚህ ይዘረዘራሉ። የሚያስቀምጡት ሁሉም የይለፍ ቃሎች የተመሰጠሩ ናቸው።\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">ስለ ማሰናሰል የበለጠ ይረዱ</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->
@@ -2667,7 +2667,7 @@
   <!-- Label to clear site data -->
   <string name="clear_site_data">ኩኪዎች እና የድረ-ገፅ ውሂብ ያጽዱ</string>
   <!-- Confirmation message for a dialog confirming if the user wants to delete all data for current site. %s is the domain of the site. -->
-  <string name="confirm_clear_site_data">\u0032የ&lt;b&gt;%s&lt;/b&gt; ድረ-ገፅን ሁሉንም ኩኪዎች እና ውሂቦች ማጽዳት እንደሚፈልጉ እርግጠኛ ነዎት?</string>
+  <string name="confirm_clear_site_data">\u0020የ&lt;b&gt;%s&lt;/b&gt; ድረ-ገፅን ሁሉንም ኩኪዎች እና ውሂቦች ማጽዳት እንደሚፈልጉ እርግጠኛ ነዎት?</string>
   <!-- Confirmation message for a dialog confirming if the user wants to delete all the permissions for all sites -->
   <string name="confirm_clear_permissions_on_all_sites">እርግጠኛ ነዎት በሁሉም ድረ-ገፆች ላይ ያሉትን ሁሉንም ፈቃዶች ማጽዳት ይፈልጋሉ?</string>
   <!-- Confirmation message for a dialog confirming if the user wants to delete all the permissions for a site -->
@@ -2825,7 +2825,7 @@
   -->
   <string name="trending_searches_header_2">በ%s ላይ በመታየት ላይ ያለ</string>
   <!-- Title for search suggestions when Google is the default search suggestion engine. -->
-  <string name="google_search_engine_suggestion_header">\u0032የጉግል ፍለጋ</string>
+  <string name="google_search_engine_suggestion_header">\u0020የጉግል ፍለጋ</string>
   <!-- Title for search suggestions when the default search suggestion engine is anything other than Google. %s is default search engine name. -->
   <string name="other_default_search_engine_suggestion_header">%s ፍለጋ</string>
   <!-- Title for recent search suggestions. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-an/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-an/strings.xml
@@ -41,7 +41,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s limpia lo tuyo historial de busquedas y de navegación en as pestanyas privadas quan las zarras u en salir de l’aplicación. Encara que no te fa invisible debant d’os puestos web u d’o tuyo furnidor de servicios, ye mas facil salvaguardar la tuya vida privada de qualsequier persona que faga servir este dispositivo.</string>
-  <string name="private_browsing_common_myths">\u0032Mitos comuns sobre la navegación privada</string>
+  <string name="private_browsing_common_myths">\u0020Mitos comuns sobre la navegación privada</string>
   <!-- Text for the negative button to decline adding a Private Browsing shortcut to the Home screen -->
   <string name="cfr_neg_button_text" moz:removedIn="138" tools:ignore="UnusedResources">No, gracias</string>
   <!--
@@ -1009,7 +1009,7 @@
   <!-- Preference for enhanced tracking protection for the strict protection settings -->
   <string name="preference_enhanced_tracking_protection_strict">Estricto</string>
   <!-- Accessibility text for the Strict protection information icon -->
-  <string name="preference_enhanced_tracking_protection_strict_info_button">Qué ye lo que ye blocau per la protección estricta contra lo seguimiento\u0032</string>
+  <string name="preference_enhanced_tracking_protection_strict_info_button">Qué ye lo que ye blocau per la protección estricta contra lo seguimiento\u0020</string>
   <!-- Preference for enhanced tracking protection for the custom protection settings -->
   <string name="preference_enhanced_tracking_protection_custom">Personalizau</string>
   <!-- Preference description for enhanced tracking protection for the strict protection settings -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ast/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ast/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s borra l\'historial de busca y de resolar de les llingüetes privaes cuando les zarres o coles de l\'aplicación. Magar qu\'esta aición nun caltién el to anonimatu nos sitios web o nel fornidor de servicios d\'internet, facilita que cualesquier persona qu\'use esti preséu nun sepa qué faes en llinia.</string>
-  <string name="private_browsing_common_myths">\u0032Mitos habituales tocante al restolar en privao\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s borra l\'historial de busca y de resolar de les llingüetes privaes cuando les zarres o coles de l\'aplicación. Magar qu\'esta aición nun caltién el to anonimatu nos sitios web o nel fornidor de servicios d\'internet, facilita que cualesquier persona qu\'use esti preséu nun sepa qué faes en llinia.</string>
+  <string name="private_browsing_common_myths">\u0020Mitos habituales tocante al restolar en privao\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-azb/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-azb/strings.xml
@@ -60,8 +60,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s گیزلی تاغلاری باغلادیغینیز زامان ویا اپ‌دن چیخدیغینیز زامان آختاریش و مورور گئچمیشی پوزولار. بو سیزی سایتلارا ویا اینترنت خیدمت وئرنلره گیزلی ائتمه‌سه‌ده، بو جهازدان ایستیفاده ائدن هرکسدن آنلاین اولاراق نه ائتدیگینیزی گیزلی ساخلاماغی آسانلاشدیریر.</string>
-  <string name="private_browsing_common_myths">\u0032گیزلی مورور حاقیندا یایقین اینانجلار\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s گیزلی تاغلاری باغلادیغینیز زامان ویا اپ‌دن چیخدیغینیز زامان آختاریش و مورور گئچمیشی پوزولار. بو سیزی سایتلارا ویا اینترنت خیدمت وئرنلره گیزلی ائتمه‌سه‌ده، بو جهازدان ایستیفاده ائدن هرکسدن آنلاین اولاراق نه ائتدیگینیزی گیزلی ساخلاماغی آسانلاشدیریر.</string>
+  <string name="private_browsing_common_myths">\u0020گیزلی مورور حاقیندا یایقین اینانجلار\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -212,7 +212,7 @@
     Browser menu banner body text for extensions onboarding.
     %s is the name of the app (for example "Firefox").
   -->
-  <string name="browser_menu_extensions_banner_onboarding_body">اوزانتی‌لار، %s نین گؤرونوشو و عملکردینی دگیشمکدن گیزلیلیک و گؤونلیگی آرتیرماغا کیمی مروروزو یوخاریا آپاریر\u0032</string>
+  <string name="browser_menu_extensions_banner_onboarding_body">اوزانتی‌لار، %s نین گؤرونوشو و عملکردینی دگیشمکدن گیزلیلیک و گؤونلیگی آرتیرماغا کیمی مروروزو یوخاریا آپاریر\u0020</string>
   <!-- Browser menu banner link text for learning more about extensions -->
   <string name="browser_menu_extensions_banner_learn_more">آرتیق بیلین</string>
   <!-- Browser menu button that opens the extensions manager -->
@@ -291,7 +291,7 @@
   <!-- Browser menu label to sign back in to sync on the device when the user's account needs to be reauthenticated -->
   <string name="browser_menu_sign_back_in_to_sync">دؤنگل اوچون گئنه گیرین</string>
   <!-- Browser menu caption label for the "Sign back in to sync" browser menu item described in `browser_menu_sign_back_in_to_sync` when there is an error in syncing -->
-  <string name="browser_menu_syncing_paused_caption">\u0032دؤنگل دایاندیریلدی</string>
+  <string name="browser_menu_syncing_paused_caption">\u0020دؤنگل دایاندیریلدی</string>
   <!-- Browser menu label that creates a private tab -->
   <string name="browser_menu_new_private_tab">یئنی گیزلی تاغ</string>
   <!-- Browser menu label that navigates to the Password screen -->
@@ -1986,7 +1986,7 @@
   <!-- Title of the "Saved cards" screen -->
   <string name="credit_cards_saved_cards">یاددا ساخلانان کارتلار</string>
   <!-- Error message for card number validation -->
-  <string name="credit_cards_number_validation_error_message_2">\u0032بیر گئچرلی کارت شماره‌سی وئر</string>
+  <string name="credit_cards_number_validation_error_message_2">\u0020بیر گئچرلی کارت شماره‌سی وئر</string>
   <!-- Error message for card name on card validation -->
   <string name="credit_cards_name_on_card_validation_error_message_2">بیر آد وئر</string>
   <!-- Message displayed in biometric prompt displayed for authentication before allowing users to view their saved credit cards -->
@@ -2121,7 +2121,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">دوغرولایان: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">دوغرولایان: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">سیل</string>
   <!-- Login overflow menu edit button -->
@@ -2293,7 +2293,7 @@
   <!-- Text indicating that the Pocket story that also displays this text is a sponsored story by other 3rd party entity. -->
   <string name="pocket_stories_sponsor_indication">اسپانسرلی</string>
   <!-- Snackbar message for enrolling in a Nimbus experiment from the secret settings when Studies preference is Off. -->
-  <string name="experiments_snackbar">\u0032دیتا گؤندرمک اوچون تل متری‌یی گوجلندیر.</string>
+  <string name="experiments_snackbar">\u0020دیتا گؤندرمک اوچون تل متری‌یی گوجلندیر.</string>
   <!-- Snackbar button text to navigate to telemetry settings. -->
   <string name="experiments_snackbar_button">تنظیم‌لره گئدین</string>
   <!--

--- a/mozilla-mobile/fenix/app/src/main/res/values-be/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-be/strings.xml
@@ -62,7 +62,7 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s выдаляе гісторыю пошуку і аглядання з прыватных картак, калі вы закрываеце іх ці выходзіце з праграмы. Гэта не робіць вас ананімным для вэб-сайтаў ці вашага правайдара, але дазваляе трымаць у сакрэце вашу сеціўную дзейнасць ад кагосьці, хто карыстаецца вашай прыладай.</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s выдаляе гісторыю пошуку і аглядання з прыватных картак, калі вы закрываеце іх ці выходзіце з праграмы. Гэта не робіць вас ананімным для вэб-сайтаў ці вашага правайдара, але дазваляе трымаць у сакрэце вашу сеціўную дзейнасць ад кагосьці, хто карыстаецца вашай прыладай.</string>
   <string name="private_browsing_common_myths">Шырокавядомыя забабоны пра прыватнае агляданне</string>
   <!--
     True Private Browsing Mode

--- a/mozilla-mobile/fenix/app/src/main/res/values-bg/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-bg/strings.xml
@@ -2311,7 +2311,7 @@
   <!-- Description of cryptominers that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_cryptominers_description">Предотвратява зловредни скриптове, придобиващи достъп до устройството ви, с цел добив на цифрова валута.</string>
   <!-- Description of fingerprinters that can be blocked by Enhanced Tracking Protection -->
-  <string name="etp_known_fingerprinters_description">Предотвратява събирането на уникални данни за обратно установяване, които могат да бъдат използвани за проследяване.\u0032</string>
+  <string name="etp_known_fingerprinters_description">Предотвратява събирането на уникални данни за обратно установяване, които могат да бъдат използвани за проследяване.\u0020</string>
   <!-- Category of trackers (tracking content) that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_tracking_content_title">Проследяващо съдържание</string>
   <!-- Description of tracking content that can be blocked by Enhanced Tracking Protection -->
@@ -2511,7 +2511,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Запазени пароли</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">Паролите, които запазите или синхронизирате с %s ще бъдат изброени тук. Всички запазени пароли са шифровани.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">Паролите, които запазите или синхронизирате с %s ще бъдат изброени тук. Всички запазени пароли са шифровани.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Научете повече за синхронизирането</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-bn/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-bn/strings.xml
@@ -32,11 +32,11 @@
   <string name="tab_tray_close_multiselect_content_description">মাল্টিলেক্ট মোড থেকে প্রস্থান করুন</string>
   <!-- About content. %1$s is the name of the app (for example "Firefox"). -->
   <string name="about_content">%1$s হচ্ছে Mozilla দ্বারা তৈরি।</string>
-  <string name="private_browsing_common_myths">\u0032ব্যাক্তিগত ব্রাউজিং সম্পর্কে কিছু ভুল ধারণা\u0032</string>
+  <string name="private_browsing_common_myths">\u0020ব্যাক্তিগত ব্রাউজিং সম্পর্কে কিছু ভুল ধারণা\u0020</string>
   <!-- Text for the negative button to decline adding a Private Browsing shortcut to the Home screen -->
   <string name="cfr_neg_button_text" moz:removedIn="138" tools:ignore="UnusedResources">না ধন্যবাদ</string>
   <!-- Text for the positive action button -->
-  <string name="open_in_app_cfr_positive_button_text">\u0032সেটিং এ যাও</string>
+  <string name="open_in_app_cfr_positive_button_text">\u0020সেটিং এ যাও</string>
   <!-- Text for the negative action button -->
   <string name="open_in_app_cfr_negative_button_text">বাতিল</string>
   <!-- Text for the positive action button to go to Android Settings to grant permissions. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-br/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-br/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s a skarzh ho roll istor klask ha merdeiñ eus an ivinelloù prevez pa guitait anezho pe pa guitait an arload. Daoust ma ne lak ket acʼhanocʼh da vezañ dizanv evit al lecʼhiennoù pe evit ho pourchaser kenrouedad e vo aesocʼh da zercʼhel prevez ar pezh a rit enlinenn evit an dud all a implij an trevnad-mañ.</string>
-  <string name="private_browsing_common_myths">\u0032Mojennoù a vez alies diwar-benn ar merdeiñ prevez\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s a skarzh ho roll istor klask ha merdeiñ eus an ivinelloù prevez pa guitait anezho pe pa guitait an arload. Daoust ma ne lak ket acʼhanocʼh da vezañ dizanv evit al lecʼhiennoù pe evit ho pourchaser kenrouedad e vo aesocʼh da zercʼhel prevez ar pezh a rit enlinenn evit an dud all a implij an trevnad-mañ.</string>
+  <string name="private_browsing_common_myths">\u0020Mojennoù a vez alies diwar-benn ar merdeiñ prevez\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -617,7 +617,7 @@
   <!-- Learn more link for the crash reporting option in the privacy preferences dialog shown during onboarding. -->
   <string name="onboarding_preferences_dialog_crash_reporting_learn_more_2">Gouzout hiroc\'h</string>
   <!-- Title for the usage data option in the privacy preferences dialog shown during onboarding. Note: The word "Mozilla" should NOT be translated. -->
-  <string name="onboarding_preferences_dialog_usage_data_title">Kas roadennoù teknikel hag etreoberiañ da vMozilla\u0032</string>
+  <string name="onboarding_preferences_dialog_usage_data_title">Kas roadennoù teknikel hag etreoberiañ da vMozilla\u0020</string>
   <string name="onboarding_preferences_dialog_usage_data_description_2" tools:ignore="BrandUsage">Roadennoù diwar-benn ho trevnad, kefluniadur ar periant ha penaos e implijit Firefox a sikour da wellaat ar c\'heweriusterioù, an digonusted hag ar stabilded evit an holl.</string>
   <string name="onboarding_preferences_dialog_usage_data_learn_more_2">Gouzout hiroc\'h</string>
   <!-- Positive button label for the privacy preferences dialog shown during onboarding. -->
@@ -817,7 +817,7 @@
   <!-- Option for the https only setting -->
   <string name="preferences_https_only_in_private_tabs">Gweredekaat en ivinelloù prevez hepken</string>
   <!-- Title shown in the error page for when trying to access a http website while https only mode is enabled. -->
-  <string name="errorpage_httpsonly_title">Lec’hienn diogel dihegerz\u0032</string>
+  <string name="errorpage_httpsonly_title">Lec’hienn diogel dihegerz\u0020</string>
   <!-- Message shown in the error page for when trying to access a http website while https only mode is enabled. The message has two paragraphs. This is the first. -->
   <string name="errorpage_httpsonly_message_title">Moarvat n’eo ket skoret an HTTPS gant al lec’hienn.</string>
   <!-- Message shown in the error page for when trying to access a http website while https only mode is enabled. The message has two paragraphs. This is the second. -->
@@ -1206,7 +1206,7 @@
     Message to warn users that a large number of tabs will be opened
     %s will be replaced by app name.
   -->
-  <string name="open_all_warning_message">Digeriñ kement a ivinelloù a c’hallfe gorrekaat %s keit m’emañ ar pajennoù o kargañ. Sur oc’h e fell deoc’h kenderc’hel?\u0032</string>
+  <string name="open_all_warning_message">Digeriñ kement a ivinelloù a c’hallfe gorrekaat %s keit m’emañ ar pajennoù o kargañ. Sur oc’h e fell deoc’h kenderc’hel?\u0020</string>
   <!-- Dialog button text for confirming open all tabs -->
   <string name="open_all_warning_confirm">Digeriñ ivinelloù</string>
   <!-- Dialog button text for canceling open all tabs -->
@@ -2258,7 +2258,7 @@
   <!-- Preference for autofilling saved logins in Firefox (in web content), %1$s will be replaced with the app name -->
   <string name="preferences_passwords_autofill2">Leuniañ emgefreek e %1$s</string>
   <!-- Description for the preference for autofilling saved logins in Firefox (in web content), %1$s will be replaced with the app name -->
-  <string name="preferences_passwords_autofill_description">\u0032Leuniañ hag enrollañ an anvioù implijer ha gerioù-tremen el lec’hiennoù en ur implijout %1$s.</string>
+  <string name="preferences_passwords_autofill_description">\u0020Leuniañ hag enrollañ an anvioù implijer ha gerioù-tremen el lec’hiennoù en ur implijout %1$s.</string>
   <!-- Preference for autofilling logins from Fenix in other apps (e.g. autofilling the Twitter app) -->
   <string name="preferences_android_autofill">Leuniañ emgefreek en arloadoù all</string>
   <!-- Description for the preference for autofilling logins from Fenix in other apps (e.g. autofilling the Twitter app) -->
@@ -2713,7 +2713,7 @@
   <!-- Paragraph explaining how a product's adjusted grading is calculated. -->
   <string name="review_quality_check_explanation_body_adjusted_grading" moz:removedIn="136" tools:ignore="UnusedResources">An &lt;b&gt;notenn reizhet&lt;/b&gt; a zo diazezet war an alioù fizius.</string>
   <!-- Paragraph explaining product review highlights. %s is the name of the retailer (e.g. Amazon). -->
-  <string name="review_quality_check_explanation_body_highlights" moz:removedIn="136" tools:ignore="UnusedResources">Ar &lt;b&gt;poentoù pouezus&lt;/b&gt; a zeu eus alioù %s er 80 devezh diwezhañ a soñj deomp int fizius.\u0032</string>
+  <string name="review_quality_check_explanation_body_highlights" moz:removedIn="136" tools:ignore="UnusedResources">Ar &lt;b&gt;poentoù pouezus&lt;/b&gt; a zeu eus alioù %s er 80 devezh diwezhañ a soñj deomp int fizius.\u0020</string>
   <!--
     Accessibility services actions labels. These will be appended to accessibility actions like "Double tap to.." but not by or applications but by services like Talkback.
 
@@ -2727,7 +2727,7 @@
   <!-- Current state for elements that can be expanded if interacting with them. Talkback will dictate this after a state change. -->
   <string name="a11y_state_label_expanded">dispaket</string>
   <!-- Action label for links to a website containing documentation about a wallpaper collection. Talkback will append this to say "Double tap to open link to learn more about this collection". -->
-  <string name="a11y_action_label_wallpaper_collection_learn_more">digeriñ an ere evit gouzout hiroc’h diwar-benn an dastumad-mañ\u0032</string>
+  <string name="a11y_action_label_wallpaper_collection_learn_more">digeriñ an ere evit gouzout hiroc’h diwar-benn an dastumad-mañ\u0020</string>
   <!-- Action label for links that point to an article. Talkback will append this to say "Double tap to read the article". -->
   <string name="a11y_action_label_read_article">lenn ar pennad</string>
   <!-- Action label for links to the Firefox Pocket website. Talkback will append this to say "Double tap to open link to learn more". -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-bs/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-bs/strings.xml
@@ -262,7 +262,7 @@
   <!-- Browser menu toggle that requests a desktop site -->
   <string name="browser_menu_desktop_site">Desktop stranica</string>
   <!-- Browser menu button that reopens a private tab as a regular tab -->
-  <string name="browser_menu_open_in_regular_tab">Otvori u standardnom tabu\u0032</string>
+  <string name="browser_menu_open_in_regular_tab">Otvori u standardnom tabu\u0020</string>
   <!-- Browser menu toggle that adds a shortcut to the site on the device home screen. -->
   <string name="browser_menu_add_to_homescreen">Dodaj na Početni ekran</string>
   <!-- Browser menu toggle that adds a PWA of the site on the device home screen. -->
@@ -2511,7 +2511,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Sačuvane lozinke</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">Lozinke koje sačuvate ili sinhronizujete sa %s će biti navedene ovdje. Sve lozinke koje sačuvate su šifrovane.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">Lozinke koje sačuvate ili sinhronizujete sa %s će biti navedene ovdje. Sve lozinke koje sačuvate su šifrovane.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Saznajte više o sinhronizaciji</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ca/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ca/strings.xml
@@ -2434,7 +2434,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Contrasenyes desades</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">Les contrasenyes que deseu o sincronitzeu amb el %s es mostraran aquí. Totes les contrasenyes que deseu estan xifrades.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">Les contrasenyes que deseu o sincronitzeu amb el %s es mostraran aquí. Totes les contrasenyes que deseu estan xifrades.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Més informació sobre la sincronització</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-cak/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-cak/strings.xml
@@ -520,7 +520,7 @@
   <!-- Title text for a detail explanation indicating cookie banner handling is off this site, this is shown as part of the cookie banner panel in the toolbar. %1$s is a shortened URL of the current site. -->
   <string name="reduce_cookie_banner_details_panel_title_off_for_site_1">¿La nichup ri ruq\'atoj kitzijol taq cookie richin %1$s?</string>
   <!-- Title text for a detail explanation indicating cookie banner reducer didn't work for the current site, this is shown as part of the cookie banner panel in the toolbar. %1$s is the name of the app (for example "Firefox"). -->
-  <string name="reduce_cookie_banner_details_panel_title_unsupported_site_request_2">\u0032Man yeruq\'ät ta ri %1$s pa ruyonil ri taq kik\'utuj taq cookie pa re ruxaq re\'. Yatikïr natäq un k\'utuj richin nito\' re ruxaq re\' ri chwa\'q kab\'ij.</string>
+  <string name="reduce_cookie_banner_details_panel_title_unsupported_site_request_2">\u0020Man yeruq\'ät ta ri %1$s pa ruyonil ri taq kik\'utuj taq cookie pa re ruxaq re\'. Yatikïr natäq un k\'utuj richin nito\' re ruxaq re\' ri chwa\'q kab\'ij.</string>
   <!-- Long text for a detail explanation indicating what will happen if cookie banner handling is on for a site, this is shown as part of the cookie banner panel in the toolbar. %1$s is the name of the app (for example "Firefox"). -->
   <string name="reduce_cookie_banner_details_panel_description_on_for_site_3">Toq nitzij, ri %1$s xtutojtob\'ej xkeruxutuj pa ruyonil ri taq kitzijol taq cookie pa re ruxaq re\'.</string>
   <!-- Title for the cookie banner re-engagement CFR, the placeholder is replaced with app name. %1$s is the name of the app (for example "Firefox"). -->
@@ -540,7 +540,7 @@
   <!-- Option for the https only setting -->
   <string name="preferences_https_only_in_private_tabs">Ketzij xa xe\' pan ichinan taq ruwi\'</string>
   <!-- Title shown in the error page for when trying to access a http website while https only mode is enabled. -->
-  <string name="errorpage_httpsonly_title">Man k\'o ta ri jikil ruxaq\u0032</string>
+  <string name="errorpage_httpsonly_title">Man k\'o ta ri jikil ruxaq\u0020</string>
   <!-- Message shown in the error page for when trying to access a http website while https only mode is enabled. The message has two paragraphs. This is the first. -->
   <string name="errorpage_httpsonly_message_title">Rik\'in jub\'a\' chi ri ajk\'amaya\'l ruxaq xa man nuk\'äm ta ri\' rik\'in ri HTTPS.</string>
   <!-- Preference for accessibility -->
@@ -1521,7 +1521,7 @@
   <!-- Preference title for enhanced tracking protection settings -->
   <string name="preference_enhanced_tracking_protection">Utzirisan Chajinïk chuwäch Ojqanem</string>
   <!-- Description of enhanced tracking protection. %s is the name of the app (for example "Firefox"). -->
-  <string name="preference_enhanced_tracking_protection_explanation_2">\u0032%s yaruchajij chi kiwäch relik ojqanela\', ri nikoqaj ri nab\'än pa k\'amab\'ey.</string>
+  <string name="preference_enhanced_tracking_protection_explanation_2">\u0020%s yaruchajij chi kiwäch relik ojqanela\', ri nikoqaj ri nab\'än pa k\'amab\'ey.</string>
   <!-- Text displayed that links to website about enhanced tracking protection -->
   <string name="preference_enhanced_tracking_protection_explanation_learn_more">Tetamäx ch\'aqa\' chik</string>
   <!-- Preference for enhanced tracking protection for the standard protection settings -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ceb/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ceb/strings.xml
@@ -40,8 +40,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032Ang %1$s moclear sa imong search ug browsing history sa private tabs kung i-sara o i-quit ang app. Bisan dili kini mohimo kanimo nga anonymous sa mga website ug sa imong internet service provider, gipasayon niini ang pagkapribado sa imong mga gihimo online gikan sa ubang gagamit niining device.</string>
-  <string name="private_browsing_common_myths">\u0032Mga tinuohan bahin sa private browsing\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020Ang %1$s moclear sa imong search ug browsing history sa private tabs kung i-sara o i-quit ang app. Bisan dili kini mohimo kanimo nga anonymous sa mga website ug sa imong internet service provider, gipasayon niini ang pagkapribado sa imong mga gihimo online gikan sa ubang gagamit niining device.</string>
+  <string name="private_browsing_common_myths">\u0020Mga tinuohan bahin sa private browsing\u0020</string>
   <!-- Text for the negative button to decline adding a Private Browsing shortcut to the Home screen -->
   <string name="cfr_neg_button_text" moz:removedIn="138" tools:ignore="UnusedResources">Salamat na lang</string>
   <!-- Text for the positive action button -->
@@ -61,7 +61,7 @@
   <!-- Text for the negative action button to dismiss the Close Tabs Banner. -->
   <string name="tab_tray_close_tabs_banner_negative_button_text">i-Dismiss</string>
   <!-- Text for the banner message to tell users about our inactive tabs feature. -->
-  <string name="tab_tray_inactive_onboarding_message">Ang mga tab nga wala nimo malantaw sulod sa duha ka-semana mabutang dinhi.\u0032</string>
+  <string name="tab_tray_inactive_onboarding_message">Ang mga tab nga wala nimo malantaw sulod sa duha ka-semana mabutang dinhi.\u0020</string>
   <!-- Text for the action link to go to Settings for inactive tabs. -->
   <string name="tab_tray_inactive_onboarding_button_text">i-Off sulod sa settings</string>
   <!--
@@ -180,7 +180,7 @@
   <!-- Search suggestion onboarding hint title text -->
   <string name="search_suggestions_onboarding_title">i-Allow ang search suggestions sulod sa private sessions?</string>
   <!-- Search suggestion onboarding hint description text, %s is the name of the app (for example "Firefox"). -->
-  <string name="search_suggestions_onboarding_text">Ang %s magbutyag sa tanan nimo gitype sulod sa address bar gamit imong default nga search engine.\u0032</string>
+  <string name="search_suggestions_onboarding_text">Ang %s magbutyag sa tanan nimo gitype sulod sa address bar gamit imong default nga search engine.\u0020</string>
   <!-- Search engine suggestion title text. %s is the name of the suggested engine. -->
   <string name="search_engine_suggestions_title">Pangitaon %1$s</string>
   <!-- Search engine suggestion description text -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ckb/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ckb/strings.xml
@@ -34,7 +34,7 @@
   <string name="tab_tray_collection_button_multiselect_content_description">بازدەرە دیاریکراوەکان هەڵبگرە لە کۆمەڵەکە</string>
   <!-- About content. %1$s is the name of the app (for example "Firefox"). -->
   <string name="about_content">%1$s بەرهەم هێنراوە لە لایەن مۆزیلاوە.</string>
-  <string name="private_browsing_common_myths">\u0032چەند ئەفسانەییەک دەربارەی گەڕانی تایبەتیی\u0032</string>
+  <string name="private_browsing_common_myths">\u0020چەند ئەفسانەییەک دەربارەی گەڕانی تایبەتیی\u0020</string>
   <!-- Text for the negative button to decline adding a Private Browsing shortcut to the Home screen -->
   <string name="cfr_neg_button_text" moz:removedIn="138" tools:ignore="UnusedResources">نا سوپاس</string>
   <!-- Text for the positive action button -->
@@ -214,7 +214,7 @@
   <!-- Preference title for switch preference to show search suggestions also in private mode -->
   <string name="preferences_show_search_suggestions_in_private">لە دانیشتنی تایبەت پیشانی بدە</string>
   <!-- Preference title for switch preference to suggest browsing history when searching -->
-  <string name="preferences_search_browsing_history">بگەڕێ لە مێژووی کار\u0032</string>
+  <string name="preferences_search_browsing_history">بگەڕێ لە مێژووی کار\u0020</string>
   <!-- Preference title for switch preference to suggest bookmarks when searching -->
   <string name="preferences_search_bookmarks">گەڕان لە نیشانەکراوەکان</string>
   <!-- Preference title for switch preference to suggest synced tabs when searching -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-co/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-co/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032· %1$s squassa e vostre cronolugie di ricerca è di navigazione da l’unghjette private quandu vò chjuditele o chitate l’appiecazione. Benchè quessu ùn vi rende micca anonimu nant’à i siti web nè da u vostru furnidore d’accessu à internet, vi permette di cunservà sicreta a vostra attività in linea per tutte l’altre persone chì impiegherianu u vostru apparechju.</string>
-  <string name="private_browsing_common_myths">\u0032Idee precuncepite apprupositu di a navigazione privata\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020· %1$s squassa e vostre cronolugie di ricerca è di navigazione da l’unghjette private quandu vò chjuditele o chitate l’appiecazione. Benchè quessu ùn vi rende micca anonimu nant’à i siti web nè da u vostru furnidore d’accessu à internet, vi permette di cunservà sicreta a vostra attività in linea per tutte l’altre persone chì impiegherianu u vostru apparechju.</string>
+  <string name="private_browsing_common_myths">\u0020Idee precuncepite apprupositu di a navigazione privata\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -3601,7 +3601,7 @@
   <!-- Label for a preference shown when the device supports screen lock (e.g., PIN, pattern, or password) but the user has not set one up. -->
   <string name="pbm_authentication_lock_device_feature_disabled">Cunfigurà l’ammarchjunata di u screnu per piattà l’unghjette</string>
   <!-- Title text for the contextual feature recommendation (CFR) suggesting the user enable a screen lock to protect private tabs -->
-  <string name="private_tab_cfr_title">Impiegà l’ammarchjunata di u screnu per piattà l’unghjette private\u0032</string>
+  <string name="private_tab_cfr_title">Impiegà l’ammarchjunata di u screnu per piattà l’unghjette private\u0020</string>
   <!-- Negative button text for the contextual feature recommendation (CFR) dismissing the screen lock suggestion -->
   <string name="private_tab_cfr_negative">Innò, vi ringraziu</string>
   <!-- Positive button text for the contextual feature recommendation (CFR) enabling screen lock for private tabs -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-cs/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-cs/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s vymaže vaši historii vyhledávání a stránek navštívených v anonymním panelu po jeho zavření nebo ukončení aplikace. S touto funkcí nejste na internetu zcela neviditelní a např. poskytovatel připojení k internetu může stále zjistit, které stránky navštěvujete. Vaše aktivita na internetu ale zůstane utajena před dalšími uživateli tohoto zařízení.</string>
-  <string name="private_browsing_common_myths">\u0032Časté omyly o fungování anonymního prohlížení\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Časté omyly o fungování anonymního prohlížení\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-cy/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-cy/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">Mae %1$s yn clirio’ch hanes chwilio a phori o dabiau preifat pan fyddwch yn eu cau neu’n gadael yr ap. Er nad yw hyn yn eich gwneud chi’n anhysbys i wefannau neu’ch darparwr gwasanaeth rhyngrwyd, mae’n ei gwneud hi’n haws cadw’r hyn rydych chi’n ei wneud ar-lein yn breifat rhag unrhyw un arall sy’n defnyddio’r ddyfais hon.</string>
-  <string name="private_browsing_common_myths">\u0032Mythau cyffredin am bori preifat\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Mythau cyffredin am bori preifat\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -1321,7 +1321,7 @@
   -->
   <string name="recently_closed_tab">%d tab</string>
   <!-- Recently closed tabs screen message when there are no recently closed tabs -->
-  <string name="recently_closed_empty_message">Dim tabiau wedi’u cau yn ddiweddar yma\u0032</string>
+  <string name="recently_closed_empty_message">Dim tabiau wedi’u cau yn ddiweddar yma\u0020</string>
   <!--
     Tab Management
 
@@ -2339,7 +2339,7 @@
   <!-- Description of redirect tracker cookies that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_redirect_trackers_description">Yn clirio cwcis wedi’u gosod i ailgyfeirio i wefannau tracio hysbys.</string>
   <!-- Preference for fingerprinting protection for the custom protection settings -->
-  <string name="etp_suspected_fingerprinters_title">Amheuaeth o Fysbrintwyr\u0032</string>
+  <string name="etp_suspected_fingerprinters_title">Amheuaeth o Fysbrintwyr\u0020</string>
   <!-- Description of fingerprinters that can be blocked by fingerprinting protection -->
   <string name="etp_suspected_fingerprinters_description">Yn galluogi diogelu rhag bysbrintio er mwyn atal bysbrintwyr posib.</string>
   <!-- Category of trackers (fingerprinters) that can be blocked by Enhanced Tracking Protection -->
@@ -2511,7 +2511,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Cyfrineiriau wedi\'u cadw</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">Bydd y cyfrineiriau rydych yn eu cadw neu eu cydweddu i %s yn cael eu rhestru yma. Mae\'r holl gyfrineiriau rydych chi\'n eu cadw wedi\'u hamgryptio.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">Bydd y cyfrineiriau rydych yn eu cadw neu eu cydweddu i %s yn cael eu rhestru yma. Mae\'r holl gyfrineiriau rydych chi\'n eu cadw wedi\'u hamgryptio.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Dysgwch fwy am gydweddu</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-da/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-da/strings.xml
@@ -481,7 +481,7 @@
     %s is the search engine name (for example: DuckDuckGo).
     The colon character (in "%s:") is intended to have the screen reader make a small pause between the search engine name and the description of the button.
   -->
-  <string name="search_engine_selector_content_description">%s: søgetjenestevælger\u0032</string>
+  <string name="search_engine_selector_content_description">%s: søgetjenestevælger\u0020</string>
   <!--
     Home onboarding
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-de/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-de/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s leert die eingegebenen Suchbegriffe und besuchten Webseiten aller privaten Tabs wenn Sie diese schließen oder die App beenden. Das macht Sie gegenüber Website-Betreibern und Internetanbietern nicht anonym, aber erleichtert es Ihnen, dass andere Nutzer dieses Geräts Ihre Aktivitäten nicht einsehen können.</string>
-  <string name="private_browsing_common_myths">\u0032Häufige Missverständnisse über das Surfen im Privaten Modus</string>
+  <string name="private_browsing_common_myths">\u0020Häufige Missverständnisse über das Surfen im Privaten Modus</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-dsb/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-dsb/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s wašu pytańsku a pśeglědowańsku historjiu z priwatnych rejtarikow wuproznijo, gaž je zacynjaśo abo nałoženje kóńcyśo. Pšez to se wólažcyjo, pśed drugimi, kótarež toś to licadło wužywaju, schowaś, což online gótujośo, lěcrownož to was za websedła abo wašogo póbitowarja internetneje słužby njeanonymizěrujo.</string>
-  <string name="private_browsing_common_myths">\u0032Ceste myty wó priwatnem modusu\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Ceste myty wó priwatnem modusu\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -549,7 +549,7 @@
     Description for enable notification permission screen used by Nimbus experiments. Nimbus experiments do not support string placeholders.
     Note: The word "Firefox" should NOT be translated
   -->
-  <string name="juno_onboarding_enable_notifications_description_nimbus_2" tools:ignore="BrandUsage">Rozesćełajśo rejtariki mjazy swójimi rědami a namakajśo druge funkcije priwatnosći w Firefox.\u0032</string>
+  <string name="juno_onboarding_enable_notifications_description_nimbus_2" tools:ignore="BrandUsage">Rozesćełajśo rejtariki mjazy swójimi rědami a namakajśo druge funkcije priwatnosći w Firefox.\u0020</string>
   <!-- Text for the button to request notification permission on the device -->
   <string name="juno_onboarding_enable_notifications_positive_button" tools:ignore="UnusedResources">Powěźeńki zmóžniś</string>
   <!-- Text for the button dismiss the screen and move on with the flow -->
@@ -589,7 +589,7 @@
   <!-- Privacy Badger name for the onboarding add-ons card, used by Nimbus experiments. Note: The word "Privacy Badger" is a brand name should NOT be translated -->
   <string name="onboarding_add_on_privacy_badger_name" tools:ignore="UnusedResources">Privacy Badger</string>
   <!-- Privacy Badger description for the onboarding add-ons card, used by Nimbus experiments. -->
-  <string name="onboarding_add_on_privacy_badger_description" tools:ignore="UnusedResources">Juwel pśeśiwnego slědowanja. Stopujśo njewidobne pśeslědowaki a spioněrujuce wabjenje.\u0032</string>
+  <string name="onboarding_add_on_privacy_badger_description" tools:ignore="UnusedResources">Juwel pśeśiwnego slědowanja. Stopujśo njewidobne pśeslědowaki a spioněrujuce wabjenje.\u0020</string>
   <!-- Search by Image name for the onboarding add-ons card, used by Nimbus experiments. Note: The word "Search by Image" is a brand name should NOT be translated -->
   <string name="onboarding_add_on_search_by_image_name" tools:ignore="UnusedResources">Pó wobrazu pytaś</string>
   <!-- Search by Image description for the onboarding add-ons card, used by Nimbus experiments. -->
@@ -2772,7 +2772,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Pśeglědany wót: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Pśeglědany wót: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Lašowaś</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-el/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-el/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032Το %1$s διαγράφει το ιστορικό αναζητήσεων και περιήγησης των ιδιωτικών καρτελών όταν κλείνετε αυτές ή την εφαρμογή. Αυτό δεν σας παρέχει ανωνυμία σε ιστοτόπους ή στον πάροχο υπηρεσιών διαδικτύου σας, αλλά σας βοηθά να προστατέψετε το απόρρητό σας από τους άλλους χρήστες αυτής της συσκευής.</string>
-  <string name="private_browsing_common_myths">\u0032Συνήθεις παρανοήσεις σχετικά με την ιδιωτική περιήγηση\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020Το %1$s διαγράφει το ιστορικό αναζητήσεων και περιήγησης των ιδιωτικών καρτελών όταν κλείνετε αυτές ή την εφαρμογή. Αυτό δεν σας παρέχει ανωνυμία σε ιστοτόπους ή στον πάροχο υπηρεσιών διαδικτύου σας, αλλά σας βοηθά να προστατέψετε το απόρρητό σας από τους άλλους χρήστες αυτής της συσκευής.</string>
+  <string name="private_browsing_common_myths">\u0020Συνήθεις παρανοήσεις σχετικά με την ιδιωτική περιήγηση\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-en-rCA/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-en-rCA/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s clears your search and browsing history from private tabs when you close them or quit the app. While this doesn’t make you anonymous to websites or your internet service provider, it makes it easier to keep what you do online private from anyone else who uses this device.</string>
-  <string name="private_browsing_common_myths">\u0032Common myths about private browsing\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Common myths about private browsing\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2633,7 +2633,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Verified By: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Verified By: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Delete</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-en-rGB/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-en-rGB/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s clears your search and browsing history from private tabs when you close them or quit the app. While this doesn’t make you anonymous to web sites or your internet service provider, it makes it easier to keep what you do online private from anyone else who uses this device.</string>
-  <string name="private_browsing_common_myths">\u0032Common myths about private browsing\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Common myths about private browsing\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-es-rAR/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-es-rAR/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s elimina tu historial de búsqueda y navegación cuando salís de la aplicación o cerrás todas las pestañas privadas. Si bien esto no te hace anónimo en los sitios web o con tu proveedor de servicios de Internet, resulta más fácil mantener privado lo que hacés en línea respecto de cualquier otra persona que use este dispositivo.</string>
-  <string name="private_browsing_common_myths">\u0032Mitos comunes sobre la navegación privada\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s elimina tu historial de búsqueda y navegación cuando salís de la aplicación o cerrás todas las pestañas privadas. Si bien esto no te hace anónimo en los sitios web o con tu proveedor de servicios de Internet, resulta más fácil mantener privado lo que hacés en línea respecto de cualquier otra persona que use este dispositivo.</string>
+  <string name="private_browsing_common_myths">\u0020Mitos comunes sobre la navegación privada\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -1505,7 +1505,7 @@
   -->
   <string name="download_delete_multiple_items_snackbar_2">Elementos eliminados: %1$d</string>
   <!-- Text for the snackbar to confirm that a single download item has been removed. %1$s is the name of the download item. -->
-  <string name="download_delete_single_item_snackbar" moz:removedIn="138" tools:ignore="UnusedResources">%1$s eliminado\u0032</string>
+  <string name="download_delete_single_item_snackbar" moz:removedIn="138" tools:ignore="UnusedResources">%1$s eliminado\u0020</string>
   <!-- Text for the snackbar to confirm that a single download item has been removed. %1$s is the name of the download item. -->
   <string name="download_delete_single_item_snackbar_2">Se eliminó “%1$s”</string>
   <!-- Text for the snackbar to confirm that downloads are in progress. -->
@@ -2731,7 +2731,7 @@
   <!-- Text shown when we aren't able to validate the custom search query. %s is the url of the custom search engine. -->
   <string name="search_add_custom_engine_error_cannot_reach">Error al conectarse con \"%s\"</string>
   <!-- Text shown when a user creates a new search engine. %s is the url of the custom search engine. -->
-  <string name="search_add_custom_engine_success_message">%s creado\u0032</string>
+  <string name="search_add_custom_engine_success_message">%s creado\u0020</string>
   <!-- Text shown when a user successfully edits a custom search engine. %s is the url of the custom search engine. -->
   <string name="search_edit_custom_engine_success_message">%s guardado</string>
   <!-- Text shown when a user successfully deletes a custom search engine. %s is the url of the custom search engine. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-es-rCL/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-es-rCL/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s limpia tu historial de búsqueda y navegación cuando sales de la aplicación o cierras todas las pestañas privadas. Si bien esto no te hace anónimo en los sitios web o con tu proveedor de servicios de Internet, facilita el mantener privado lo que haces en línea para cualquier otra persona que use este dispositivo.</string>
-  <string name="private_browsing_common_myths">\u0032Mitos comunes sobre la navegación privada\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Mitos comunes sobre la navegación privada\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-es-rES/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-es-rES/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s limpia tu historial de búsquedas y de navegación en las pestañas privadas cuando las cierras o al salir de la aplicación. Aunque no te hace invisible frente a los sitios web o tu proveedor de servicios, es más fácil salvaguardar tu vida privada de cualquier persona que use este dispositivo.</string>
-  <string name="private_browsing_common_myths">\u0032Mitos comunes sobre la navegación privada</string>
+  <string name="private_browsing_common_myths">\u0020Mitos comunes sobre la navegación privada</string>
   <!--
     True Private Browsing Mode
 
@@ -2197,7 +2197,7 @@
   <!-- Preference description for enhanced tracking protection for the strict protection settings -->
   <string name="preference_enhanced_tracking_protection_strict_description_4">Protección contra rastreo mejorada y mayor rendimiento, pero puede que algunos sitios no funcionen correctamente.</string>
   <!-- Accessibility text for the Strict protection information icon -->
-  <string name="preference_enhanced_tracking_protection_strict_info_button">Qué es lo que está bloqueado por la protección estricta contra el rastreo\u0032</string>
+  <string name="preference_enhanced_tracking_protection_strict_info_button">Qué es lo que está bloqueado por la protección estricta contra el rastreo\u0020</string>
   <!-- Preference for enhanced tracking protection for the custom protection settings -->
   <string name="preference_enhanced_tracking_protection_custom">Personalizado</string>
   <!-- Preference description for enhanced tracking protection for the strict protection settings -->
@@ -2673,7 +2673,7 @@
   <!-- Text shown when we aren't able to validate the custom search query. %s is the url of the custom search engine. -->
   <string name="search_add_custom_engine_error_cannot_reach">Error al conectar con “%s”</string>
   <!-- Text shown when a user creates a new search engine. %s is the url of the custom search engine. -->
-  <string name="search_add_custom_engine_success_message">%s creado\u0032</string>
+  <string name="search_add_custom_engine_success_message">%s creado\u0020</string>
   <!-- Text shown when a user successfully edits a custom search engine. %s is the url of the custom search engine. -->
   <string name="search_edit_custom_engine_success_message">%s guardado</string>
   <!-- Text shown when a user successfully deletes a custom search engine. %s is the url of the custom search engine. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-es/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-es/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s limpia tu historial de búsquedas y de navegación en las pestañas privadas cuando las cierras o al salir de la aplicación. Aunque no te hace invisible frente a los sitios web o tu proveedor de servicios, es más fácil salvaguardar tu vida privada de cualquier persona que use este dispositivo.</string>
-  <string name="private_browsing_common_myths">\u0032Mitos comunes sobre la navegación privada</string>
+  <string name="private_browsing_common_myths">\u0020Mitos comunes sobre la navegación privada</string>
   <!--
     True Private Browsing Mode
 
@@ -2197,7 +2197,7 @@
   <!-- Preference description for enhanced tracking protection for the strict protection settings -->
   <string name="preference_enhanced_tracking_protection_strict_description_4">Protección contra rastreo mejorada y mayor rendimiento, pero puede que algunos sitios no funcionen correctamente.</string>
   <!-- Accessibility text for the Strict protection information icon -->
-  <string name="preference_enhanced_tracking_protection_strict_info_button">Qué es lo que está bloqueado por la protección estricta contra el rastreo\u0032</string>
+  <string name="preference_enhanced_tracking_protection_strict_info_button">Qué es lo que está bloqueado por la protección estricta contra el rastreo\u0020</string>
   <!-- Preference for enhanced tracking protection for the custom protection settings -->
   <string name="preference_enhanced_tracking_protection_custom">Personalizado</string>
   <!-- Preference description for enhanced tracking protection for the strict protection settings -->
@@ -2673,7 +2673,7 @@
   <!-- Text shown when we aren't able to validate the custom search query. %s is the url of the custom search engine. -->
   <string name="search_add_custom_engine_error_cannot_reach">Error al conectar con “%s”</string>
   <!-- Text shown when a user creates a new search engine. %s is the url of the custom search engine. -->
-  <string name="search_add_custom_engine_success_message">%s creado\u0032</string>
+  <string name="search_add_custom_engine_success_message">%s creado\u0020</string>
   <!-- Text shown when a user successfully edits a custom search engine. %s is the url of the custom search engine. -->
   <string name="search_edit_custom_engine_success_message">%s guardado</string>
   <!-- Text shown when a user successfully deletes a custom search engine. %s is the url of the custom search engine. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-et/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-et/strings.xml
@@ -62,7 +62,7 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s kustutab privaatsete kaartide otsimise ja lehitsemise ajaloo, kui väljud rakendusest või sulged privaatsed kaardid. Kuigi see ei muuda sind külastatavate veebilehtede või internetiteenuse pakkuja ees anonüümseks, kaitseb see siiski sinu privaatsust teiste selle seadme kasutajate eest.</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s kustutab privaatsete kaartide otsimise ja lehitsemise ajaloo, kui väljud rakendusest või sulged privaatsed kaardid. Kuigi see ei muuda sind külastatavate veebilehtede või internetiteenuse pakkuja ees anonüümseks, kaitseb see siiski sinu privaatsust teiste selle seadme kasutajate eest.</string>
   <string name="private_browsing_common_myths">Levinumad müüdid privaatse veebilehitsemise kohta</string>
   <!--
     True Private Browsing Mode

--- a/mozilla-mobile/fenix/app/src/main/res/values-eu/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-eu/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s(e)k fitxa pribatuetako zure bilaketa- eta nabigatze-historia garbitzen du hauek ixtean edo aplikaziotik irtetean. Honek ez zaitu anonimo egiten webguneen edo zure interneteko zerbitzu-hornitzailearen aurrean baina erraztu egiten du ordenagailu hau erabiltzen duten beste erabiltzaileengandik online duzun jarduera pribatu mantentzen.</string>
-  <string name="private_browsing_common_myths">\u0032Nabigatze pribatuari buruzko ohiko mitoak\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Nabigatze pribatuari buruzko ohiko mitoak\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -615,7 +615,7 @@
   <!-- Title for the crash reporting option in the privacy preferences dialog shown during onboarding. -->
   <string name="onboarding_preferences_dialog_crash_reporting_title">Bidali automatikoki hutsegite-txostenak</string>
   <!-- Description for the crash reporting option in the privacy preferences dialog shown during onboarding. -->
-  <string name="onboarding_preferences_dialog_crash_reporting_description">Hutsegite-txostenek nabigatzailearen arazoak diagnostikatu eta konpontzen laguntzen digute. Txostenek datu pertsonal edo kontuzkoak izan litzakete.\u0032</string>
+  <string name="onboarding_preferences_dialog_crash_reporting_description">Hutsegite-txostenek nabigatzailearen arazoak diagnostikatu eta konpontzen laguntzen digute. Txostenek datu pertsonal edo kontuzkoak izan litzakete.\u0020</string>
   <!-- Learn more link for the crash reporting option in the privacy preferences dialog shown during onboarding. -->
   <string name="onboarding_preferences_dialog_crash_reporting_learn_more_2">Argibide gehiago</string>
   <!-- Title for the usage data option in the privacy preferences dialog shown during onboarding. Note: The word "Mozilla" should NOT be translated. -->
@@ -1149,7 +1149,7 @@
   <!-- Preference switch title for automatically submitting crash reports -->
   <string name="preferences_automatically_send_crashes_title">Bidali automatikoki hutsegite-txostenak</string>
   <!-- Preference switch description for automatically submitting crash reports -->
-  <string name="preferences_automatically_send_crashes_description">Hauek nabigatzailearen arazoak diagnostikatu eta konpontzen laguntzen digu honek. Txostenek datu pertsonal edo kontuzkoak izan litzakete.\u0032</string>
+  <string name="preferences_automatically_send_crashes_description">Hauek nabigatzailearen arazoak diagnostikatu eta konpontzen laguntzen digu honek. Txostenek datu pertsonal edo kontuzkoak izan litzakete.\u0020</string>
   <!-- Learn more link for crash reporting preference -->
   <string name="onboarding_preferences_dialog_crash_reporting_learn_more">Hutsegite-txostenei buruzko argibide gehiago</string>
   <!-- Title for studies preferences -->
@@ -2434,7 +2434,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Gordetako pasahitzak</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">%s(e)n gordetzen edo sinkronizatzen dituzun pasahitzak hemen agertuko dira. Gordetzen dituzun pasahitz guztiak zifratuta daude.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">%s(e)n gordetzen edo sinkronizatzen dituzun pasahitzak hemen agertuko dira. Gordetzen dituzun pasahitz guztiak zifratuta daude.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Sinkronizazioari buruzko argibide gehiago</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->
@@ -2693,7 +2693,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Egiaztatzailea: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Egiaztatzailea: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Ezabatu</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-fa/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-fa/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s جست‌وجوها و تاریخچهٔ مرور شما را هنگام خروج از برنامه یا بستن زبانه‌های خصوصی پاک می‌کند. در حالی که این کار شما را برای وبگاه‌ها یا فراهم‌کنندگان اینترنت ناشناس نمی‌کند، این کار مخفی کردن فعالیت‌های برخط شما را برای هرکس دیگری که از این افزاره استفاده می‌کند را ساده‌تر می‌کند.</string>
-  <string name="private_browsing_common_myths">\u0032باورهای غلط و رایج در مورد مرور خصوصی\u0032</string>
+  <string name="private_browsing_common_myths">\u0020باورهای غلط و رایج در مورد مرور خصوصی\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -530,7 +530,7 @@
   <!-- Text for the button dismiss the screen and move on with the flow -->
   <string name="juno_onboarding_default_browser_negative_button" tools:ignore="UnusedResources">اکنون نه</string>
   <!-- Title for sign in to sync screen. -->
-  <string name="juno_onboarding_sign_in_title_2">وقتی از دستگاه های مختلف استفاده می‌کنید رمزگذاری بمانید.\u0032</string>
+  <string name="juno_onboarding_sign_in_title_2">وقتی از دستگاه های مختلف استفاده می‌کنید رمزگذاری بمانید.\u0020</string>
   <!--
     Description for sign in to sync screen. Nimbus experiments do not support string placeholders.
     Note: The word "Firefox" should NOT be translated
@@ -2353,7 +2353,7 @@
   <!-- Preference to access list of login exceptions that we don't use DNS over HTTPS -->
   <string name="preference_doh_exceptions">استثناها</string>
   <!-- Description of "exceptions" for "DNS over HTTPS". %1$s is the name of the app (for example "Firefox"). -->
-  <string name="preference_doh_exceptions_summary">\u0032%1$s در این وبگاه‌ها و زیردامنه‌هایشان از ساناد امن استفاده نمی‌کند.</string>
+  <string name="preference_doh_exceptions_summary">\u0020%1$s در این وبگاه‌ها و زیردامنه‌هایشان از ساناد امن استفاده نمی‌کند.</string>
   <!-- Text displayed that links to adding website domain for "DNS over HTTPS" exceptions. -->
   <string name="preference_doh_exceptions_add">افزودن وبگاه</string>
   <!-- Text displayed above the input field when adding exceptions for "DNS over HTTPS". -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-fi/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-fi/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s tyhjentää haku- ja selaushistoriasi, kun suljet sovelluksen tai kaikki yksityiset välilehdet. Vaikka tämä ei tee sinusta anonyymia verkkosivustojen tai internetpalveluntarjoajan suuntaan, se helpottaa piilottamaan verkossa tekemiäsi asioita muilta tätä laitetta käyttäviltä.</string>
-  <string name="private_browsing_common_myths">\u0032Yleiset myytit yksityisestä selaamisesta\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Yleiset myytit yksityisestä selaamisesta\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-fr/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-fr/strings.xml
@@ -1455,7 +1455,7 @@
   -->
   <string name="download_delete_multiple_items_snackbar_2">Éléments supprimés : %1$d</string>
   <!-- Text for the snackbar to confirm that a single download item has been removed. %1$s is the name of the download item. -->
-  <string name="download_delete_single_item_snackbar" moz:removedIn="138" tools:ignore="UnusedResources">%1$s a été supprimé\u0032</string>
+  <string name="download_delete_single_item_snackbar" moz:removedIn="138" tools:ignore="UnusedResources">%1$s a été supprimé\u0020</string>
   <!-- Text for the snackbar to confirm that a single download item has been removed. %1$s is the name of the download item. -->
   <string name="download_delete_single_item_snackbar_2">« %1$s » supprimé</string>
   <!-- Text for the snackbar to confirm that downloads are in progress. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-fur/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-fur/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s al nete la cronologjie di ricercje e di navigazion des tôs schedis privadis cuant che tu lis sieris o tu jessis de aplicazion. Ancje se chest no ti rint anonim sui sîts web o al to furnidôr di servizis internet, al rint plui sempliç tignî privât ce che tu fasis in rêt, a chei altris che a doprin chest dispositîf.</string>
-  <string name="private_browsing_common_myths">\u0032Falsis crodincis su la navigazion privade\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s al nete la cronologjie di ricercje e di navigazion des tôs schedis privadis cuant che tu lis sieris o tu jessis de aplicazion. Ancje se chest no ti rint anonim sui sîts web o al to furnidôr di servizis internet, al rint plui sempliç tignî privât ce che tu fasis in rêt, a chei altris che a doprin chest dispositîf.</string>
+  <string name="private_browsing_common_myths">\u0020Falsis crodincis su la navigazion privade\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -615,7 +615,7 @@
   <!-- Title for the crash reporting option in the privacy preferences dialog shown during onboarding. -->
   <string name="onboarding_preferences_dialog_crash_reporting_title">Mande in automatic i rapuarts sui colàs</string>
   <!-- Description for the crash reporting option in the privacy preferences dialog shown during onboarding. -->
-  <string name="onboarding_preferences_dialog_crash_reporting_description">Lis segnalazions sui colàs nus permetin di fâ une diagnosi e comedâ i problemis cul navigadôr. Lis segnalazions a puedin includi dâts personâi o sensibii.\u0032</string>
+  <string name="onboarding_preferences_dialog_crash_reporting_description">Lis segnalazions sui colàs nus permetin di fâ une diagnosi e comedâ i problemis cul navigadôr. Lis segnalazions a puedin includi dâts personâi o sensibii.\u0020</string>
   <!-- Learn more link for the crash reporting option in the privacy preferences dialog shown during onboarding. -->
   <string name="onboarding_preferences_dialog_crash_reporting_learn_more_2">Plui informazions</string>
   <!-- Title for the usage data option in the privacy preferences dialog shown during onboarding. Note: The word "Mozilla" should NOT be translated. -->
@@ -831,7 +831,7 @@
   <!-- Preference for accessibility -->
   <string name="preferences_accessibility">Acessibilitât</string>
   <!-- Preference to override the Mozilla account server -->
-  <string name="preferences_override_account_server">Servidôr di account Mozilla personalizât\u0032</string>
+  <string name="preferences_override_account_server">Servidôr di account Mozilla personalizât\u0020</string>
   <!-- Preference to override the Sync token server -->
   <string name="preferences_override_sync_tokenserver">Servidôr personalizât par Sync</string>
   <!-- Preference category for account information -->
@@ -2430,7 +2430,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Passwords salvadis</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">Lis passwords salvadis o sincronizadis su %s a vignaran listadis achì. Dutis lis passwords che tu salvis a vegnin cifradis.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">Lis passwords salvadis o sincronizadis su %s a vignaran listadis achì. Dutis lis passwords che tu salvis a vegnin cifradis.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Plui informazions su la sincronizazion</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-fy-rNL/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-fy-rNL/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s wisket jo syk- en browserskiednis sa gau as jo de tapassing ôfslute of alle priveeljepblêden slute. Hoewol dit jo net anonym makket foar websites of jo ynternetprovider, makket dit it makliker om wat jo online dogge privee te hâlden tsjinoer oaren dy’t dit apparaat brûke.</string>
-  <string name="private_browsing_common_myths">\u0032Faaks hearde myten oer priveenavigaasje\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Faaks hearde myten oer priveenavigaasje\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2239,7 +2239,7 @@
   <!-- Preference summary for enhanced tracking protection settings on/off switch -->
   <string name="preference_enhanced_tracking_protection_summary">No mei Totale cookiebeskerming, ús krêftichste barriêre oant no ta tsjin cross-sitetrackers.</string>
   <!-- Description of enhanced tracking protection. %s is the name of the app (for example "Firefox"). -->
-  <string name="preference_enhanced_tracking_protection_explanation_2">%s beskermet jo tsjin in protte fan de meast foarkommende trackers dy\\’t folgje wat jo online dogge.\u0032</string>
+  <string name="preference_enhanced_tracking_protection_explanation_2">%s beskermet jo tsjin in protte fan de meast foarkommende trackers dy\\’t folgje wat jo online dogge.\u0020</string>
   <!-- Text displayed that links to website about enhanced tracking protection -->
   <string name="preference_enhanced_tracking_protection_explanation_learn_more">Mear ynfo</string>
   <!-- Preference for enhanced tracking protection for the standard protection settings -->
@@ -2511,7 +2511,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Bewarre wachtwurden</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">De wachtwurden dy’t jo bewarje of syngronisearje mei %s sille hjir fermeld wurde. Alle wachtwurden dy’t jo bewarje binne fersifere.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">De wachtwurden dy’t jo bewarje of syngronisearje mei %s sille hjir fermeld wurde. Alle wachtwurden dy’t jo bewarje binne fersifere.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Mear ynfo oer syngronisaasje</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->
@@ -2535,7 +2535,7 @@
   <!-- Shown in snackbar to tell user that the password has been copied -->
   <string name="logins_password_copied">Wachtwurd nei klamboerd kopiearre</string>
   <!-- Shown in snackbar to tell user that the username has been copied -->
-  <string name="logins_username_copied">Brûkersnamme nei klamboerd kopiearre\u0032</string>
+  <string name="logins_username_copied">Brûkersnamme nei klamboerd kopiearre\u0020</string>
   <!-- Content Description (for screenreaders etc) read for the button to copy a password in logins -->
   <string name="saved_logins_copy_password">Wachtwurd kopiearje</string>
   <!-- Content Description (for screenreaders etc) read for the button to clear a password while editing a login -->
@@ -2772,7 +2772,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Ferifiearre troch: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Ferifiearre troch: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Fuortsmite</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ga-rIE/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ga-rIE/strings.xml
@@ -14,7 +14,7 @@
   <string name="search_hint">Cuardaigh nó cuir seoladh isteach</string>
   <!-- No Open Tabs Message Description -->
   <string name="no_open_tabs_description">Taispeánfar do chluaisíní oscailte anseo.</string>
-  <string name="private_browsing_common_myths">\u0032Gnáthmhiotais maidir le brabhsáil phríobháideach\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Gnáthmhiotais maidir le brabhsáil phríobháideach\u0020</string>
   <!-- Text for the negative button to decline adding a Private Browsing shortcut to the Home screen -->
   <string name="cfr_neg_button_text" moz:removedIn="138" tools:ignore="UnusedResources">Ná cuir</string>
   <!--

--- a/mozilla-mobile/fenix/app/src/main/res/values-gd/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-gd/strings.xml
@@ -62,7 +62,7 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032Falamhaichidh %1$s eachdraidh nan lorg is a’ bhrabhsaidh aig tabaichean prìobhaideachd nuair a dhùineas tu iad no nuair a dh’fhàgas tu an aplacaid. Fhad ’s nach cuir seo am falach cò thusa mu choinneamh làraichean-lìn no solaraiche nan seirbheisean-lìn agad, cumaidh e na nì thu air loidhne am falach o dhaoine eile a chleachdas an t-uidheam seo.</string>
+  <string name="private_browsing_placeholder_description_2">\u0020Falamhaichidh %1$s eachdraidh nan lorg is a’ bhrabhsaidh aig tabaichean prìobhaideachd nuair a dhùineas tu iad no nuair a dh’fhàgas tu an aplacaid. Fhad ’s nach cuir seo am falach cò thusa mu choinneamh làraichean-lìn no solaraiche nan seirbheisean-lìn agad, cumaidh e na nì thu air loidhne am falach o dhaoine eile a chleachdas an t-uidheam seo.</string>
   <string name="private_browsing_common_myths">Faoin-sgeulan cumanta mun bhrabhsadh phrìobhaideach</string>
   <!--
     True Private Browsing Mode
@@ -132,7 +132,7 @@
   <!-- Text for the negative action button to dismiss the Close Tabs Banner. -->
   <string name="tab_tray_close_tabs_banner_negative_button_text">Leig seachad</string>
   <!-- Text for the banner message to tell users about our inactive tabs feature. -->
-  <string name="tab_tray_inactive_onboarding_message">Thèid tabaichean nach dug thu sùil orra fad cola-deug a ghluasad an-seo.\u0032</string>
+  <string name="tab_tray_inactive_onboarding_message">Thèid tabaichean nach dug thu sùil orra fad cola-deug a ghluasad an-seo.\u0020</string>
   <!-- Text for the action link to go to Settings for inactive tabs. -->
   <string name="tab_tray_inactive_onboarding_button_text">Cuir dheth sna roghainnean</string>
   <!-- Text for title for the auto-close dialog of the inactive tabs. -->
@@ -1633,7 +1633,7 @@
   <!-- Title B shown in the notification that pops up to re-engage the user -->
   <string name="notification_re_engagement_B_title">Tòisich air rudan a lorg</string>
   <!-- Text B shown in the notification that pops up to re-engage the user -->
-  <string name="notification_re_engagement_B_text">Lorg rud-eigin am fagas. No faigh lorg air rud-eigin spòrsail.\u0032</string>
+  <string name="notification_re_engagement_B_text">Lorg rud-eigin am fagas. No faigh lorg air rud-eigin spòrsail.\u0020</string>
   <!--
     Survey
 
@@ -1740,7 +1740,7 @@
   <!-- Action item in menu for the Delete browsing data on quit feature -->
   <string name="delete_browsing_data_on_quit_action">Fàg an-seo</string>
   <!-- Title text of a delete browsing data dialog. -->
-  <string name="delete_history_prompt_title">An rainse-ama a tha ri sguabadh às\u0032</string>
+  <string name="delete_history_prompt_title">An rainse-ama a tha ri sguabadh às\u0020</string>
   <!-- Body text of a delete browsing data dialog. -->
   <string name="delete_history_prompt_body_2">Bheir seo air falbh an eachdraidh (a’ gabhail a-staigh eachdraidh a chaidh a shioncronachadh o uidheaman eile)</string>
   <!-- Radio button in the delete browsing data dialog to delete history items for the last hour. -->
@@ -2777,7 +2777,7 @@
   <!-- The survey completion header -->
   <string name="micro_survey_survey_header_confirmation" tools:ignore="UnusedResources">Tha an t-suirbhidh air a choileanadh</string>
   <!-- The survey completion confirmation text -->
-  <string name="micro_survey_feedback_confirmation">Mòran taing airson do bheachdan a chur thugainn!\u0032</string>
+  <string name="micro_survey_feedback_confirmation">Mòran taing airson do bheachdan a chur thugainn!\u0020</string>
   <!-- Option for likert scale -->
   <string name="likert_scale_option_1" tools:ignore="UnusedResources">Glè riaraichte</string>
   <!-- Option for likert scale -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-gl/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-gl/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s limpa o historial de buscas e de navegación das lapelas privadas ao saír delas ou pechar a aplicación. Aínda que isto non conserva o seu anonimato en sitios web para o seu fornecedor de servizos de internet, si facilita manter en privado o que fai na rede para calquera outra persoa que utilice este ordenador.</string>
-  <string name="private_browsing_common_myths">\u0032Mitos frecuentes sobre a navegación privada\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s limpa o historial de buscas e de navegación das lapelas privadas ao saír delas ou pechar a aplicación. Aínda que isto non conserva o seu anonimato en sitios web para o seu fornecedor de servizos de internet, si facilita manter en privado o que fai na rede para calquera outra persoa que utilice este ordenador.</string>
+  <string name="private_browsing_common_myths">\u0020Mitos frecuentes sobre a navegación privada\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-gn/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-gn/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s omopotĩ nde jeheka ha kundahára rembiasakue tendayke ñemiguápe emboty térã esẽenguévo ko tembiporu’ígui. Kóva nande kuaukáiramo jepe ñanduti rendápe térã ne ñanduti me’ẽhárape, nombohasýi eime ñemi hag̃ua opaite tapicha oiporúva ko mba’e’oka renondépe.</string>
-  <string name="private_browsing_common_myths">\u0032Mombe’ugua’u kundahára ñemi rehegua\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Mombe’ugua’u kundahára ñemi rehegua\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -927,7 +927,7 @@
   <!-- Preference for notifications -->
   <string name="preferences_notifications">Ñemomarandu</string>
   <!-- Summary for notification preference indicating notifications are allowed -->
-  <string name="notifications_allowed_summary">Moneĩmbyre\u0032</string>
+  <string name="notifications_allowed_summary">Moneĩmbyre\u0020</string>
   <!-- Summary for notification preference indicating notifications are not allowed -->
   <string name="notifications_not_allowed_summary">Oñemoneĩ’ỹva</string>
   <!--
@@ -1806,7 +1806,7 @@
   <!-- Label that indicates that a permission must be blocked -->
   <string name="preference_option_phone_feature_blocked">Jokopyre</string>
   <!-- Label that indicates that a permission must be allowed -->
-  <string name="preference_option_phone_feature_allowed">Moneĩmbyre\u0032</string>
+  <string name="preference_option_phone_feature_allowed">Moneĩmbyre\u0020</string>
   <!-- Label that indicates a permission is by the Android OS -->
   <string name="phone_feature_blocked_by_android">Android ojokopyre</string>
   <!-- Preference for showing a list of websites that the default configurations won't apply to them -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-gu-rIN/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-gu-rIN/strings.xml
@@ -32,7 +32,7 @@
   <string name="tab_tray_close_multiselect_content_description">મલ્ટિસિલેક્ટ મોડમાંથી બહાર નીકળો</string>
   <!-- Content description for save to collection button while in multiselect mode in tab tray -->
   <string name="tab_tray_collection_button_multiselect_content_description">પસંદ કરેલા ટૅબ્સને સંગ્રહમાં સાચવો</string>
-  <string name="private_browsing_common_myths">\u0032ખાનગી બ્રાઉઝિંગ વિશે સામાન્ય માન્યતાઓ\u0032</string>
+  <string name="private_browsing_common_myths">\u0020ખાનગી બ્રાઉઝિંગ વિશે સામાન્ય માન્યતાઓ\u0020</string>
   <!-- Text for the negative button to decline adding a Private Browsing shortcut to the Home screen -->
   <string name="cfr_neg_button_text" moz:removedIn="138" tools:ignore="UnusedResources">ના આભાર</string>
   <!--
@@ -210,7 +210,7 @@
 
     Name of the "receive tabs" notification channel. Displayed in the "App notifications" system settings for the app
   -->
-  <string name="fxa_received_tab_channel_name">પ્રાપ્ત ટેબ્સ\u0032</string>
+  <string name="fxa_received_tab_channel_name">પ્રાપ્ત ટેબ્સ\u0020</string>
   <!-- Description of the "receive tabs" notification channel. Displayed in the "App notifications" system settings for the app -->
   <string name="fxa_received_tab_channel_description" tools:ignore="BrandUsage">અન્ય Firefox ઉપકરણોથી પ્રાપ્ત ટેબ્સ માટેની સૂચનાઓ.</string>
   <!-- The body for these is the URL of the tab received -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-hsb/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-hsb/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s wašu pytansku a přehladowansku historjiu z priwatnych rajtarkow wuprózdni, hdyž je začinjeće abo nałoženje kónčiće. Přez to so wosnadnja, před druhimi, kotřiž tutón grat wužiwaja, schować, štož online činiće, hačrunjež to was za websydła abo wašeho poskićowarja internetneje słužby njeanonymizuje.</string>
-  <string name="private_browsing_common_myths">\u0032Časte myty wo priwatnym modusu\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Časte myty wo priwatnym modusu\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -549,7 +549,7 @@
     Description for enable notification permission screen used by Nimbus experiments. Nimbus experiments do not support string placeholders.
     Note: The word "Firefox" should NOT be translated
   -->
-  <string name="juno_onboarding_enable_notifications_description_nimbus_2" tools:ignore="BrandUsage">Rozsyłajće rajtarki mjez swojimi gratami a wotkryjće druhe funkcije priwatnosće w Firefox.\u0032</string>
+  <string name="juno_onboarding_enable_notifications_description_nimbus_2" tools:ignore="BrandUsage">Rozsyłajće rajtarki mjez swojimi gratami a wotkryjće druhe funkcije priwatnosće w Firefox.\u0020</string>
   <!-- Text for the button to request notification permission on the device -->
   <string name="juno_onboarding_enable_notifications_positive_button" tools:ignore="UnusedResources">Zdźělenki zmóžnić</string>
   <!-- Text for the button dismiss the screen and move on with the flow -->
@@ -589,7 +589,7 @@
   <!-- Privacy Badger name for the onboarding add-ons card, used by Nimbus experiments. Note: The word "Privacy Badger" is a brand name should NOT be translated -->
   <string name="onboarding_add_on_privacy_badger_name" tools:ignore="UnusedResources">Privacy Badger</string>
   <!-- Privacy Badger description for the onboarding add-ons card, used by Nimbus experiments. -->
-  <string name="onboarding_add_on_privacy_badger_description" tools:ignore="UnusedResources">Juwel přećiwneho slědowanja. Stopujće njewidźomne přescěhowaki a spionowace wabjenje.\u0032</string>
+  <string name="onboarding_add_on_privacy_badger_description" tools:ignore="UnusedResources">Juwel přećiwneho slědowanja. Stopujće njewidźomne přescěhowaki a spionowace wabjenje.\u0020</string>
   <!-- Search by Image name for the onboarding add-ons card, used by Nimbus experiments. Note: The word "Search by Image" is a brand name should NOT be translated -->
   <string name="onboarding_add_on_search_by_image_name" tools:ignore="UnusedResources">Po wobrazu pytać</string>
   <!-- Search by Image description for the onboarding add-ons card, used by Nimbus experiments. -->
@@ -2772,7 +2772,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Přepruwowany wot: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Přepruwowany wot: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Zhašeć</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-hu/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-hu/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">A %1$s törli a keresési és böngészési előzményeit a privát lapokból, ha bezárja őket vagy kilép az alkalmazásból. Ugyan ez nem teszi névtelenné a weboldalak vagy a szolgáltatója felé, könnyebbé teszi, hogy bizalmasan kezelje az online tevékenységét, és más ne tudjon róla, aki ezt az eszközt használja.</string>
-  <string name="private_browsing_common_myths">\u0032Gyakori tévhitek a privát böngészésről\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Gyakori tévhitek a privát böngészésről\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2720,7 +2720,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Ellenőrizte: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Ellenőrizte: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Törlés</string>
   <!-- Login overflow menu edit button -->
@@ -3553,7 +3553,7 @@
   <!-- The title of the sign-in task for the setup checklist -->
   <string name="setup_checklist_task_account_sync">Bejelentkezés a fiókjába</string>
   <!-- The title of the theme selection task for the setup checklist -->
-  <string name="setup_checklist_task_theme_selection">Téma kiválasztása\u0032</string>
+  <string name="setup_checklist_task_theme_selection">Téma kiválasztása\u0020</string>
   <!-- The title of the toolbar selection task for the setup checklist -->
   <string name="setup_checklist_task_toolbar_selection">Eszköztár elhelyezésének kiválasztása</string>
   <!-- The title of the explore extensions task for the setup checklist -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-hy-rAM/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-hy-rAM/strings.xml
@@ -62,7 +62,7 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s-ը մաքրում է որոնման և դիտարկման պատմությունը, երբ փակում եք ներդիրը կամ դուրս եք գալիս հավելվածից: Չնայած դա ձեզ անանուն չի դարձնում կայքերի կամ ձեր համացանցի ծառայություններ մատուցողի համար, այն ավելի հեշտ է դարձնում ձեր առցանց ակտիվության գաղտնիությունը այն դեպքում, եթե մեկ ուրիշը ևս օգտագործում է տվյալ սարքը:</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s-ը մաքրում է որոնման և դիտարկման պատմությունը, երբ փակում եք ներդիրը կամ դուրս եք գալիս հավելվածից: Չնայած դա ձեզ անանուն չի դարձնում կայքերի կամ ձեր համացանցի ծառայություններ մատուցողի համար, այն ավելի հեշտ է դարձնում ձեր առցանց ակտիվության գաղտնիությունը այն դեպքում, եթե մեկ ուրիշը ևս օգտագործում է տվյալ սարքը:</string>
   <string name="private_browsing_common_myths">Տարածված առասպելներ գաղտնի դիտարկման վերաբերյալ</string>
   <!--
     True Private Browsing Mode
@@ -1590,7 +1590,7 @@
     %2$s is the total size of the downloaded file.
     %3$s is the amount of time remaining to complete the download.
   -->
-  <string name="download_item_in_progress_description" tools:ignore="UnusedResources">%1$s / %2$s • մնացել է՝ %3$s\u0032</string>
+  <string name="download_item_in_progress_description" tools:ignore="UnusedResources">%1$s / %2$s • մնացել է՝ %3$s\u0020</string>
   <!-- Text to indicate that an in progress download is paused. -->
   <string name="download_item_status_paused" tools:ignore="UnusedResources">դադարի մեջ</string>
   <!-- Text to indicate that the download speed of an in progress download is being calculated. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ia/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ia/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s rade tu chronologia de recerca e de navigation del schedas private quando tu los claude o quita le application. Ben que isto non te rende anonyme pro sitos web o pro tu fornitor de servicio internet, isto rende plus facile mantener tu activitates in linea private pro altere personas que usa iste apparato.</string>
-  <string name="private_browsing_common_myths">\u0032Mythos commun sur le navigation private\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Mythos commun sur le navigation private\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -1126,7 +1126,7 @@
   <!-- Label indicating that sync is in progress -->
   <string name="sync_syncing_in_progress">Synchronisation…</string>
   <!-- Label summary indicating that sync failed. %s is the date stamp showing last time it succeeded. -->
-  <string name="sync_failed_summary">Synchronisar fallite, ultime successo: %s\u0032</string>
+  <string name="sync_failed_summary">Synchronisar fallite, ultime successo: %s\u0020</string>
   <!-- Label summary showing never synced -->
   <string name="sync_failed_never_synced_summary">Synchronisation fallite. Ultime synchronisation: jammais</string>
   <!-- Label summary the date we last synced. %s is date stamp showing last time sync was completed. -->
@@ -1720,7 +1720,7 @@
   <!-- Bookmark overflow menu select all bookmarks -->
   <string name="bookmark_menu_select_all_bookmarks">Seliger toto</string>
   <!-- Bookmark overflow menu open in new tab button -->
-  <string name="bookmark_menu_open_in_new_tab_button">Aperir in un nove scheda\u0032</string>
+  <string name="bookmark_menu_open_in_new_tab_button">Aperir in un nove scheda\u0020</string>
   <!-- Bookmark overflow menu open in private tab button -->
   <string name="bookmark_menu_open_in_private_tab_button">Aperir in scheda private</string>
   <!-- Bookmark overflow menu open all in tabs button -->
@@ -2122,7 +2122,7 @@
   <!-- Title for Accessibility Text Size Scaling Preference -->
   <string name="preference_accessibility_font_size_title">Dimension del characteres</string>
   <!-- Title for Accessibility Text Automatic Size Scaling Preference -->
-  <string name="preference_accessibility_auto_size_2">Dimensionamento automatic del characteres\u0032</string>
+  <string name="preference_accessibility_auto_size_2">Dimensionamento automatic del characteres\u0020</string>
   <!-- Summary for Accessibility Text Automatic Size Scaling Preference -->
   <string name="preference_accessibility_auto_size_summary">Le dimension del characteres cercara le concordantias in tu parametros de Android. Disactiva hic le gestion del dimension del characteres.</string>
   <!-- Title for the Delete browsing data preference -->
@@ -2173,7 +2173,7 @@
   <!-- Radio button in the delete browsing data dialog to delete all history. -->
   <string name="delete_history_prompt_button_everything">Toto</string>
   <!-- Dialog message to the user asking to delete browsing data. %s is the name of the app (for example "Firefox"). -->
-  <string name="delete_browsing_data_prompt_message_3">%s delera le datos de navigation eligite.\u0032</string>
+  <string name="delete_browsing_data_prompt_message_3">%s delera le datos de navigation eligite.\u0020</string>
   <!-- Text for the cancel button for the data deletion dialog -->
   <string name="delete_browsing_data_prompt_cancel">Cancellar</string>
   <!-- Text for the allow button for the data deletion dialog -->
@@ -2239,7 +2239,7 @@
   <!-- Preference summary for enhanced tracking protection settings on/off switch -->
   <string name="preference_enhanced_tracking_protection_summary">Ora con le Protection total del cookies, nostre ancora plus potente barriera contra traciatores inter-sitos.</string>
   <!-- Description of enhanced tracking protection. %s is the name of the app (for example "Firefox"). -->
-  <string name="preference_enhanced_tracking_protection_explanation_2">%s te protege contra multe del traciatores commun que seque lo que tu face in linea.\u0032</string>
+  <string name="preference_enhanced_tracking_protection_explanation_2">%s te protege contra multe del traciatores commun que seque lo que tu face in linea.\u0020</string>
   <!-- Text displayed that links to website about enhanced tracking protection -->
   <string name="preference_enhanced_tracking_protection_explanation_learn_more">Saper plus</string>
   <!-- Preference for enhanced tracking protection for the standard protection settings -->
@@ -3395,7 +3395,7 @@
   <!-- Text shown in prompt for search microsurvey. Note: The word "Firefox" should NOT be translated. -->
   <string name="microsurvey_prompt_search_title" tools:ignore="BrandUsage,UnusedResources">Adjuta a render melior le recerca in Firefox. Illo prende solo un minuta</string>
   <!-- Text shown in prompt for sync microsurvey. Note: The word "Firefox" should NOT be translated. -->
-  <string name="microsurvey_prompt_sync_title" tools:ignore="BrandUsage,UnusedResources">Adjutar a render melior sync in Firefox. Illo prende solo un minuta\u0032</string>
+  <string name="microsurvey_prompt_sync_title" tools:ignore="BrandUsage,UnusedResources">Adjutar a render melior sync in Firefox. Illo prende solo un minuta\u0020</string>
   <!-- Text shown in the survey title for printing microsurvey. Note: The word "Firefox" should NOT be translated. -->
   <string name="microsurvey_survey_printing_title" tools:ignore="BrandUsage,UnusedResources">Quanto es tu satisfacite del impression in Firefox?</string>
   <!-- Text shown in the survey title for homepage microsurvey. Note: The word "Firefox" should NOT be translated. -->
@@ -3477,7 +3477,7 @@
   <!-- The title of the button for overriding home and current region. -->
   <string name="debug_drawer_override_region">Substituer region initial e actual</string>
   <!-- The title of the button for overriding home region permanently. -->
-  <string name="debug_drawer_override_home_region_permanently">Permanentemente supplantar le region principal\u0032</string>
+  <string name="debug_drawer_override_home_region_permanently">Permanentemente supplantar le region principal\u0020</string>
   <!--
     Messages explaining how to exit fullscreen mode
 
@@ -3649,7 +3649,7 @@
   <!-- Authentication prompt title to enable the private tabs mode -->
   <string name="pbm_authentication_enable_lock">Activar blocada de schermo pro schedas private</string>
   <!-- Authentication prompt title to disable the private tabs mode -->
-  <string name="pbm_authentication_disable_lock">Disactivar blocada de schermo pro schedas private\u0032</string>
+  <string name="pbm_authentication_disable_lock">Disactivar blocada de schermo pro schedas private\u0020</string>
   <!-- Label for a preference shown when the device supports screen lock (e.g., PIN, pattern, or password) but the user has not set one up. -->
   <string name="pbm_authentication_lock_device_feature_disabled">Configurar blocada de schermo pro celar schedas</string>
   <!-- Title text for the contextual feature recommendation (CFR) suggesting the user enable a screen lock to protect private tabs -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-in/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-in/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s menghapus riwayat pencarian dan penjelajahan dari tab privat ketika Anda menutupnya atau keluar dari aplikasi. Ketika hal ini tidak membuat Anda jadi anonim pada situs Web atau penyedia jasa Internet Anda, ini akan mempermudah dalam menjaga apa yang Anda lakukan daring secara privat dari orang lain yang menggunakan peranti ini.</string>
-  <string name="private_browsing_common_myths">\u0032Mitos umum tentang penjelajahan privat\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Mitos umum tentang penjelajahan privat\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-is/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-is/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032· %1$s hreinsar leitar- og vafraferilinn þinn þegar þú lokar forritinu eða lokar öllum huliðsflipum og gluggum. Þó að þetta sé ekki nafnlaust gagnvart vefsíðum eða þjónustuveitanda þínum, þá gerir þetta þér auðveldara að halda því sem þú gerir á netinu huldu gagnvart öðrum þeim sem nota þetta tæki.</string>
-  <string name="private_browsing_common_myths">\u0032Algengar mýtur um huliðsvafur</string>
+  <string name="private_browsing_placeholder_description_2">\u0020· %1$s hreinsar leitar- og vafraferilinn þinn þegar þú lokar forritinu eða lokar öllum huliðsflipum og gluggum. Þó að þetta sé ekki nafnlaust gagnvart vefsíðum eða þjónustuveitanda þínum, þá gerir þetta þér auðveldara að halda því sem þú gerir á netinu huldu gagnvart öðrum þeim sem nota þetta tæki.</string>
+  <string name="private_browsing_common_myths">\u0020Algengar mýtur um huliðsvafur</string>
   <!--
     True Private Browsing Mode
 
@@ -2511,7 +2511,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Vistuð lykilorð</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">Lykilorðin sem þú vistar eða samstillir við %s verða skráð hér. Öll lykilorð sem þú vistar eru dulrituð.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">Lykilorðin sem þú vistar eða samstillir við %s verða skráð hér. Öll lykilorð sem þú vistar eru dulrituð.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Frekari upplýsingar um samstillingu</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-iw/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-iw/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s מנקה את היסטוריית החיפוש והגלישה שלך מלשוניות פרטיות בעת סגירתן או כשהיישומון נסגר. פעולה זו אמנם לא הופכת אותך לאלמוני כלפי אתרים או ספק האינטרנט שלך, אבל כן מקלה עליך בשמירה על הפעולות המקוונות שלך מפני כל מי שמשתמש במכשיר זה.</string>
-  <string name="private_browsing_common_myths">\u0032מיתוסים נפוצים על גלישה פרטית\u0032</string>
+  <string name="private_browsing_common_myths">\u0020מיתוסים נפוצים על גלישה פרטית\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2766,7 +2766,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">אומת על־ידי %1$s\u0032</string>
+  <string name="certificate_info_verified_by">אומת על־ידי %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">מחיקה</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ja/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ja/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s のプライベートタブを閉じるかアプリを終了すると、その検索履歴と閲覧履歴が消去されます。これは、ウェブサイトやインターネットサービスプロバイダーに対して匿名でアクセスしているわけではありません。この機能は、この端末を使用する他者に対してオンライン上のプライベートな行動を隠すものです。</string>
-  <string name="private_browsing_common_myths">\u0032プライベートブラウジングについての誤解\u0032</string>
+  <string name="private_browsing_common_myths">\u0020プライベートブラウジングについての誤解\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -1726,7 +1726,7 @@
     Bookmark snackbar message on deletion
     %1$s is the host part of the URL of the bookmark deleted, if any
   -->
-  <string name="bookmark_deletion_snackbar_message">\u0032%1$s を削除しました</string>
+  <string name="bookmark_deletion_snackbar_message">\u0020%1$s を削除しました</string>
   <!-- Bookmark snackbar message on deleting multiple bookmarks not including folders -->
   <string name="bookmark_deletion_multiple_snackbar_message_2">ブックマークを削除しました</string>
   <!-- Bookmark snackbar message on deleting multiple bookmarks including folders -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ka/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ka/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s გაასუფთავებს თქვენი ძიებისა და ნახვების ისტორიას ყველა პირადი ჩანართის დახურვისას ან გამოსვლისას. მართალია, ეს ვერ დაფარავს თქვენს ვინაობას საიტებისა და ინტერნეტის მომწოდებლისგან, მაგრამ გაგიადვილებთ, დაიცვათ პირადი მონაცემები, თუ ამ მოწყობილობის სხვაც გამოიყენებს.</string>
-  <string name="private_browsing_common_myths">\u0032ცრუ წარმოდგენები პირადი თვალიერების შესახებ\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s გაასუფთავებს თქვენი ძიებისა და ნახვების ისტორიას ყველა პირადი ჩანართის დახურვისას ან გამოსვლისას. მართალია, ეს ვერ დაფარავს თქვენს ვინაობას საიტებისა და ინტერნეტის მომწოდებლისგან, მაგრამ გაგიადვილებთ, დაიცვათ პირადი მონაცემები, თუ ამ მოწყობილობის სხვაც გამოიყენებს.</string>
+  <string name="private_browsing_common_myths">\u0020ცრუ წარმოდგენები პირადი თვალიერების შესახებ\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -1967,7 +1967,7 @@
   <!-- A message template for the shared link with a footer. %1$s is the shared link, %2$s is the app name (e.g. Firefox) and %3$s is a download link for the app. -->
   <string name="sent_from_firefox_template" tools:ignore="UnusedResources">%1$s\n\nგთავაზობთ %2$s 🦊 გამოცადოთ მობილური ბრაუზერი: %3$s</string>
   <!-- A short message template for the shared link with a footer. %1$s is the shared link, %2$s is the app name (e.g. Firefox) and %3$s is a download link for the app. -->
-  <string name="sent_from_firefox_template_short" tools:ignore="UnusedResources">%1$s\n\nგთავაზობთ %2$s 🦊 %3$s\u0032</string>
+  <string name="sent_from_firefox_template_short" tools:ignore="UnusedResources">%1$s\n\nგთავაზობთ %2$s 🦊 %3$s\u0020</string>
   <!--
     Notifications
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-kaa/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-kaa/strings.xml
@@ -51,7 +51,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s izlew hám kóriw tariyxın jeke betlerdi japqanıńızda yamasa baǵdarlamadan shıqqanıńızda óshiredi. Bul sizdi veb-saytlar yamasa internet-provayderlar ushın anonim qılmaydı, tek ǵana usı qurılmanı qollanatuǵın basqa adamlardan óz háreketlerińizdiń internet tarmaǵında qupıyalıǵıńızdı saqlawdı jeńillestiredi.</string>
-  <string name="private_browsing_common_myths">\u0032Jeke kóriw haqqında tarqalǵan jalǵanlar\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Jeke kóriw haqqında tarqalǵan jalǵanlar\u0020</string>
   <!--
     Private mode shortcut "contextual feature recommendation" (CFR)
 
@@ -309,7 +309,7 @@
     Preference linking to about page for Fenix
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="preferences_about">%1$s haqqında\u0032</string>
+  <string name="preferences_about">%1$s haqqında\u0020</string>
   <!-- Preference for settings related to changing the default browser -->
   <string name="preferences_set_as_default_browser">Tiykarǵi brauzer retinde ornatıw</string>
   <!-- Preference category for advanced settings -->
@@ -946,7 +946,7 @@
   <!-- Preference for altering the storage access setting for all websites -->
   <string name="preference_phone_feature_cross_origin_storage_access">Saytlar aralıq cookielar</string>
   <!-- Preference for altering the EME access for all websites -->
-  <string name="preference_phone_feature_media_key_system_access">\u0032Avtor huqıqları menen qorǵalǵan kontent</string>
+  <string name="preference_phone_feature_media_key_system_access">\u0020Avtor huqıqları menen qorǵalǵan kontent</string>
   <!-- Label that indicates that a permission must be asked always -->
   <string name="preference_option_phone_feature_ask_to_allow">Ruqsat beriwdi sorań</string>
   <!-- Label that indicates that a permission must be blocked -->
@@ -1368,7 +1368,7 @@
   <!-- About page link text to open privacy notice link -->
   <string name="about_privacy_notice">Qupıyalıq esletpeleri</string>
   <!-- About page link text to open know your rights link -->
-  <string name="about_know_your_rights">Huqıqlarıńızdı biliń\u0032</string>
+  <string name="about_know_your_rights">Huqıqlarıńızdı biliń\u0020</string>
   <!-- About page link text to open licensing information link -->
   <string name="about_licensing_information">Licenziya maǵlıwmatları</string>
   <!-- About page link text to open a screen with libraries that are used -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-kab/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-kab/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s iseffeḍ amazray-ik n unadi d tunigin seg waccaren n tunigin tusligin mi ara tent-tmeḍleḍ neɣ mi ara teffɣeḍ seg usnas. Ɣas wama aya ur yettarra ara d udrig deg yismal web neɣ deg usaǧǧaw-ik n unekcum Internet, aya ad k-yeǧǧ ad tḥarzeḍ tabaḍnit n urmud-ik srid i wid yesseqdacen ibenk-ik.</string>
-  <string name="private_browsing_common_myths">\u0032Tiktiwin tigejdanin yuzzlen ur nṣeḥḥi ara\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Tiktiwin tigejdanin yuzzlen ur nṣeḥḥi ara\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2324,7 +2324,7 @@
     Open source licenses page title
     %s is the name of the app (for example "Firefox")
   -->
-  <string name="open_source_licenses_title">%s | timkerḍiyin OSS\u0032</string>
+  <string name="open_source_licenses_title">%s | timkerḍiyin OSS\u0020</string>
   <!-- Category of trackers (redirect trackers) that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_redirect_trackers_title">Welleh i yineḍfaren</string>
   <!-- Description of redirect tracker cookies that can be blocked by Enhanced Tracking Protection -->
@@ -2985,7 +2985,7 @@
   <!-- Label for the dropdown to select which language to translate to on the translations dialog. Usually the translate to language selected will be the user's preferred language. -->
   <string name="translations_bottom_sheet_translate_to">Suqqel ɣer</string>
   <!-- Label for the dropdown to select which language to translate from on the translations dialog when the page language is not supported. This selection is to allow the user to select another language, in case we automatically detected the page language incorrectly. -->
-  <string name="translations_bottom_sheet_translate_from_unsupported_language">Ɛreḍ tutlayt taɣbalut niḍen\u0032</string>
+  <string name="translations_bottom_sheet_translate_from_unsupported_language">Ɛreḍ tutlayt taɣbalut niḍen\u0020</string>
   <!-- Button text on the translations dialog to dismiss the dialog and return to the browser. -->
   <string name="translations_bottom_sheet_negative_button">Mačči tura</string>
   <!-- Button text on the translations dialog to restore the translated website back to the original untranslated version. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-kmr/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-kmr/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s, dema ku te hilpekînên veşartî girtin an jî tu ji sepanê derket ew ê raboriya te ya gerîn û lêgerînê ji hilpekînên veşartî bên paqijkirin. Ev, rê li ber şopandina te ya ji aliyê malper û peydakerên servîsê ve nagirê lê heke hin kesên din ên vê cîhazê bi kar tînin hebin ew ê bihêle ku tu raboriya xwe ji wan veşêrî.</string>
-  <string name="private_browsing_common_myths">\u0032Efsaneyên berbelav ên têkildarî gerîna veşartî\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s, dema ku te hilpekînên veşartî girtin an jî tu ji sepanê derket ew ê raboriya te ya gerîn û lêgerînê ji hilpekînên veşartî bên paqijkirin. Ev, rê li ber şopandina te ya ji aliyê malper û peydakerên servîsê ve nagirê lê heke hin kesên din ên vê cîhazê bi kar tînin hebin ew ê bihêle ku tu raboriya xwe ji wan veşêrî.</string>
+  <string name="private_browsing_common_myths">\u0020Efsaneyên berbelav ên têkildarî gerîna veşartî\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -149,7 +149,7 @@
     Text for the body for the auto-close dialog of the inactive tabs.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="tab_tray_inactive_auto_close_body_2">\u0032%1$s dikare hilpekînên te di meha borî de venekirine bigire.</string>
+  <string name="tab_tray_inactive_auto_close_body_2">\u0020%1$s dikare hilpekînên te di meha borî de venekirine bigire.</string>
   <!-- Content description for close button in the auto-close dialog of the inactive tabs. -->
   <string name="tab_tray_inactive_auto_close_button_content_description">Bigire</string>
   <!-- Text for turn on auto close tabs button in the auto-close dialog of the inactive tabs. -->
@@ -377,7 +377,7 @@
   <!-- Browser menu label that navigates to the edit bookmark screen for the current bookmarked page -->
   <string name="browser_menu_edit_bookmark">Favoriyan serast bike</string>
   <!-- Browser menu label that the saves the currently visited page as a PDF -->
-  <string name="browser_menu_save_as_pdf">\u0032Wekî PDF qeyd bike…</string>
+  <string name="browser_menu_save_as_pdf">\u0020Wekî PDF qeyd bike…</string>
   <!-- Browser menu label for turning ON reader view of the current visited page -->
   <string name="browser_menu_turn_on_reader_view">Xuyakirina Readerê veke</string>
   <!-- Browser menu label for turning OFF reader view of the current visited page -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ko/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ko/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s는 사생활 보호 탭을 닫거나 앱을 종료할 때 사생활 보호 탭으로부터 검색과 방문 기록을 지웁니다. 이것이 사용자를 웹 사이트나 인터넷 서비스 제공자로부터 익명으로 만들지는 않지만, 사용자가 온라인에서 한 일을 이 기기를 사용하는 다른 사용자로부터 보호 할 수 있게 합니다.</string>
-  <string name="private_browsing_common_myths">\u0032사생활 보호 모드에 관한 흔한 오해\u0032</string>
+  <string name="private_browsing_common_myths">\u0020사생활 보호 모드에 관한 흔한 오해\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -1070,7 +1070,7 @@
   <!-- Title for the "Momo" themed alternative app icon variant in the icon picker screen. The app icon was created by artist @heyheymomodraws and features a unique hand-drawn style with a friendly fox. -->
   <string name="alternative_app_icon_option_momo">모모</string>
   <!-- Subtitle for the "Momo" themed alternative app icon variant in the icon picker screen. The app icon was created by artist @heyheymomodraws and features a unique hand-drawn style with a friendly fox. -->
-  <string name="alternative_app_icon_option_momo_subtitle">\u0064heyheymomodraws 제작</string>
+  <string name="alternative_app_icon_option_momo_subtitle">\u0040heyheymomodraws 제작</string>
   <!--
     Add-ons general availability nimbus message
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-lo/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-lo/strings.xml
@@ -62,7 +62,7 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s ຈະລຶບລ້າງປະຫວັດການຊອກຫາ ແລະການຊອກຫາຂອງທ່ານອອກຈາກແຖບສ່ວນຕົວ ເມື່ອທ່ານປິດພວກມັນ ຫຼືອອກຈາກແອັບ. ໃນຂະນະທີ່ນີ້ບໍ່ໄດ້ເຮັດໃຫ້ທ່ານບໍ່ເປີດເຜີຍຊື່ກັບເວັບໄຊທ໌ ຫຼືຜູ້ໃຫ້ບໍລິການອິນເຕີເນັດຂອງທ່ານ, ມັນເຮັດໃຫ້ມັນງ່າຍຂຶ້ນທີ່ຈະຮັກສາສິ່ງທີ່ທ່ານເຮັດອອນໄລນ໌ເປັນສ່ວນຕົວຈາກຜູ້ອື່ນທີ່ໃຊ້ອຸປະກອນນີ້.</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s ຈະລຶບລ້າງປະຫວັດການຊອກຫາ ແລະການຊອກຫາຂອງທ່ານອອກຈາກແຖບສ່ວນຕົວ ເມື່ອທ່ານປິດພວກມັນ ຫຼືອອກຈາກແອັບ. ໃນຂະນະທີ່ນີ້ບໍ່ໄດ້ເຮັດໃຫ້ທ່ານບໍ່ເປີດເຜີຍຊື່ກັບເວັບໄຊທ໌ ຫຼືຜູ້ໃຫ້ບໍລິການອິນເຕີເນັດຂອງທ່ານ, ມັນເຮັດໃຫ້ມັນງ່າຍຂຶ້ນທີ່ຈະຮັກສາສິ່ງທີ່ທ່ານເຮັດອອນໄລນ໌ເປັນສ່ວນຕົວຈາກຜູ້ອື່ນທີ່ໃຊ້ອຸປະກອນນີ້.</string>
   <string name="private_browsing_common_myths">ຄວາມເຂົ້າໃຈຜິດທີ່ມັກພົບຕະລອດກ່ຽວກັບການທ່ອງເວັບແບບສ່ວນຕົວ</string>
   <!--
     True Private Browsing Mode
@@ -929,7 +929,7 @@
   <!-- Preference for extensions -->
   <string name="preferences_extensions">ສ່ວນຂະຫຍາຍ</string>
   <!-- Preference for installing a local extension -->
-  <string name="preferences_install_local_extension">ຕິດຕັ້ງສ່ວນຂະຫຍາຍຈາກໄຟລ໌\u0032</string>
+  <string name="preferences_install_local_extension">ຕິດຕັ້ງສ່ວນຂະຫຍາຍຈາກໄຟລ໌\u0020</string>
   <!-- Preference for notifications -->
   <string name="preferences_notifications">ການແຈ້ງເຕືອນ</string>
   <!-- Summary for notification preference indicating notifications are allowed -->
@@ -1010,7 +1010,7 @@
   <!-- Text for classic wallpapers title. %s is the name of the app (for example "Firefox"). -->
   <string name="wallpaper_classic_title">ຄລາດສິກ %s</string>
   <!-- Text for artist series wallpapers title. "Artist series" represents a collection of artist collaborated wallpapers. -->
-  <string name="wallpaper_artist_series_title">ຊຸດສິນລະປິນ\u0032</string>
+  <string name="wallpaper_artist_series_title">ຊຸດສິນລະປິນ\u0020</string>
   <!-- Description text for the artist series wallpapers with learn more link. %s is a learn more link using wallpaper_learn_more as text. "Independent voices" is the name of the wallpaper collection -->
   <string name="wallpaper_artist_series_description_with_learn_more">ການເກັບກໍາສຽງເອກະລາດ. %s</string>
   <!-- Description text for the artist series wallpapers. "Independent voices" is the name of the wallpaper collection -->
@@ -1550,7 +1550,7 @@
   <!-- Placeholder text to indicate that users can use the search bar to search for a download. -->
   <string name="download_search_placeholder">ຄົ້ນຫາການດາວໂຫຼດ</string>
   <!-- Text to indicate that no downloads match the search query. -->
-  <string name="download_search_no_results_found">ບໍ່ພົບຜົນການຄົ້ນຫາ\u0032</string>
+  <string name="download_search_no_results_found">ບໍ່ພົບຜົນການຄົ້ນຫາ\u0020</string>
   <!-- Text for the "Select all" button, which selects all downloaded items in the downloads list. -->
   <string name="download_select_all_items">ເລືອກ​ທັງ​ຫມົດ</string>
   <!--
@@ -2746,7 +2746,7 @@
   -->
   <string name="firefox_suggest_header" tools:ignore="BrandUsage">Firefox ແນະນໍາ</string>
   <!-- Title for search suggestions when Google is the default search suggestion engine. -->
-  <string name="google_search_engine_suggestion_header">ຄົ້ນ​ຫາ Google\u0032</string>
+  <string name="google_search_engine_suggestion_header">ຄົ້ນ​ຫາ Google\u0020</string>
   <!-- Title for search suggestions when the default search suggestion engine is anything other than Google. %s is default search engine name. -->
   <string name="other_default_search_engine_suggestion_header">%s ຄົ້ນຫາ</string>
   <!-- Default browser card text -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ml/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ml/strings.xml
@@ -360,13 +360,13 @@
   <!-- Content description (not visible, for screen readers etc.) for bottom sheet handlebar custom tab menu. -->
   <string name="browser_custom_tab_menu_handlebar_content_description">ഇഷ്ടാനുസൃത ടാബുകുറിപ്പടി താളു് അടയ്ക്കുക</string>
   <!-- Browser menu description that describes the various tools related menu items inside of the tools sub-menu when the "Report broken site" feature is available -->
-  <string name="browser_menu_tools_description_with_translate_with_report_site_2">വായന കാഴ്ച, വിവർത്തനം, തകർന്ന വെബ്സ്ഥാനത്തിനെ കുറിച്ചു് വിവരം അറിയിക്കുക,അച്ചടിപ്പു്, പങ്കിയൽ, പ്രയോഗം തുറക്കുക\u0032</string>
+  <string name="browser_menu_tools_description_with_translate_with_report_site_2">വായന കാഴ്ച, വിവർത്തനം, തകർന്ന വെബ്സ്ഥാനത്തിനെ കുറിച്ചു് വിവരം അറിയിക്കുക,അച്ചടിപ്പു്, പങ്കിയൽ, പ്രയോഗം തുറക്കുക\u0020</string>
   <!-- Browser menu description that describes the various tools related menu items inside of the tools sub-menu -->
-  <string name="browser_menu_tools_description_with_translate_without_report_site">വായന കാഴ്ച, വിവർത്തനം, അച്ചടിപ്പു്, പങ്കിയൽ, പ്രയോഗം തുറക്കുക\u0032</string>
+  <string name="browser_menu_tools_description_with_translate_without_report_site">വായന കാഴ്ച, വിവർത്തനം, അച്ചടിപ്പു്, പങ്കിയൽ, പ്രയോഗം തുറക്കുക\u0020</string>
   <!-- Browser menu description that describes the various tools related menu items inside of the tools sub-menu when the "Report broken site" feature is available -->
-  <string name="browser_menu_tools_description_with_report_site_2">വായന കാഴ്ച, തകർന്ന വെബ്സ്ഥാനത്തിനെ കുറിച്ചു് വിവരം അറിയിക്കുക,അച്ചടിപ്പു്, പങ്കിയൽ, പ്രയോഗം തുറക്കുക\u0032</string>
+  <string name="browser_menu_tools_description_with_report_site_2">വായന കാഴ്ച, തകർന്ന വെബ്സ്ഥാനത്തിനെ കുറിച്ചു് വിവരം അറിയിക്കുക,അച്ചടിപ്പു്, പങ്കിയൽ, പ്രയോഗം തുറക്കുക\u0020</string>
   <!-- Browser menu description that describes the various tools related menu items inside of the tools sub-menu -->
-  <string name="browser_menu_tools_description_without_report_site">വായന കാഴ്ച, അച്ചടിപ്പു്, പങ്കിയൽ, പ്രയോഗം തുറക്കുക\u0032</string>
+  <string name="browser_menu_tools_description_without_report_site">വായന കാഴ്ച, അച്ചടിപ്പു്, പങ്കിയൽ, പ്രയോഗം തുറക്കുക\u0020</string>
   <!--
     Browser menu label that navigates to the save sub-menu, which contains various save related menu items such as
     bookmarking a page, saving to collection, shortcut or as a PDF, and adding to home screen
@@ -434,7 +434,7 @@
     %1$s is the name of the language that is displayed in the original page. (For example: English)
     %2$s is the name of the language which the page was translated to. (For example: French)
   -->
-  <string name="browser_toolbar_translated_successfully">ഈ താൾ %1$s-ൽ നിന്നു് %2$s-ലേക്കു് വിവർത്തനം ചെയ്തിരിക്കുന്നു\u0032</string>
+  <string name="browser_toolbar_translated_successfully">ഈ താൾ %1$s-ൽ നിന്നു് %2$s-ലേക്കു് വിവർത്തനം ചെയ്തിരിക്കുന്നു\u0020</string>
   <!--
     Locale Settings Fragment
 
@@ -501,7 +501,7 @@
   <!-- Text for the button to skip the onboarding on the home onboarding dialog. -->
   <string name="onboarding_home_skip_button">ഒഴിവാക്കുക</string>
   <!-- Onboarding home screen sync popup dialog message, shown on top of Recent Synced Tabs in the Jump back in section. -->
-  <string name="sync_cfr_message">താങ്ങളുടെ ടാബുകൾ സമന്വയിപ്പിക്കുന്നു! താങ്ങളുടെ മറ്റു് ഉപകരണത്തിൽ നിർത്തിയിടത്തു് നിന്നു് വീണ്ടും തുടങ്ങുക.\u0032</string>
+  <string name="sync_cfr_message">താങ്ങളുടെ ടാബുകൾ സമന്വയിപ്പിക്കുന്നു! താങ്ങളുടെ മറ്റു് ഉപകരണത്തിൽ നിർത്തിയിടത്തു് നിന്നു് വീണ്ടും തുടങ്ങുക.\u0020</string>
   <!-- Content description (not visible, for screen readers etc.): Close button for the home onboarding dialog -->
   <string name="onboarding_home_content_description_close_button">അടയ്ക്കുക</string>
   <!--
@@ -509,7 +509,7 @@
 
     Description for learning more about our privacy notice.
   -->
-  <string name="juno_onboarding_privacy_notice_text" tools:ignore="BrandUsage">Firefox സ്വകാര്യത അറിയിപ്പു്\u0032</string>
+  <string name="juno_onboarding_privacy_notice_text" tools:ignore="BrandUsage">Firefox സ്വകാര്യത അറിയിപ്പു്\u0020</string>
   <!-- Title for set firefox as default browser screen used by Nimbus experiments. -->
   <string name="juno_onboarding_default_browser_title_nimbus_2">താങ്ങളെ സുരക്ഷിതമായി വയ്ക്കാൻ ഞങ്ങളുടെ കടമയാണു്</string>
   <!--
@@ -535,7 +535,7 @@
     Description for sign in to sync screen. Nimbus experiments do not support string placeholders.
     Note: The word "Firefox" should NOT be translated
   -->
-  <string name="juno_onboarding_sign_in_description_3" tools:ignore="BrandUsage">താങ്ങൾ സമന്വയിപ്പിച്ചിരിക്കുമ്പോഴു് ഫയർഫോക്സു് താങ്ങളുടെ രഹസ്യവാക്കുകളും അടയാളക്കുറിപ്പുകളും മറ്റും രൂപമാറ്റി വയ്ക്കാരുണ്ടു്.\u0032</string>
+  <string name="juno_onboarding_sign_in_description_3" tools:ignore="BrandUsage">താങ്ങൾ സമന്വയിപ്പിച്ചിരിക്കുമ്പോഴു് ഫയർഫോക്സു് താങ്ങളുടെ രഹസ്യവാക്കുകളും അടയാളക്കുറിപ്പുകളും മറ്റും രൂപമാറ്റി വയ്ക്കാരുണ്ടു്.\u0020</string>
   <!-- Text for the button to sign in to sync on the device -->
   <string name="juno_onboarding_sign_in_positive_button" tools:ignore="UnusedResources">പ്രവേശിക്കുക</string>
   <!-- Text for the button dismiss the screen and move on with the flow -->
@@ -684,7 +684,7 @@
 
     Widget description for widget picker screen
   -->
-  <string name="widget_picket_description">ഒരു ഉടന്തിരച്ചിൽ തുടങ്ങുക\u0032</string>
+  <string name="widget_picket_description">ഒരു ഉടന്തിരച്ചിൽ തുടങ്ങുക\u0020</string>
   <!--
     Search Widget
 
@@ -757,7 +757,7 @@
   <!-- Preference for enabling "HTTPS-Only" mode -->
   <string name="preferences_https_only_title">HTTPS-മാത്രം രീതി</string>
   <!-- Preference title for using the screen lock to hide tabs in private browsing -->
-  <string name="preferences_pbm_lock_screen_title">സ്വകാര്യ തിരച്ചിലിൽ ടാബുകളെ മറയ്ക്കാൻ വേണ്ടി പ്രതലത്താഴു് ഉപയോഗിക്കുക\u0032</string>
+  <string name="preferences_pbm_lock_screen_title">സ്വകാര്യ തിരച്ചിലിൽ ടാബുകളെ മറയ്ക്കാൻ വേണ്ടി പ്രതലത്താഴു് ഉപയോഗിക്കുക\u0020</string>
   <!-- Label for cookie banner section in quick settings panel. -->
   <string name="cookie_banner_blocker">കുക്കീസു് പൊന്തുവരൽ തടയൽയന്ത്രം</string>
   <!-- Preference for removing cookie/consent banners from sites automatically in private mode. See reduce_cookie_banner_summary for additional context. -->
@@ -791,7 +791,7 @@
   <!-- Title for the cookie banner re-engagement CFR, the placeholder is replaced with app name. %1$s is the name of the app (for example "Firefox"). -->
   <string name="cookie_banner_cfr_title">%1$s താങ്ങൾക്കായി കുക്കികൾ നിരസിച്ചു</string>
   <!-- Message for the cookie banner re-engagement CFR -->
-  <string name="cookie_banner_cfr_message">കുറഞ്ഞ പതൎച്ചയും കുറഞ്ഞ കുക്കിപ്പിന്തുടൎച്ചയും\u0032</string>
+  <string name="cookie_banner_cfr_message">കുറഞ്ഞ പതൎച്ചയും കുറഞ്ഞ കുക്കിപ്പിന്തുടൎച്ചയും\u0020</string>
   <!-- Summary of https only preference if https only is set to off -->
   <string name="preferences_https_only_off">അണച്ചതു്</string>
   <!-- Summary of https only preference if https only is set to on in all tabs -->
@@ -1224,7 +1224,7 @@
     Message to warn users that a large number of tabs will be opened
     %s will be replaced by app name.
   -->
-  <string name="open_all_warning_message">\u0032താളുകള്‍ ലഭ്യമാക്കുമ്പോഴു് ഇത്രോളം ടാബുകൾ തുറന്നാൽ %s-ന്റെ വേഗത കുറയ്ക്കുവാന്‍ ഇതു് ചിലപ്പോള്‍ കാരണമാകുന്നു. തുടരണമെന്നു് ഉറപ്പാണോ?</string>
+  <string name="open_all_warning_message">\u0020താളുകള്‍ ലഭ്യമാക്കുമ്പോഴു് ഇത്രോളം ടാബുകൾ തുറന്നാൽ %s-ന്റെ വേഗത കുറയ്ക്കുവാന്‍ ഇതു് ചിലപ്പോള്‍ കാരണമാകുന്നു. തുടരണമെന്നു് ഉറപ്പാണോ?</string>
   <!-- Dialog button text for confirming open all tabs -->
   <string name="open_all_warning_confirm">തുറന്ന ടാബുകള്‍</string>
   <!-- Dialog button text for canceling open all tabs -->
@@ -1284,7 +1284,7 @@
 
     Title of a preference that allows a user to choose what screen to show after opening the app
   -->
-  <string name="preferences_opening_screen">ആമുഖം\u0032</string>
+  <string name="preferences_opening_screen">ആമുഖം\u0020</string>
   <!-- Option for always opening the homepage when re-opening the app -->
   <string name="opening_screen_homepage">ആമുഖത്താൾ</string>
   <!-- Option for always opening the user's last-open tab when re-opening the app -->
@@ -3047,7 +3047,7 @@
   <!-- Content description (not visible, for screen readers etc.): For a language list item that was not downloaded. -->
   <string name="download_languages_item_content_description_not_downloaded_state">ഇറക്കിവയ്ക്കുക</string>
   <!-- The title of the warning card informs the user that an error has occurred when fetching the list of languages. -->
-  <string name="download_languages_fetch_error_warning_text">ഭാഷാകൾ ലഭ്യമാക്കാൻ കഴിഞ്ഞില്ല. കുറച്ചു് നേരം കഴിഞ്ഞു് വീണ്ടും ശ്രമിക്കുക.\u0032</string>
+  <string name="download_languages_fetch_error_warning_text">ഭാഷാകൾ ലഭ്യമാക്കാൻ കഴിഞ്ഞില്ല. കുറച്ചു് നേരം കഴിഞ്ഞു് വീണ്ടും ശ്രമിക്കുക.\u0020</string>
   <!--
     The title of the warning card informs the user that an error has occurred at downloading a language.
     %1$s is the language name, for example, "Spanish".
@@ -3086,7 +3086,7 @@
   -->
   <string name="download_language_file_dialog_title">ദത്ത കരുതിവയ്ക്കൽ രീതിയിൽ ഭാഷ ഇറക്കിവയ്ക്കണോ (%1$s)?</string>
   <!-- Additional information for the data saving mode warning dialog used by the translations feature. This text explains the reason a download is required for a translation. -->
-  <string name="download_language_file_dialog_message_all_languages">വിവൎത്തനങ്ങളെ സ്വകാര്യമായി വയ്ക്കുന്നതിനു് ഞങ്ങൾ ഭാഗികമായി ഭാഷകളെ താങ്ങളുടെ ഗണനികയതിവേഗോൎമ്മയിലോട്ടു് ഇറക്കിവയ്ക്കാരുണ്ടു്.\u0032</string>
+  <string name="download_language_file_dialog_message_all_languages">വിവൎത്തനങ്ങളെ സ്വകാര്യമായി വയ്ക്കുന്നതിനു് ഞങ്ങൾ ഭാഗികമായി ഭാഷകളെ താങ്ങളുടെ ഗണനികയതിവേഗോൎമ്മയിലോട്ടു് ഇറക്കിവയ്ക്കാരുണ്ടു്.\u0020</string>
   <!-- Checkbox label text on the data saving mode warning dialog used by the translations feature. This checkbox allows users to ignore the data usage warnings. -->
   <string name="download_language_file_dialog_checkbox_text">എപ്പോഴും ദത്തകരുതിവയ്ക്കൽ രീതിയിൽ ഇറക്കിവയ്ക്കുക</string>
   <!-- Button text on the data saving mode warning dialog used by the translations feature to allow users to confirm they wish to continue and download the language file. -->
@@ -3131,7 +3131,7 @@
     Text for displaying the total number of trackers blocked in the protection panel.
     %d is a placeholder for the number of trackers blocked.
   -->
-  <string name="protection_panel_num_trackers_blocked">തടഞ്ഞിരിക്കുന്ന പിന്തുടർച്ചായന്ത്രങ്ങൾ: %d\u0032</string>
+  <string name="protection_panel_num_trackers_blocked">തടഞ്ഞിരിക്കുന്ന പിന്തുടർച്ചായന്ത്രങ്ങൾ: %d\u0020</string>
   <!-- Text for when no trackers have been blocked. -->
   <string name="protection_panel_no_trackers_blocked">പിന്തുടർച്ചയന്ത്രങ്ങൾ കണ്ടെത്താൻ കഴിഞ്ഞില്ല</string>
   <!-- Link text to navigate to privacy and security settings from the protection panel. -->
@@ -3142,7 +3142,7 @@
     Text for displaying the total number of trackers blocked in the trackers blocked panel.
     %d is a placeholder for the number of trackers blocked.
   -->
-  <string name="trackers_blocked_panel_total_num_trackers_blocked">തടഞ്ഞിരിക്കുന്ന പിന്തുടർച്ചായന്ത്രങ്ങൾ: %d\u0032</string>
+  <string name="trackers_blocked_panel_total_num_trackers_blocked">തടഞ്ഞിരിക്കുന്ന പിന്തുടർച്ചായന്ത്രങ്ങൾ: %d\u0020</string>
   <!--
     Text for displaying the number of trackers blocked for a specific tracker category in the trackers blocked panel.
     %s is a placeholder for the name of the tracker category.
@@ -3205,7 +3205,7 @@
     quantity greater than the max tabs. %1$s is the maximum number of tabs
     that can be generated in one operation.
   -->
-  <string name="debug_drawer_tab_tools_tab_quantity_exceed_max_error">ഒരു ക്രയത്തിൽ ഉച്ചനില സൃഷ്ടിക്കാനാവുന്ന ടാബുകളുടെ (%1$s) അതിരുകവിഞ്ഞു\u0032</string>
+  <string name="debug_drawer_tab_tools_tab_quantity_exceed_max_error">ഒരു ക്രയത്തിൽ ഉച്ചനില സൃഷ്ടിക്കാനാവുന്ന ടാബുകളുടെ (%1$s) അതിരുകവിഞ്ഞു\u0020</string>
   <!-- The button text to add tabs to the active tab group in the tab creation tool. -->
   <string name="debug_drawer_tab_tools_tab_creation_tool_button_text_active">സജീവ ടാബുകളിലേക്ക് ചേർക്കുക</string>
   <!-- The button text to add tabs to the inactive tab group in the tab creation tool. -->
@@ -3219,7 +3219,7 @@
 
     The microsurvey prompt title. Note: The word "Firefox" should NOT be translated
   -->
-  <string name="micro_survey_prompt_title" tools:ignore="BrandUsage,UnusedResources">ഫയർഫോക്സിനു് മെച്ചപെടുത്താൻ സഹായിക്കുക. ഇതു് ചെയ്യാൻ വെറും ഒരു നിമിഷം എടുക്കും\u0032</string>
+  <string name="micro_survey_prompt_title" tools:ignore="BrandUsage,UnusedResources">ഫയർഫോക്സിനു് മെച്ചപെടുത്താൻ സഹായിക്കുക. ഇതു് ചെയ്യാൻ വെറും ഒരു നിമിഷം എടുക്കും\u0020</string>
   <!-- The continue button label -->
   <string name="micro_survey_continue_button_label" tools:ignore="UnusedResources">തുടരുക</string>
   <!--
@@ -3253,11 +3253,11 @@
   <!-- Option for likert scale -->
   <string name="likert_scale_option_8" tools:ignore="UnusedResources">ഞാൻ സമന്വയം ഉപയോഗിക്കാരില്ല</string>
   <!-- Text shown in prompt for printing microsurvey. "sec" It's an abbreviation for "second". Note: The word "Firefox" should NOT be translated. -->
-  <string name="microsurvey_prompt_printing_title" tools:ignore="BrandUsage,UnusedResources">ഫയർഫോക്സിൽ അച്ചടിപ്പു് മെച്ചപെടുത്താൻ സഹായിക്കുക. ഇതു് ചെയ്യാൻ വെറും ഒരു നിമിഷം എടുക്കും\u0032</string>
+  <string name="microsurvey_prompt_printing_title" tools:ignore="BrandUsage,UnusedResources">ഫയർഫോക്സിൽ അച്ചടിപ്പു് മെച്ചപെടുത്താൻ സഹായിക്കുക. ഇതു് ചെയ്യാൻ വെറും ഒരു നിമിഷം എടുക്കും\u0020</string>
   <!-- Text shown in prompt for search microsurvey. Note: The word "Firefox" should NOT be translated. -->
-  <string name="microsurvey_prompt_search_title" tools:ignore="BrandUsage,UnusedResources">ഫയർഫോക്സിൽ തിരച്ചിൽ മെച്ചപെടുത്താൻ സഹായിക്കുക. ഇതു് ചെയ്യാൻ വെറും ഒരു നിമിഷം എടുക്കും\u0032</string>
+  <string name="microsurvey_prompt_search_title" tools:ignore="BrandUsage,UnusedResources">ഫയർഫോക്സിൽ തിരച്ചിൽ മെച്ചപെടുത്താൻ സഹായിക്കുക. ഇതു് ചെയ്യാൻ വെറും ഒരു നിമിഷം എടുക്കും\u0020</string>
   <!-- Text shown in prompt for sync microsurvey. Note: The word "Firefox" should NOT be translated. -->
-  <string name="microsurvey_prompt_sync_title" tools:ignore="BrandUsage,UnusedResources">ഫയർഫോക്സിൽ സമന്വയം മെച്ചപെടുത്താൻ സഹായിക്കുക. ഇതു് ചെയ്യാൻ വെറും ഒരു നിമിഷം എടുക്കും\u0032</string>
+  <string name="microsurvey_prompt_sync_title" tools:ignore="BrandUsage,UnusedResources">ഫയർഫോക്സിൽ സമന്വയം മെച്ചപെടുത്താൻ സഹായിക്കുക. ഇതു് ചെയ്യാൻ വെറും ഒരു നിമിഷം എടുക്കും\u0020</string>
   <!-- Text shown in the survey title for printing microsurvey. Note: The word "Firefox" should NOT be translated. -->
   <string name="microsurvey_survey_printing_title" tools:ignore="BrandUsage,UnusedResources">ഫയർഫോക്സിൽ അച്ചടിപ്പുക്കൂടെ താങ്ങൾക്കു് എത്രത്തോളം സംതൃപ്തിയുണ്ട്?</string>
   <!-- Text shown in the survey title for homepage microsurvey. Note: The word "Firefox" should NOT be translated. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-my/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-my/strings.xml
@@ -48,7 +48,7 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s သည် သင် ပိတ်လိုက်သောအခါ (သို့မဟုတ်) အက်ပ်မှ ထွက်သောအခါ သင်၏ သီးသန့် တပ်ဗ်များမှ ရှာဖွေမှု မှတ်တမ်းများအား ရှင်းပစ်သည်။ ၎င်းသည် ၀က်ဘ်ဆိုက်များ (သို့မဟုတ်) သင်၏ အင်တာနက် ၀န်ဆောင်မှုပေးသူ ထံတွင် သင့်အား အမည်မဖော်လိုသူ အဖြစ် မထားပေးနိုင်သော်လည်း ဤစက်ကိရိယာကို သုံးသော အခြားသူများထံမှ သင် အွန်လိုင်း ပေါ်တွင် လုပ်ဆောင်လိုက်သည်များကို သီးသန့်ထားရန် ပိုမို လွယ်ကူစေသည်။\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s သည် သင် ပိတ်လိုက်သောအခါ (သို့မဟုတ်) အက်ပ်မှ ထွက်သောအခါ သင်၏ သီးသန့် တပ်ဗ်များမှ ရှာဖွေမှု မှတ်တမ်းများအား ရှင်းပစ်သည်။ ၎င်းသည် ၀က်ဘ်ဆိုက်များ (သို့မဟုတ်) သင်၏ အင်တာနက် ၀န်ဆောင်မှုပေးသူ ထံတွင် သင့်အား အမည်မဖော်လိုသူ အဖြစ် မထားပေးနိုင်သော်လည်း ဤစက်ကိရိယာကို သုံးသော အခြားသူများထံမှ သင် အွန်လိုင်း ပေါ်တွင် လုပ်ဆောင်လိုက်သည်များကို သီးသန့်ထားရန် ပိုမို လွယ်ကူစေသည်။\u0020</string>
   <string name="private_browsing_common_myths">ပုဂ္ဂလိက browsing ဆိုင်ရာ အမြင်မှားများ</string>
   <!-- Text for the negative button to decline adding a Private Browsing shortcut to the Home screen -->
   <string name="cfr_neg_button_text" moz:removedIn="138" tools:ignore="UnusedResources">နေပါစေ</string>
@@ -740,7 +740,7 @@
   <!-- Content description (not visible, for screen readers etc.): Opens the collection menu when pressed -->
   <string name="collection_menu_button_content_description">စုဆောင်းခြင်းမီနူး</string>
   <!-- Label to describe what collections are to a new user without any collections -->
-  <string name="no_collections_description2">သင့် အတွက် အရေးပါသည့် အရာများကို စုဆောင်းပါ။ နောက်ပိုင်းတွင် အမြန် ရှာဖွေနိုင်ဖို့ အလားတူ ရှာဖွေမှုများ၊ ဆိုက်များ နှင့် တပ်ဗ်များကို စုစည်းပါ။\u0032</string>
+  <string name="no_collections_description2">သင့် အတွက် အရေးပါသည့် အရာများကို စုဆောင်းပါ။ နောက်ပိုင်းတွင် အမြန် ရှာဖွေနိုင်ဖို့ အလားတူ ရှာဖွေမှုများ၊ ဆိုက်များ နှင့် တပ်ဗ်များကို စုစည်းပါ။\u0020</string>
   <!-- Title for the "select tabs" step of the collection creator -->
   <string name="create_collection_select_tabs">တက်ပ်များကိုရွေးပါ</string>
   <!-- Title for the "select collection" step of the collection creator -->
@@ -941,7 +941,7 @@
   <!-- Text shown for settings option for sign with email -->
   <string name="sign_in_with_email">အီးမေးလ်အစား</string>
   <!-- Text shown for settings option for create new account text.'Firefox' intentionally hardcoded here. -->
-  <string name="sign_in_create_account_text" tools:ignore="BrandUsage">အကောင့် မရှိဘူးလား? &lt;u&gt; သုံးစွဲသည့် ကိရိယာများ အကြား Firefox ကို တစ်ပြေးညီတည်း ချိန်ညှိရန် &lt;/u&gt; တစ်ခု ဖန်တီးပါ။\u0032</string>
+  <string name="sign_in_create_account_text" tools:ignore="BrandUsage">အကောင့် မရှိဘူးလား? &lt;u&gt; သုံးစွဲသည့် ကိရိယာများ အကြား Firefox ကို တစ်ပြေးညီတည်း ချိန်ညှိရန် &lt;/u&gt; တစ်ခု ဖန်တီးပါ။\u0020</string>
   <!-- Text shown in confirmation dialog to sign out of account. %s is the name of the app (for example "Firefox"). -->
   <string name="sign_out_confirmation_message_2">%s သည် အကောင့်နှင့် အချက်အလက်များ ထပ်တူပြုခြင်းကို ရပ်တန့်ပါမည်။ သို့သော် ယခု ကိရိယာရှိ သင်၏ မည်သည့် အချက်အလက် ကိုမျှ ဖျက်ပစ်မည် မဟုတ်ပါ။</string>
   <!-- Option to continue signing out of account shown in confirmation dialog to sign out of account -->
@@ -1091,7 +1091,7 @@
   <!-- Description for the preference for autofilling saved logins in Firefox (in web content), %1$s will be replaced with the app name -->
   <string name="preferences_passwords_autofill_description">%1$s ကို သုံးနေစဉ် ၀က်ဆိုက်များတွင် အသုံးပြုသူအမည် နှင့် စကားဝှက်များကို ဖြည့်ပြီး သိမ်းဆည်းပါ</string>
   <!-- Preference for autofilling logins from Fenix in other apps (e.g. autofilling the Twitter app) -->
-  <string name="preferences_android_autofill">အခြား အက်ပ်များတွင် အလိုအလျောက် ဖြည့်ပါ\u0032</string>
+  <string name="preferences_android_autofill">အခြား အက်ပ်များတွင် အလိုအလျောက် ဖြည့်ပါ\u0020</string>
   <!-- Description for the preference for autofilling logins from Fenix in other apps (e.g. autofilling the Twitter app) -->
   <string name="preferences_android_autofill_description">သင့် စက် ရှိ အခြားသော အက်ပ်များတွင် အသုံးပြုသူအမည်များ နှင့် စကားဝှက်များကို ဖြည့်ပါ။</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->
@@ -1244,7 +1244,7 @@
   <!-- Text displayed asking user to re-authenticate -->
   <string name="synced_tabs_reauth">ကျေးဇူးပြု၍ ပြန်လည် အတည်ပြုပါ။</string>
   <!-- Text displayed when user has disabled tab syncing in Firefox Sync Account -->
-  <string name="synced_tabs_enable_tab_syncing">ကျေးဇူးပြ၍ တပ်ဗ် ထပ်တူတစ်ပြေးတည်း ဖြစ်စေရန် ဖွင့်ပါ\u0032</string>
+  <string name="synced_tabs_enable_tab_syncing">ကျေးဇူးပြ၍ တပ်ဗ် ထပ်တူတစ်ပြေးတည်း ဖြစ်စေရန် ဖွင့်ပါ\u0020</string>
   <!-- Text displayed when user has no tabs that have been synced -->
   <string name="synced_tabs_no_tabs" tools:ignore="BrandUsage">သင့် အခြား စက်ပစ္စည်းများတွင် Firefox ၌ ဖွင့်ထားသော တပ်ဗ်များ မရှိပါ</string>
   <!-- Text displayed in the synced tabs screen when a user is not signed in to Firefox Sync describing Synced Tabs -->
@@ -1264,7 +1264,7 @@
 
     Title text displayed in the tabs tray when a tab has been unused for 14 days.
   -->
-  <string name="inactive_tabs_title">လှုပ်ရှားမှုမရှိသော တပ်ဗ်များ\u0032</string>
+  <string name="inactive_tabs_title">လှုပ်ရှားမှုမရှိသော တပ်ဗ်များ\u0020</string>
   <!-- Default browser card text -->
   <string name="default_browser_experiment_card_text" tools:ignore="BrandUsage">Firefox တွင် ဝက်ဘ်ဆိုက်များ၊ အီးမေးလ်များ နှင့် မက်ဆေ့ခ်ျများမှ လင့်ခ်များ အလိုအလျောက် ပွင့်ရန် သတ်မှတ်ပါ။</string>
   <!-- Content description for close button in collection placeholder. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ne-rNP/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ne-rNP/strings.xml
@@ -40,8 +40,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s ले तपाइँको खोज र ब्राउजिङ्ग इतिहासलाई निजी ट्याबहरूबाट खाली गर्दछ जब, तपाइँ तिनीहरूलाई बन्द गर्नुहुन्छ वा एप छोड्नुहुन्छ। यद्यपि यसले तपाइँलाई वेबसाइटहरू वा तपाइँको इन्टरनेट सेवा प्रदायकको लागि गुमनाम बनाउँदैन, यसले तपाइँलाई यो यन्त्र प्रयोग गर्ने अरू कसैबाट तपाइँ अनलाइन गर्ने कुरालाई गोप्य राख्न सजिलो बनाउँछ।</string>
-  <string name="private_browsing_common_myths">\u0032निजी ब्राउजिङ्ग बारे सामान्य मिथकहरू\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s ले तपाइँको खोज र ब्राउजिङ्ग इतिहासलाई निजी ट्याबहरूबाट खाली गर्दछ जब, तपाइँ तिनीहरूलाई बन्द गर्नुहुन्छ वा एप छोड्नुहुन्छ। यद्यपि यसले तपाइँलाई वेबसाइटहरू वा तपाइँको इन्टरनेट सेवा प्रदायकको लागि गुमनाम बनाउँदैन, यसले तपाइँलाई यो यन्त्र प्रयोग गर्ने अरू कसैबाट तपाइँ अनलाइन गर्ने कुरालाई गोप्य राख्न सजिलो बनाउँछ।</string>
+  <string name="private_browsing_common_myths">\u0020निजी ब्राउजिङ्ग बारे सामान्य मिथकहरू\u0020</string>
   <!-- Text for the negative button to decline adding a Private Browsing shortcut to the Home screen -->
   <string name="cfr_neg_button_text" moz:removedIn="138" tools:ignore="UnusedResources">पर्दैन, धन्यबाद</string>
   <!-- Text for the positive action button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-nl/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-nl/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s wist uw zoek- en browsergeschiedenis zodra u de toepassing afsluit of alle privétabbladen sluit. Hoewel dit u niet anoniem maakt voor websites of uw internetprovider, maakt dit het makkelijker om wat u online doet privé te houden voor anderen die dit apparaat gebruiken.</string>
-  <string name="private_browsing_common_myths">\u0032Veelgehoorde mythes over privénavigatie\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Veelgehoorde mythes over privénavigatie\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2772,7 +2772,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Geverifieerd door: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Geverifieerd door: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Verwijderen</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-oc/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-oc/strings.xml
@@ -613,7 +613,7 @@
   <!-- Title for the crash reporting option in the privacy preferences dialog shown during onboarding. -->
   <string name="onboarding_preferences_dialog_crash_reporting_title">Enviar automaticament los rapòrts de plantatge</string>
   <!-- Description for the crash reporting option in the privacy preferences dialog shown during onboarding. -->
-  <string name="onboarding_preferences_dialog_crash_reporting_description">\u0032Los rapòrts de plantatge nos permeton de diagnosticar e de corregir de problèmas amb lo navegador. Los rapòrts pòdon conténer de donadas personalas o sensiblas.\u0032</string>
+  <string name="onboarding_preferences_dialog_crash_reporting_description">\u0020Los rapòrts de plantatge nos permeton de diagnosticar e de corregir de problèmas amb lo navegador. Los rapòrts pòdon conténer de donadas personalas o sensiblas.\u0020</string>
   <!-- Learn more link for the crash reporting option in the privacy preferences dialog shown during onboarding. -->
   <string name="onboarding_preferences_dialog_crash_reporting_learn_more_2">Ne saber mai</string>
   <!-- Title for the usage data option in the privacy preferences dialog shown during onboarding. Note: The word "Mozilla" should NOT be translated. -->
@@ -1147,7 +1147,7 @@
   <!-- Preference switch title for automatically submitting crash reports -->
   <string name="preferences_automatically_send_crashes_title">Enviar automaticament los rapòrts de plantatge</string>
   <!-- Preference switch description for automatically submitting crash reports -->
-  <string name="preferences_automatically_send_crashes_description">Aquò nos permet de diagnosticar e de corregir de problèmas amb lo navegador. Los rapòrts pòdon conténer de donadas personalas o sensiblas.\u0032</string>
+  <string name="preferences_automatically_send_crashes_description">Aquò nos permet de diagnosticar e de corregir de problèmas amb lo navegador. Los rapòrts pòdon conténer de donadas personalas o sensiblas.\u0020</string>
   <!-- Learn more link for crash reporting preference -->
   <string name="onboarding_preferences_dialog_crash_reporting_learn_more">Ne saber mai suls rapòrts de plantatge</string>
   <!-- Title for studies preferences -->
@@ -2428,7 +2428,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Senhals salvats</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">Los senhals que salvatz o sincronizatz amb %s seràn listats aquí. Totes los senhals qu’enregistratz son chifrats.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">Los senhals que salvatz o sincronizatz amb %s seràn listats aquí. Totes los senhals qu’enregistratz son chifrats.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Per ne saber mai sus sync</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-pa-rIN/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-pa-rIN/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032ਜਦੋਂ ਤੁਸੀਂ ਸਾਰੀਆਂ ਪ੍ਰਾਈਵੇਟ ਟੈਬਾਂ ਨੂੰ ਬੰਦ ਕਰਦੇ ਹੋ ਜਾਂ ਐਪ ਤੋਂ ਬਾਹਰ ਜਾਂਦੇ ਹੋ ਤਾਂ %1$s ਤੁਹਾਡੀ ਖੋਜ ਅਤੇ ਬਰਾਊਜ਼ਿੰਗ ਅਤੀਤ ਨੂੰ ਸਾਫ ਕਰਦਾ ਹੈ। ਹਾਲਾਂਕਿ ਇਹ ਤੁਹਾਨੂੰ ਵੈਬਸਾਈਟਾਂ ਜਾਂ ਤੁਹਾਡੇ ਇੰਟਰਨੈੱਟ ਦੇਣ ਵਾਲੇ ਲਈ ਅਣਪਛਾਤਾ ਨਹੀਂ ਬਣਾਉਂਦਾ, ਪਰ ਇਸ ਨਾਲ ਇਸ ਡਿਵਾਈਸ ਨੂੰ ਵਰਤੇ ਵਾਲੇ ਕਿਸੇ ਤੋਂ ਵੀ ਤੁਹਾਡੇ ਵਲੋਂ ਆਨਲਾਈਨ ਕੀਤੇ ਨੂੰ ਪ੍ਰਾਈਵੇਟ ਰੱਖਣਾ ਹੋਰ ਸੌਖਾ ਹੋ ਜਾਂਦਾ ਹੈ।</string>
-  <string name="private_browsing_common_myths">\u0032ਪ੍ਰਾਈਵੇਟ ਟੈਬਾਂ ਬਾਰੇ ਆਮ ਫ਼ਰਜ਼ੀ ਗੱਲਾਂ\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020ਜਦੋਂ ਤੁਸੀਂ ਸਾਰੀਆਂ ਪ੍ਰਾਈਵੇਟ ਟੈਬਾਂ ਨੂੰ ਬੰਦ ਕਰਦੇ ਹੋ ਜਾਂ ਐਪ ਤੋਂ ਬਾਹਰ ਜਾਂਦੇ ਹੋ ਤਾਂ %1$s ਤੁਹਾਡੀ ਖੋਜ ਅਤੇ ਬਰਾਊਜ਼ਿੰਗ ਅਤੀਤ ਨੂੰ ਸਾਫ ਕਰਦਾ ਹੈ। ਹਾਲਾਂਕਿ ਇਹ ਤੁਹਾਨੂੰ ਵੈਬਸਾਈਟਾਂ ਜਾਂ ਤੁਹਾਡੇ ਇੰਟਰਨੈੱਟ ਦੇਣ ਵਾਲੇ ਲਈ ਅਣਪਛਾਤਾ ਨਹੀਂ ਬਣਾਉਂਦਾ, ਪਰ ਇਸ ਨਾਲ ਇਸ ਡਿਵਾਈਸ ਨੂੰ ਵਰਤੇ ਵਾਲੇ ਕਿਸੇ ਤੋਂ ਵੀ ਤੁਹਾਡੇ ਵਲੋਂ ਆਨਲਾਈਨ ਕੀਤੇ ਨੂੰ ਪ੍ਰਾਈਵੇਟ ਰੱਖਣਾ ਹੋਰ ਸੌਖਾ ਹੋ ਜਾਂਦਾ ਹੈ।</string>
+  <string name="private_browsing_common_myths">\u0020ਪ੍ਰਾਈਵੇਟ ਟੈਬਾਂ ਬਾਰੇ ਆਮ ਫ਼ਰਜ਼ੀ ਗੱਲਾਂ\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -116,7 +116,7 @@
   -->
   <string name="navbar_cfr_title" moz:removedIn="140" tools:ignore="UnusedResources">ਨਵੀਂ ਨੈਵੀਗੇਸ਼ਨ ਨਾਲ ਵੱਧ ਤੇਜ਼ੀ ਨਾਲ ਬਰਾਊਜ਼ ਕਰੋ</string>
   <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-  <string name="navbar_cfr_message_2" moz:removedIn="140" tools:ignore="UnusedResources">\u0032ਵੈੱਬਸਾਈਟ ਉੱਤੇ ਵਾਧੂ ਬਰਾਊਜ਼ ਕਰਨ ਲਈ ਥਾਂ ਬਣਾਉਣ ਵਾਸਤੇ ਸਕਰੋਲ ਕਰਨ ਦੇ ਦੌਰਾਨ ਇਸ ਪੱਟੀ ਨੂੰ ਪਾਸੇ ਕਰ ਦਿੱਤਾ ਜਾਂਦਾ ਹੈ।</string>
+  <string name="navbar_cfr_message_2" moz:removedIn="140" tools:ignore="UnusedResources">\u0020ਵੈੱਬਸਾਈਟ ਉੱਤੇ ਵਾਧੂ ਬਰਾਊਜ਼ ਕਰਨ ਲਈ ਥਾਂ ਬਣਾਉਣ ਵਾਸਤੇ ਸਕਰੋਲ ਕਰਨ ਦੇ ਦੌਰਾਨ ਇਸ ਪੱਟੀ ਨੂੰ ਪਾਸੇ ਕਰ ਦਿੱਤਾ ਜਾਂਦਾ ਹੈ।</string>
   <!-- Text for the message displayed for the popup promoting the long press of navigation in the navigation bar. -->
   <string name="navbar_navigation_buttons_cfr_message" moz:removedIn="140" tools:ignore="UnusedResources">ਇਸ ਟੈਬ ਦੇ ਅਤੀਤ ਵਿਚਲੇ ਸਫ਼ਿਆਂ ਵਿੱਚ ਜਾਣ ਲਈ ਤੀਰ ਦੇ ਨਿਸ਼ਾਨਾਂ ਨੂੰ ਛੂਹ ਕੇ ਰੱਖੋ।</string>
   <!--
@@ -1114,7 +1114,7 @@
   -->
   <string name="fxa_tabs_closed_notification_title">%1$s ਟੈਬਾਂ ਬੰਦ ਕੀਤੀਆਂ: %2$d</string>
   <!-- The body for a "closed synced tabs" notification. -->
-  <string name="fxa_tabs_closed_text">\u0032ਤਾਜ਼ਾ ਬੰਦ ਕੀਤੀਆਂ ਟੈਬਾਂ ਨੂੰ ਵੇਖੋ</string>
+  <string name="fxa_tabs_closed_text">\u0020ਤਾਜ਼ਾ ਬੰਦ ਕੀਤੀਆਂ ਟੈਬਾਂ ਨੂੰ ਵੇਖੋ</string>
   <!--
     Advanced Preferences
 
@@ -1350,7 +1350,7 @@
     Title for the list of tabs in the current private session used by a11y services
     The %1$s will be replaced by the number of opened private tabs
   -->
-  <string name="tabs_header_private_tabs_counter_title">\u0032ਖੁੱਲ੍ਹੀਆਂ ਪ੍ਰਾਈਵੇਟ ਟੈਬਾਂ: %1$s। ਟੈਬਾਂ ਬਦਲਣ ਲਈ ਛੂਹੋ।</string>
+  <string name="tabs_header_private_tabs_counter_title">\u0020ਖੁੱਲ੍ਹੀਆਂ ਪ੍ਰਾਈਵੇਟ ਟੈਬਾਂ: %1$s। ਟੈਬਾਂ ਬਦਲਣ ਲਈ ਛੂਹੋ।</string>
   <!--
     Title for the list of tabs in the synced tabs used by a11y services
     The %1$s will be replaced by the number of opened synced tabs
@@ -1457,7 +1457,7 @@
   <!-- Text for the snackbar to confirm that a single download item has been removed. %1$s is the name of the download item. -->
   <string name="download_delete_single_item_snackbar" moz:removedIn="138" tools:ignore="UnusedResources">%1$s ਹਟਾਏ</string>
   <!-- Text for the snackbar to confirm that a single download item has been removed. %1$s is the name of the download item. -->
-  <string name="download_delete_single_item_snackbar_2">\u0032“%1$s” ਨੂੰ ਹਟਾਇਆ</string>
+  <string name="download_delete_single_item_snackbar_2">\u0020“%1$s” ਨੂੰ ਹਟਾਇਆ</string>
   <!-- Text for the snackbar to confirm that downloads are in progress. -->
   <string name="download_in_progress_snackbar" tools:ignore="UnusedResources">ਡਾਊਨਲੋਡ ਜਾਰੀ ਹੈ…</string>
   <!-- Text for the snackbar action button to view in progress download details. -->
@@ -2441,7 +2441,7 @@
   <!-- Preference for managing the saving of logins and passwords in Fenix -->
   <string name="preferences_passwords_save_logins_2">ਪਾਸਵਰਡਾਂ ਨੂੰ ਸੰਭਾਲੋ</string>
   <!-- Preference option for asking to save passwords in Fenix -->
-  <string name="preferences_passwords_save_logins_ask_to_save">\u0032ਸੰਭਾਲਣ ਲਈ ਪੁੱਛੋ</string>
+  <string name="preferences_passwords_save_logins_ask_to_save">\u0020ਸੰਭਾਲਣ ਲਈ ਪੁੱਛੋ</string>
   <!-- Preference option for never saving passwords in Fenix -->
   <string name="preferences_passwords_save_logins_never_save">ਕਦੇ ਨਾ ਸੰਭਾਲੋ</string>
   <!-- Preference for autofilling saved logins in Firefox (in web content), %1$s will be replaced with the app name -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-pa-rPK/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-pa-rPK/strings.xml
@@ -60,8 +60,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032جدوں تسیں ساریاں نجی ٹیباں نوں بند کردے او یا ایپ توں باہر جاندے او تاں %1$s تہاڈی کھوج تے ورتوں دی تاریخ نوں ساف کردا اے۔ حالاں‌کہ ایہہ تہانوں سائٹاں یا تہاڈے اینٹرنیٹ دیݨ والے لئی اݨپچھاتا نہیں بݨاوندا، پر ایس نال ایس فون نوں ورتے والے کسے توں وی تہاڈے ولوں آن‌لائین کیتے نوں نجی رکھݨا ہور سوکھا ہو جاندا اے۔</string>
-  <string name="private_browsing_common_myths">\u0032نجی ورتوں بارے عام فرضی گلاں\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020جدوں تسیں ساریاں نجی ٹیباں نوں بند کردے او یا ایپ توں باہر جاندے او تاں %1$s تہاڈی کھوج تے ورتوں دی تاریخ نوں ساف کردا اے۔ حالاں‌کہ ایہہ تہانوں سائٹاں یا تہاڈے اینٹرنیٹ دیݨ والے لئی اݨپچھاتا نہیں بݨاوندا، پر ایس نال ایس فون نوں ورتے والے کسے توں وی تہاڈے ولوں آن‌لائین کیتے نوں نجی رکھݨا ہور سوکھا ہو جاندا اے۔</string>
+  <string name="private_browsing_common_myths">\u0020نجی ورتوں بارے عام فرضی گلاں\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -236,7 +236,7 @@
   <!-- Browser menu toggle that adds a shortcut to the site on the device home screen. -->
   <string name="browser_menu_add_to_homescreen">مکھ سکرین تے جوڑو</string>
   <!-- Browser menu toggle that adds a shortcut to the site on the device home screen. -->
-  <string name="browser_menu_add_to_homescreen_2">ہوم سکرین تے جوڑو\u0032</string>
+  <string name="browser_menu_add_to_homescreen_2">ہوم سکرین تے جوڑو\u0020</string>
   <!-- Content description (not visible, for screen readers etc.) for the Resync tabs button -->
   <string name="resync_button_content_description">مڑ جوڑ کرو</string>
   <!-- Browser menu button that opens the find in page menu -->
@@ -311,7 +311,7 @@
     Browser menu label that navigates to the save sub-menu, which contains various save related menu items such as
     bookmarking a page, saving to collection, shortcut or as a PDF, and adding to home screen
   -->
-  <string name="browser_menu_save">سنبھالو\u0032</string>
+  <string name="browser_menu_save">سنبھالو\u0020</string>
   <!-- Browser menu description that describes the various save related menu items inside of the save sub-menu -->
   <string name="browser_menu_save_description">بک‌مارک، شارٹ‌کٹ، مکھ صفحہ، بھنڈار، PDF جوڑو</string>
   <!-- Browser menu label that bookmarks the currently visited page -->
@@ -548,7 +548,7 @@
   <!-- Will inform the user of the risk of activating Allow screenshots in private browsing option -->
   <string name="preferences_screenshots_in_private_mode_disclaimer">جے اجازت دتی تاں نجی ٹیباں اودوں وی دکھائی دیݨ‌گیاں، جدوں کئی ایپاں کھلھیاں ہندیاں ہن</string>
   <!-- Preference for adding private browsing shortcut -->
-  <string name="preferences_add_private_browsing_shortcut">\u0032نجی براؤز کرن شارٹ‌کٹ جوڑو</string>
+  <string name="preferences_add_private_browsing_shortcut">\u0020نجی براؤز کرن شارٹ‌کٹ جوڑو</string>
   <!-- Preference for enabling "HTTPS-Only" mode -->
   <string name="preferences_https_only_title">سرف HTTPS ڈھنگ</string>
   <!-- Label for cookie banner section in quick settings panel. -->
@@ -743,7 +743,7 @@
   <!-- Summary for the customize home screen section with Pocket. %s is "Pocket". -->
   <string name="customize_toggle_pocket_summary">%s ولوں تیار کیتے لیکھ</string>
   <!-- Title for the customize home screen section with sponsored Pocket stories. -->
-  <string name="customize_toggle_pocket_sponsored">حمایت کیتیاں کہاݨیاں\u0032</string>
+  <string name="customize_toggle_pocket_sponsored">حمایت کیتیاں کہاݨیاں\u0020</string>
   <!-- Title for the opening wallpaper settings screen -->
   <string name="customize_wallpapers">والپیپر</string>
   <!-- Title for the customize home screen section with sponsored shortcuts. -->
@@ -803,7 +803,7 @@
   -->
   <string name="extension_process_crash_dialog_message">اک جاں ودھ پھیلاواں کم نہیں کر رہیاں، جس نال تہاڈا سسٹم استھر ہو رہا اے۔ %1$s نے پھیلاواں نوں مڑ چالو کرن دی اسپھل کوشش کیتی سی۔ \n\nتہاڈے موجودہ سیشن دے دوران پھیلاؤ مڑ شروع نہیں ہووےگی۔ \n\nپھیلاواں نوں ہٹاوݨ جاں اسمرتھ کرن نال ایہہ مسئلہ ٹھیک ہو سکدا اے۔</string>
   <!-- Button text on the extension crash dialog to prompt the user to try restarting the extensions but the dialog will reappear if it is unsuccessful again -->
-  <string name="extension_process_crash_dialog_retry_button_text" tools:ignore="UnusedResources">پھیلاواں نوں مڑ چالو کرکے ویکھو\u0032</string>
+  <string name="extension_process_crash_dialog_retry_button_text" tools:ignore="UnusedResources">پھیلاواں نوں مڑ چالو کرکے ویکھو\u0020</string>
   <!-- Button text on the extension crash dialog to prompt the user to continue with all extensions disabled. -->
   <string name="extension_process_crash_dialog_disable_extensions_button_text">پھیلاواں نوں بند کرکے جاری رکھو</string>
   <!--
@@ -815,7 +815,7 @@
   <!-- Summary of the preference for managing your account via accounts.firefox.com. -->
   <string name="preferences_manage_account_summary">آپݨا پاس‌ورڈ بدلو، ڈیٹا اکتر کرن دا انتظام کرو جاں آپݨے کھاتے نوں ہٹاؤ</string>
   <!-- Preference for triggering sync -->
-  <string name="preferences_sync_now">ہݨے ہم وقت کرو\u0032</string>
+  <string name="preferences_sync_now">ہݨے ہم وقت کرو\u0020</string>
   <!-- Preference category for sync -->
   <string name="preferences_sync_category">چݨو کہ کیہہ ہم وقت کرنا اے</string>
   <!-- Preference for syncing history -->
@@ -991,7 +991,7 @@
   <!-- Option in library for Recently Closed Tabs -->
   <string name="library_recently_closed_tabs">تازہ بند کیتیاں ٹیباں</string>
   <!-- Option in library to open Recently Closed Tabs page -->
-  <string name="recently_closed_show_full_history">پوری تاریخ نوں دکھاؤ\u0032</string>
+  <string name="recently_closed_show_full_history">پوری تاریخ نوں دکھاؤ\u0020</string>
   <!--
     Text to show users they have multiple tabs saved in the Recently Closed Tabs section of history.
     %d is a placeholder for the number of tabs selected.
@@ -1041,11 +1041,11 @@
   <!-- Option for always opening the homepage when re-opening the app after four hours of inactivity -->
   <string name="opening_screen_after_four_hours_of_inactivity">چار گھنٹیاں دی غیرفعالت دے بعد مکھ صفحہ</string>
   <!-- Summary for tabs preference when auto closing tabs setting is set to manual close -->
-  <string name="close_tabs_manually_summary">خود بند کرو\u0032</string>
+  <string name="close_tabs_manually_summary">خود بند کرو\u0020</string>
   <!-- Summary for tabs preference when auto closing tabs setting is set to auto close tabs after one day -->
   <string name="close_tabs_after_one_day_summary">اک دن بعد بند کرو</string>
   <!-- Summary for tabs preference when auto closing tabs setting is set to auto close tabs after one week -->
-  <string name="close_tabs_after_one_week_summary">اک ہفتے بعد بند کرو\u0032</string>
+  <string name="close_tabs_after_one_week_summary">اک ہفتے بعد بند کرو\u0020</string>
   <!-- Summary for tabs preference when auto closing tabs setting is set to auto close tabs after one month -->
   <string name="close_tabs_after_one_month_summary">اک مہینے بعد بند کرو</string>
   <!-- Summary for homepage preference indicating always opening the homepage when re-opening the app -->
@@ -1259,7 +1259,7 @@
   <!-- Text for the button to search all bookmarks -->
   <string name="bookmark_search">کھوج دی لکھت پایو</string>
   <!-- Content description for the bookmark navigation bar back button -->
-  <string name="bookmark_navigate_back_button_content_description">واپس کرو\u0032</string>
+  <string name="bookmark_navigate_back_button_content_description">واپس کرو\u0020</string>
   <!-- Content description for the bookmark list new folder navigation bar button -->
   <string name="bookmark_add_new_folder_button_content_description">نواں فولڈر جوڑو</string>
   <!-- Content description for bookmark search floating action button -->
@@ -1335,7 +1335,7 @@
   <!-- Label that indicates that video and audio autoplay is only allowed over Wi-Fi -->
   <string name="preference_option_autoplay_allowed_wifi_only2">صرف موبائیل ڈیٹے توں آڈیو تے ویڈیو تے روک لاؤ</string>
   <!-- Subtext that explains 'autoplay on Wi-Fi only' option -->
-  <string name="preference_option_autoplay_allowed_wifi_subtext">وائی‌فائی تے آڈیو تے ویڈیو چلائے جاݨ‌گے\u0032</string>
+  <string name="preference_option_autoplay_allowed_wifi_subtext">وائی‌فائی تے آڈیو تے ویڈیو چلائے جاݨ‌گے\u0020</string>
   <!-- Label for global setting that indicates that video autoplay is allowed, but audio autoplay is blocked -->
   <string name="preference_option_autoplay_block_audio2">صرف آڈیو تے پابندی لاؤ</string>
   <!-- Label for site specific setting that indicates that video autoplay is allowed, but audio autoplay is blocked -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-pl/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-pl/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s usuwa historię wyszukiwania i przeglądania w prywatnych kartach po ich zamknięciu lub wyłączeniu aplikacji. Chociaż nie czyni to użytkownika anonimowym wobec stron internetowych ani dostawcy Internetu, to ułatwia zachowanie prywatności przed pozostałymi użytkownikami tego urządzenia.</string>
-  <string name="private_browsing_common_myths">\u0032Popularne mity na temat przeglądania prywatnego\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Popularne mity na temat przeglądania prywatnego\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-pt-rBR/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-pt-rBR/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">O %1$s limpa o histórico de pesquisa e navegação de abas privativas quando você as fecha ou sai do aplicativo. Apesar disso não tornar você anônimo em sites ou no seu provedor de internet, facilita manter o que você faz online privativo de qualquer outra pessoa que use este dispositivo.</string>
-  <string name="private_browsing_common_myths">\u0032Lendas comuns sobre navegação privativa\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Lendas comuns sobre navegação privativa\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2720,7 +2720,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Homologado por: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Homologado por: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Excluir</string>
   <!-- Login overflow menu edit button -->
@@ -2953,7 +2953,7 @@
   <!-- Title for the translation dialog that allows a user to translate the webpage when a user uses the translation feature the first time. %1$s is the name of the app (for example "Firefox"). -->
   <string name="translations_bottom_sheet_title_first_time">Experimente tradução privativa no %1$s</string>
   <!-- Additional information on the translation dialog that appears when a user uses the translation feature the first time. %1$s is a link using translations_bottom_sheet_info_message_learn_more as text. -->
-  <string name="translations_bottom_sheet_info_message">Para sua privacidade, o texto de tradução nunca sai do seu dispositivo. Novos idiomas e melhorias em breve! %1$s\u0032</string>
+  <string name="translations_bottom_sheet_info_message">Para sua privacidade, o texto de tradução nunca sai do seu dispositivo. Novos idiomas e melhorias em breve! %1$s\u0020</string>
   <!-- Text that links to additional information about the Firefox translations feature. -->
   <string name="translations_bottom_sheet_info_message_learn_more">Saiba mais</string>
   <!-- Label for the dropdown to select which language to translate from on the translations dialog. Usually the translate from language selected will be the same as the page language. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-pt-rPT/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-pt-rPT/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s limpa o seu histórico de pesquisa e de navegação dos separadores privados quando os fecha ou sai da aplicação. Enquanto isto não o torna anónimo nos websites ou no seu provedor de serviços da Internet, este torna mais fácil em manter privado o que você faz online de qualquer pessoa que utiliza este dispositivo.</string>
-  <string name="private_browsing_common_myths">\u0032Mitos comuns sobre a navegação privada\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Mitos comuns sobre a navegação privada\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2511,7 +2511,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Palavras-passe guardadas</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">As palavras-passe que guardar ou sincronizar com o %s serão listadas aqui. Todas as palavras-passe que guarda são encriptadas.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">As palavras-passe que guardar ou sincronizar com o %s serão listadas aqui. Todas as palavras-passe que guarda são encriptadas.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Saber mais sobre a sincronização</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->
@@ -3617,7 +3617,7 @@
 
     The title of the 'essentials' group in the setup checklist. %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="setup_checklist_group_essentials">O essencial do %1$s\u0032</string>
+  <string name="setup_checklist_group_essentials">O essencial do %1$s\u0020</string>
   <!-- The title of the 'customize' group in the setup checklist. %1$s is the name of the app (for example "Firefox"). -->
   <string name="setup_checklist_group_customize">Personalize o seu %1$s</string>
   <!-- The title of the 'helpful tools' group in the setup checklist -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-rm/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-rm/strings.xml
@@ -892,7 +892,7 @@
     Summary for preference to show sponsored Firefox Suggest search suggestions.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="preferences_show_sponsored_suggestions_summary">Sustegna %1$s cun propostas occasiunalas sponsurisadas\u0032</string>
+  <string name="preferences_show_sponsored_suggestions_summary">Sustegna %1$s cun propostas occasiunalas sponsurisadas\u0020</string>
   <!--
     Preference title for switch preference to show Firefox Suggest search suggestions for web content.
     %1$s is the name of the app (for example "Firefox").

--- a/mozilla-mobile/fenix/app/src/main/res/values-ru/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ru/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s удаляет историю поиска и просмотра страниц в приватных вкладках, когда вы закрываете их или выходите из приложения. Хотя это не делает вас анонимными для веб-сайтов или вашего Интернет-провайдера, вам будет легче сохранить конфиденциальность ваших действий в Интернете от других людей, которые используют это устройство.</string>
-  <string name="private_browsing_common_myths">\u0032Распространённые мифы о приватном просмотре\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Распространённые мифы о приватном просмотре\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2461,7 +2461,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Сохранённые пароли</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">Пароли, которые вы сохраните или синхронизируете в %s, будут показаны здесь. Все сохраняемые вами пароли зашифрованы.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">Пароли, которые вы сохраните или синхронизируете в %s, будут показаны здесь. Все сохраняемые вами пароли зашифрованы.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Узнайте больше о синхронизации</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->
@@ -2720,7 +2720,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Подтверждено: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Подтверждено: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Удалить</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-sat/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-sat/strings.xml
@@ -493,7 +493,7 @@
   <!-- Home onboarding dialog sign into sync screen title text. -->
   <string name="onboarding_home_sync_title_3">ᱯᱚᱨᱫᱟ ᱵᱚᱫᱚᱞ ᱫᱚ ᱱᱤᱛᱚᱜ ᱟᱹᱰᱤ ᱤᱫᱤᱜ ᱠᱟᱱᱟ</string>
   <!-- Home onboarding dialog sign into sync screen description text. -->
-  <string name="onboarding_home_sync_description">ᱚᱲᱟᱜ ᱥᱟᱦᱴᱟ ᱨᱮ ᱱᱤᱛᱚᱜ ᱡᱟᱦᱟᱸ ᱠᱷᱚᱱ ᱮᱢ ᱟᱲᱟᱜ ᱞᱮᱜᱼᱟ ᱮᱴᱟᱜ ᱥᱟᱫᱷᱚᱱ ᱨᱮᱭᱟᱜ ᱴᱮᱵᱽ ᱠᱷᱚᱱ ᱯᱟᱧᱡᱟ ᱫᱟᱲᱮᱭᱟᱜᱼᱟᱢ ᱾\u0032</string>
+  <string name="onboarding_home_sync_description">ᱚᱲᱟᱜ ᱥᱟᱦᱴᱟ ᱨᱮ ᱱᱤᱛᱚᱜ ᱡᱟᱦᱟᱸ ᱠᱷᱚᱱ ᱮᱢ ᱟᱲᱟᱜ ᱞᱮᱜᱼᱟ ᱮᱴᱟᱜ ᱥᱟᱫᱷᱚᱱ ᱨᱮᱭᱟᱜ ᱴᱮᱵᱽ ᱠᱷᱚᱱ ᱯᱟᱧᱡᱟ ᱫᱟᱲᱮᱭᱟᱜᱼᱟᱢ ᱾\u0020</string>
   <!-- Text for the button to continue the onboarding on the home onboarding dialog. -->
   <string name="onboarding_home_get_started_button">ᱫᱮᱞᱟ ᱮᱛᱦᱚᱵ ᱞᱮᱜᱮ ᱵᱚᱱ</string>
   <!-- Text for the button to navigate to the sync sign in screen on the home onboarding dialog. -->
@@ -799,7 +799,7 @@
   <!-- Title text for a detail explanation indicating cookie banner handling is off this site, this is shown as part of the cookie banner panel in the toolbar. %1$s is a shortened URL of the current site. -->
   <string name="reduce_cookie_banner_details_panel_title_off_for_site_1">%1$s ᱞᱟᱹᱜᱤᱫ ᱠᱩᱠᱤ ᱵᱮᱱᱚᱨ ᱟᱠᱚᱴᱤᱭᱟᱹ ᱵᱚᱸᱫᱚ ᱪᱷᱚᱭ ᱢᱮ?</string>
   <!-- Title text for a detail explanation indicating cookie banner reducer didn't work for the current site, this is shown as part of the cookie banner panel in the toolbar. %1$s is the name of the app (for example "Firefox"). -->
-  <string name="reduce_cookie_banner_details_panel_title_unsupported_site_request_2">ᱱᱚᱶᱟ ᱥᱟᱭᱤᱴ ᱨᱮ %1$s ᱫᱚ ᱟᱡ ᱛᱮ ᱠᱩᱠᱤ ᱱᱚᱦᱚᱨ ᱵᱟᱝ ᱢᱟᱱᱟ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟᱭ ᱾ ᱵᱷᱚᱵᱤᱥᱚᱛ ᱨᱮ ᱱᱚᱶᱟ ᱥᱟᱭᱤᱴ ᱜᱚᱲᱚ ᱮᱢ ᱞᱟᱹᱜᱤᱫ ᱱᱮᱦᱚᱨ ᱵᱷᱮᱡᱟ ᱫᱟᱲᱮᱭᱟᱜᱼᱟᱢ ᱾\u0032</string>
+  <string name="reduce_cookie_banner_details_panel_title_unsupported_site_request_2">ᱱᱚᱶᱟ ᱥᱟᱭᱤᱴ ᱨᱮ %1$s ᱫᱚ ᱟᱡ ᱛᱮ ᱠᱩᱠᱤ ᱱᱚᱦᱚᱨ ᱵᱟᱝ ᱢᱟᱱᱟ ᱫᱟᱲᱮᱭᱟᱜ ᱠᱟᱱᱟᱭ ᱾ ᱵᱷᱚᱵᱤᱥᱚᱛ ᱨᱮ ᱱᱚᱶᱟ ᱥᱟᱭᱤᱴ ᱜᱚᱲᱚ ᱮᱢ ᱞᱟᱹᱜᱤᱫ ᱱᱮᱦᱚᱨ ᱵᱷᱮᱡᱟ ᱫᱟᱲᱮᱭᱟᱜᱼᱟᱢ ᱾\u0020</string>
   <!-- Long text for a detail explanation indicating what will happen if cookie banner handling is off for a site, this is shown as part of the cookie banner panel in the toolbar. %1$s is the name of the app (for example "Firefox"). -->
   <string name="reduce_cookie_banner_details_panel_description_off_for_site_1">ᱵᱚᱸᱫᱚᱭ ᱢᱮ ᱟᱨ %1$s ᱫᱚ ᱠᱩᱠᱤ ᱠᱚ ᱢᱮᱴᱟᱣ ᱠᱟᱛᱮ ᱱᱚᱣᱟ ᱥᱟᱦᱴᱟ ᱨᱤᱞᱚᱰ ᱟ ᱾ ᱱᱚᱶᱟ ᱫᱚ ᱟᱢ ᱵᱟᱦᱨᱮ ᱩᱰᱩᱠ ᱢᱮᱭᱟᱭ ᱥᱮ ᱠᱤᱨᱤᱧ ᱠᱟᱨᱴ ᱠᱷᱟᱹᱞᱤ ᱟ ᱾</string>
   <!-- Long text for a detail explanation indicating what will happen if cookie banner handling is on for a site, this is shown as part of the cookie banner panel in the toolbar. %1$s is the name of the app (for example "Firefox"). -->
@@ -1040,7 +1040,7 @@
   <!-- Preference for triggering sync -->
   <string name="preferences_sync_now">ᱱᱤᱛᱚᱜ ᱥᱭᱝᱠ ᱢᱮ</string>
   <!-- Preference category for sync -->
-  <string name="preferences_sync_category">ᱚᱠᱟ ᱥᱭᱝᱠ ᱨᱮᱭᱟᱜ ᱛᱟᱦᱮᱸᱱᱟ ᱵᱟᱪᱷᱟᱣ ᱢᱮ\u0032</string>
+  <string name="preferences_sync_category">ᱚᱠᱟ ᱥᱭᱝᱠ ᱨᱮᱭᱟᱜ ᱛᱟᱦᱮᱸᱱᱟ ᱵᱟᱪᱷᱟᱣ ᱢᱮ\u0020</string>
   <!-- Preference for syncing history -->
   <string name="preferences_sync_history">ᱱᱟᱜᱟᱢ</string>
   <!-- Preference for syncing bookmarks -->
@@ -1270,7 +1270,7 @@
   <!-- Option for always opening the homepage when re-opening the app after four hours of inactivity -->
   <string name="opening_screen_after_four_hours_of_inactivity">ᱯᱩᱱ ᱴᱟᱲᱟᱝ ᱵᱤᱱᱟᱹ ᱠᱟᱹᱢᱤ ᱞᱟᱦᱟ ᱨᱮ ᱚᱲᱟᱜ ᱥᱟᱦᱴᱟ</string>
   <!-- Summary for tabs preference when auto closing tabs setting is set to manual close -->
-  <string name="close_tabs_manually_summary">ᱱᱤᱡᱮ ᱛᱮ ᱵᱚᱸᱫᱽ ᱢᱮ\u0032</string>
+  <string name="close_tabs_manually_summary">ᱱᱤᱡᱮ ᱛᱮ ᱵᱚᱸᱫᱽ ᱢᱮ\u0020</string>
   <!-- Summary for tabs preference when auto closing tabs setting is set to auto close tabs after one day -->
   <string name="close_tabs_after_one_day_summary">ᱢᱤᱫᱽ ᱫᱤᱱ ᱛᱟᱭᱚᱢ ᱛᱮ ᱵᱚᱸᱫᱚᱭ ᱢᱮ</string>
   <!-- Summary for tabs preference when auto closing tabs setting is set to auto close tabs after one week -->
@@ -2098,7 +2098,7 @@
   <!-- Preference description for enhanced tracking protection for the strict protection settings -->
   <string name="preference_enhanced_tracking_protection_custom_description_2">ᱵᱟᱪᱷᱟᱣ ᱢᱮ ᱚᱠᱟ ᱯᱟᱧᱡᱟ ᱫᱟᱱᱟᱲ ᱠᱚ ᱟᱨ ᱥᱠᱨᱤᱯᱴ ᱞᱚ ᱵᱞᱚᱠ ᱠᱚᱣᱟ ᱾</string>
   <!-- Accessibility text for the Strict protection information icon -->
-  <string name="preference_enhanced_tracking_protection_custom_info_button">ᱠᱚᱥᱴᱚᱢ ᱜᱷᱮᱨ ᱮᱥᱮᱫ ᱯᱨᱚᱴᱮᱠᱥᱚᱱ ᱛᱮ ᱪᱮᱫ ᱵᱞᱚᱠ ᱟᱹᱠᱟᱱᱟ\u0032</string>
+  <string name="preference_enhanced_tracking_protection_custom_info_button">ᱠᱚᱥᱴᱚᱢ ᱜᱷᱮᱨ ᱮᱥᱮᱫ ᱯᱨᱚᱴᱮᱠᱥᱚᱱ ᱛᱮ ᱪᱮᱫ ᱵᱞᱚᱠ ᱟᱹᱠᱟᱱᱟ\u0020</string>
   <!--
     Header for categories that are being blocked by current Enhanced Tracking Protection settings
 
@@ -2136,7 +2136,7 @@
   <!-- Category of trackers (social media trackers) that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_social_media_trackers_title">ᱥᱟᱸᱣᱛᱟ ᱢᱤᱰᱤᱭᱟ ᱯᱟᱧᱡᱟ ᱫᱟᱱᱟᱲ ᱠᱚ</string>
   <!-- Description of social media trackers that can be blocked by Enhanced Tracking Protection -->
-  <string name="etp_social_media_trackers_description">ᱵᱽᱨᱟᱣᱩᱡᱤᱝ ᱠᱟᱹᱢᱤ ᱠᱚ ᱮᱢᱟᱱ ᱥᱚᱥᱤᱭᱟᱹᱢ ᱢᱮᱰᱤᱭᱟ ᱱᱮᱴᱣᱟᱨᱠ ᱨᱮ ᱜᱷᱮᱨ ᱮᱥᱮᱫ ᱠᱚ ᱣᱮᱵᱽ ᱨᱮ ᱞᱤᱢᱤᱴ ᱛᱟᱢᱟᱭ ᱾\u0032</string>
+  <string name="etp_social_media_trackers_description">ᱵᱽᱨᱟᱣᱩᱡᱤᱝ ᱠᱟᱹᱢᱤ ᱠᱚ ᱮᱢᱟᱱ ᱥᱚᱥᱤᱭᱟᱹᱢ ᱢᱮᱰᱤᱭᱟ ᱱᱮᱴᱣᱟᱨᱠ ᱨᱮ ᱜᱷᱮᱨ ᱮᱥᱮᱫ ᱠᱚ ᱣᱮᱵᱽ ᱨᱮ ᱞᱤᱢᱤᱴ ᱛᱟᱢᱟᱭ ᱾\u0020</string>
   <!-- Category of trackers (cross-site tracking cookies) that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_cookies_title">ᱠᱨᱚᱥᱼᱥᱟᱭᱤᱴ ᱜᱷᱮᱨ ᱮᱥᱮᱫ ᱠᱩᱠᱤ ᱠᱚ</string>
   <!-- Category of trackers (cross-site tracking cookies) that can be blocked by Enhanced Tracking Protection -->
@@ -2693,7 +2693,7 @@
   -->
   <string name="default_browser_experiment_card_title">ᱟᱢᱟᱜ ᱢᱩᱞ ᱵᱽᱨᱟᱣᱡᱚᱨ ᱛᱮ ᱩᱪᱟᱹᱲᱚᱜ ᱢᱮ</string>
   <!-- Default browser card text -->
-  <string name="default_browser_experiment_card_text" tools:ignore="BrandUsage">Firefox ᱟᱡ ᱛᱮ ᱠᱷᱩᱞᱟᱹ ᱪᱷᱚ ᱞᱟᱹᱜᱤᱫ ᱣᱮᱵᱥᱟᱭᱤᱴ, ᱤᱢᱮᱞ, ᱟᱨ ᱢᱮᱥᱮᱡᱽ ᱨᱮᱭᱟᱜ ᱞᱤᱝᱠ ᱥᱮᱴ ᱢᱮ ᱾\u0032</string>
+  <string name="default_browser_experiment_card_text" tools:ignore="BrandUsage">Firefox ᱟᱡ ᱛᱮ ᱠᱷᱩᱞᱟᱹ ᱪᱷᱚ ᱞᱟᱹᱜᱤᱫ ᱣᱮᱵᱥᱟᱭᱤᱴ, ᱤᱢᱮᱞ, ᱟᱨ ᱢᱮᱥᱮᱡᱽ ᱨᱮᱭᱟᱜ ᱞᱤᱝᱠ ᱥᱮᱴ ᱢᱮ ᱾\u0020</string>
   <!-- Content description for close button in collection placeholder. -->
   <string name="remove_home_collection_placeholder_content_description">ᱚᱪᱟᱜ</string>
   <!-- Content description radio buttons with a link to more information -->
@@ -2918,7 +2918,7 @@
   -->
   <string name="download_languages_translations_toolbar_title_preference">ᱯᱟᱹᱨᱥᱤᱠᱚ ᱰᱟᱣᱱᱞᱚᱰ ᱢᱮ</string>
   <!-- Screen header presenting the download language preference feature. It will appear under the toolbar. %1$s is a link using download_languages_header_learn_more_preference as text ("Learn more"). Talkback will append this to say "Double tap to open link to learn more". -->
-  <string name="download_languages_header_preference">ᱞᱚᱜᱚᱱ ᱛᱚᱨᱡᱚᱢᱟ ᱟᱨ ᱚᱯᱷᱞᱟᱭᱤᱱ ᱛᱚᱨᱡᱚᱢᱟ ᱞᱟᱹᱜᱤᱫ ᱯᱩᱨᱟᱹ ᱯᱟᱹᱨᱥᱠᱚ ᱰᱟᱣᱩᱱᱞᱚᱰ ᱢᱮ ᱾%1$s\u0032</string>
+  <string name="download_languages_header_preference">ᱞᱚᱜᱚᱱ ᱛᱚᱨᱡᱚᱢᱟ ᱟᱨ ᱚᱯᱷᱞᱟᱭᱤᱱ ᱛᱚᱨᱡᱚᱢᱟ ᱞᱟᱹᱜᱤᱫ ᱯᱩᱨᱟᱹ ᱯᱟᱹᱨᱥᱠᱚ ᱰᱟᱣᱩᱱᱞᱚᱰ ᱢᱮ ᱾%1$s\u0020</string>
   <!-- Clickable text from the screen header that links to a website. -->
   <string name="download_languages_header_learn_more_preference">ᱰᱷᱮᱨ ᱥᱮᱬᱟᱭ ᱢᱮ</string>
   <!-- The subhead of the download language preference screen will appear above the pivot language. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-sc/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-sc/strings.xml
@@ -60,8 +60,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s lìmpiat sa cronologia de chirca e de navigatzione tuas dae is ischedas privadas cando ddas serras o essis de s’aplicatzione. Non ti faghet abarrare in anònimu pro is sitos web e su frunidore de servìtzios de internet tuo, però t’agiudat a cunservare in privadu su chi ses faghende in lìnia dae àtera gente chi imperat custu dispositivu.</string>
-  <string name="private_browsing_common_myths">\u0032Mitos fitianos subra de sa navigatzione privada\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s lìmpiat sa cronologia de chirca e de navigatzione tuas dae is ischedas privadas cando ddas serras o essis de s’aplicatzione. Non ti faghet abarrare in anònimu pro is sitos web e su frunidore de servìtzios de internet tuo, però t’agiudat a cunservare in privadu su chi ses faghende in lìnia dae àtera gente chi imperat custu dispositivu.</string>
+  <string name="private_browsing_common_myths">\u0020Mitos fitianos subra de sa navigatzione privada\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-scn/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-scn/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s scancella i to risciduti e a to crunuluggìa di navicazzioni quannu nesci di l\'applicazzioni o quannu chiuji tutti i schedi privati. Puru si chistu nun ti fa anònimu pî siti o pû to furnituri dû sirbizzu internet, è cchiù fàcili tèniri privatu chiḍḍu chi fai \'n linia di tutti chiḍḍi ca ùsanu stu dispusitivu.</string>
-  <string name="private_browsing_common_myths">\u0032Liggenni ncapu â navicazzioni privata\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s scancella i to risciduti e a to crunuluggìa di navicazzioni quannu nesci di l\'applicazzioni o quannu chiuji tutti i schedi privati. Puru si chistu nun ti fa anònimu pî siti o pû to furnituri dû sirbizzu internet, è cchiù fàcili tèniri privatu chiḍḍu chi fai \'n linia di tutti chiḍḍi ca ùsanu stu dispusitivu.</string>
+  <string name="private_browsing_common_myths">\u0020Liggenni ncapu â navicazzioni privata\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -426,7 +426,7 @@
     Content description (not visible, for screen readers etc.): Erase button: Erase the browsing
     history and go back to the home screen.
   -->
-  <string name="browser_toolbar_erase">Scancella crunuluggìa di navicazzioni\u0032</string>
+  <string name="browser_toolbar_erase">Scancella crunuluggìa di navicazzioni\u0020</string>
   <!-- Content description for the translate page toolbar button that opens the translations dialog when no translation has occurred. -->
   <string name="browser_toolbar_translate">Traduci pàggina</string>
   <!--
@@ -442,7 +442,7 @@
   -->
   <string name="a11y_selected_locale_content_description">Lingua scartata</string>
   <!-- Text for default locale item -->
-  <string name="default_locale_text">Sicuta a lingua dû dispusitivu\u0032</string>
+  <string name="default_locale_text">Sicuta a lingua dû dispusitivu\u0020</string>
   <!-- Placeholder text shown in the search bar before a user enters text -->
   <string name="locale_search_hint">Riscedi lingua</string>
   <!--
@@ -2697,7 +2697,7 @@
   <!-- Label that indicates a site is using a insecure connection -->
   <string name="quick_settings_sheet_insecure_connection_2">A cunnissioni nun è sicura</string>
   <!-- Label that indicates a site is displaying a local document -->
-  <string name="quick_settings_sheet_local_page">Sta pàggina è sarbata nnô to dispusitivu\u0032</string>
+  <string name="quick_settings_sheet_local_page">Sta pàggina è sarbata nnô to dispusitivu\u0020</string>
   <!-- Label to clear site data -->
   <string name="clear_site_data">Scancella i viscotta e i dati dî siti</string>
   <!-- Confirmation message for a dialog confirming if the user wants to delete all data for current site. %s is the domain of the site. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-si/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-si/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032ඔබ පෞද්. පටිති වසා දැමූ විට හෝ යෙදුමෙන් ඉවත් වූ විට %1$s ඔබගේ සෙවුම් සහ පිරික්සුම් ඉතිහාසය හිස් කරයි, නමුත් ඔබව අඩවි වලින් හෝ අන්තර්ජාල සැපයුම්කරුගෙන් නිර්නාමික නොකරයි. මෙය ඔබ මාර්ගගතව කරන දෑ මෙම උපාංගය භාවිතා කරන වෙනත් අයගෙන් පෞද්ගලිකව තබා ගැනීම පහසු කරයි.</string>
-  <string name="private_browsing_common_myths">\u0032පෞද්ගලික පිරික්සීම පිළිබඳව සුලබ මිථ්‍යා\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020ඔබ පෞද්. පටිති වසා දැමූ විට හෝ යෙදුමෙන් ඉවත් වූ විට %1$s ඔබගේ සෙවුම් සහ පිරික්සුම් ඉතිහාසය හිස් කරයි, නමුත් ඔබව අඩවි වලින් හෝ අන්තර්ජාල සැපයුම්කරුගෙන් නිර්නාමික නොකරයි. මෙය ඔබ මාර්ගගතව කරන දෑ මෙම උපාංගය භාවිතා කරන වෙනත් අයගෙන් පෞද්ගලිකව තබා ගැනීම පහසු කරයි.</string>
+  <string name="private_browsing_common_myths">\u0020පෞද්ගලික පිරික්සීම පිළිබඳව සුලබ මිථ්‍යා\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-sk/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-sk/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s vymaže históriu vyhľadávania a navštívených stránok po zavretí aplikácie alebo všetkých súkromných kariet a okien. S touto funkciou nie ste na internete neviditeľní a napríklad váš poskytovateľ pripojenia na internet môže stále zistiť, aké stránky navštevujete. Vaša aktivita na internete ale zostane utajená pred ďalšími používateľmi na tomto zariadení.</string>
-  <string name="private_browsing_common_myths">\u0032Časté mýty o súkromnom prehliadaní\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Časté mýty o súkromnom prehliadaní\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-skr/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-skr/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s نجی ٹیب نال تہاݙے ڳولݨ تے براؤزنگ دی تاریخ کوں صاف کریندے جہڑے ویلے تساں انہاں کوں بند کریندے ہو یا ایپ کوں چھوڑ ݙیندے ہو۔ ڄݙاں جو ایہ تہاکوں ویب سائٹاں یا انٹرنیٹ سروس فراہم کرݨ آلیاں کیتے گمنام کائنی بݨیندا، تساں ایندے نال جو کجھ وی آن لائن کریندے ہو، اوں کوں ایہ ڈیوائس ورتݨ آلے کہیں وی ٻئے کنوں نجی رکھݨ سوکھا بݨیندے۔</string>
-  <string name="private_browsing_common_myths">\u0032نجی براؤزنگ بارے عام فرضی قصے\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s نجی ٹیب نال تہاݙے ڳولݨ تے براؤزنگ دی تاریخ کوں صاف کریندے جہڑے ویلے تساں انہاں کوں بند کریندے ہو یا ایپ کوں چھوڑ ݙیندے ہو۔ ڄݙاں جو ایہ تہاکوں ویب سائٹاں یا انٹرنیٹ سروس فراہم کرݨ آلیاں کیتے گمنام کائنی بݨیندا، تساں ایندے نال جو کجھ وی آن لائن کریندے ہو، اوں کوں ایہ ڈیوائس ورتݨ آلے کہیں وی ٻئے کنوں نجی رکھݨ سوکھا بݨیندے۔</string>
+  <string name="private_browsing_common_myths">\u0020نجی براؤزنگ بارے عام فرضی قصے\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -505,7 +505,7 @@
     Description for add search widget screen used by Nimbus experiments. Nimbus experiments do not support string placeholders.
     Note: The word "Firefox" should NOT be translated
   -->
-  <string name="juno_onboarding_add_search_widget_description" tools:ignore="BrandUsage,UnusedResources">تُہاݙی ہوم سکرین اُتے فائر فاکس دے نال، تُہاکوں رازداری-پہلاں براؤزر تئیں سَوکھی رسائی حاصل تھی ویسی جہڑا کراس سائٹ ٹریکراں کوں روکین٘دا ہِے۔\u0032</string>
+  <string name="juno_onboarding_add_search_widget_description" tools:ignore="BrandUsage,UnusedResources">تُہاݙی ہوم سکرین اُتے فائر فاکس دے نال، تُہاکوں رازداری-پہلاں براؤزر تئیں سَوکھی رسائی حاصل تھی ویسی جہڑا کراس سائٹ ٹریکراں کوں روکین٘دا ہِے۔\u0020</string>
   <!--
     Text for the button to add search widget on the device used by Nimbus experiments. Nimbus experiments do not support string placeholders.
     Note: The word "Firefox" should NOT be translated
@@ -788,7 +788,7 @@
   <!-- Title for the customize home screen section with Pocket. -->
   <string name="customize_toggle_pocket_2">فکر انگیز کہاݨیاں</string>
   <!-- Summary for the customize home screen section with Pocket. %s is "Pocket". -->
-  <string name="customize_toggle_pocket_summary">\u0032%s ولوں تکڑے تھئے مضمون</string>
+  <string name="customize_toggle_pocket_summary">\u0020%s ولوں تکڑے تھئے مضمون</string>
   <!-- Title for the customize home screen section with sponsored Pocket stories. -->
   <string name="customize_toggle_pocket_sponsored">سپانسر تھیاں کہاݨیاں</string>
   <!-- Title for the opening wallpaper settings screen -->
@@ -1912,7 +1912,7 @@
     Description of the SmartBlock Enhanced Tracking Protection feature. The * symbol is intentionally hardcoded here,
     as we use it on the UI to indicate which trackers have been partially unblocked.
   -->
-  <string name="preference_etp_smartblock_description">\u0032ہیٹھاں کجھ نشان زدہ ٹریکرز کوں ایں ورقے تے جزوی طور تے اݨ بلاک کر ݙتا ڳئے کیوں جو تساں انہاں نال تعامل کیتے*۔</string>
+  <string name="preference_etp_smartblock_description">\u0020ہیٹھاں کجھ نشان زدہ ٹریکرز کوں ایں ورقے تے جزوی طور تے اݨ بلاک کر ݙتا ڳئے کیوں جو تساں انہاں نال تعامل کیتے*۔</string>
   <!-- Text displayed that links to website about enhanced tracking protection SmartBlock -->
   <string name="preference_etp_smartblock_learn_more">ٻیا سِکھو</string>
   <!--
@@ -2185,7 +2185,7 @@
   <!-- Placeholder text shown in the Search String TextField before a user enters text -->
   <string name="search_add_custom_engine_search_string_hint_2">ڳولݨ دے ورتݨ کیتے یوآرایل</string>
   <!-- Description text for the Search String TextField. The %s is part of the string -->
-  <string name="search_add_custom_engine_search_string_example" formatted="false">\u0032“%s” نال سوال وٹاؤ۔ مثال:\nhttps://www.google.com/search?q=%s</string>
+  <string name="search_add_custom_engine_search_string_example" formatted="false">\u0020“%s” نال سوال وٹاؤ۔ مثال:\nhttps://www.google.com/search?q=%s</string>
   <!-- Accessibility description for the form in which details about the custom search engine are entered -->
   <string name="search_add_custom_engine_form_description">من پسند ڳولݨ انجݨ تفصیلاں</string>
   <!-- Label for the TextField in which user enters custom search engine suggestion URL -->
@@ -2223,7 +2223,7 @@
   <!-- Label that indicates a site is using a insecure connection -->
   <string name="quick_settings_sheet_insecure_connection_2">کنکشن محفوظ کائنی۔</string>
   <!-- Label to clear site data -->
-  <string name="clear_site_data">کوکیاں تے سائٹ ڈیٹا صاف کرو\u0032</string>
+  <string name="clear_site_data">کوکیاں تے سائٹ ڈیٹا صاف کرو\u0020</string>
   <!-- Confirmation message for a dialog confirming if the user wants to delete all data for current site. %s is the domain of the site. -->
   <string name="confirm_clear_site_data">بھلا تہاکوں پک ہے جو تساں سائٹ &lt;b&gt;%s&lt;/b&gt; کیتے ساریاں کوکیاں تے ڈیٹا صاف کرݨ چاہندے ہو؟</string>
   <!-- Confirmation message for a dialog confirming if the user wants to delete all the permissions for all sites -->
@@ -2661,7 +2661,7 @@
     The dialog will be presented when the user requests deletion of a language.
     %1$s is the name of the language, for example, "Spanish" and %2$s is the size in kilobytes or megabytes of the language file.
   -->
-  <string name="delete_language_file_dialog_title">\u0032%1$s (%2$s) مٹاؤں؟</string>
+  <string name="delete_language_file_dialog_title">\u0020%1$s (%2$s) مٹاؤں؟</string>
   <!-- Additional information for the dialog used by the translations feature to confirm deleting a language. %1$s is the name of the app (for example "Firefox"). -->
   <string name="delete_language_file_dialog_message">ڄیکر تُساں اِیں ٻولی کوں حذف کرین٘دے ہِیوے، تاں %1$s تُہاݙے ترجمہ کرݨ ویلے تُہاݙے کیشے وِچ جزوی ٻولیاں ڈاؤن لوڈ کر ݙیسی۔</string>
   <!--

--- a/mozilla-mobile/fenix/app/src/main/res/values-sl/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-sl/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s izbriše zgodovino iskanja in brskanja zasebnih zavihkov, ko jih zaprete ali zaprete aplikacijo. Čeprav to ne pomeni, da ste za spletna mesta ali ponudnike internetnih storitev anonimni, vam omogoča uporabo spleta v zasebnosti, skrito pred očmi ostalih uporabnikov te naprave.</string>
-  <string name="private_browsing_common_myths">\u0032Pogoste zmote o zasebnem brskanju\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Pogoste zmote o zasebnem brskanju\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-sq/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-sq/strings.xml
@@ -43,7 +43,7 @@
   <!-- Content description for close button while in multiselect mode in tab tray -->
   <string name="tab_tray_close_multiselect_content_description">Dil nga mënyra përzgjedhje e shumëfishtë</string>
   <!-- Content description for save to collection button while in multiselect mode in tab tray -->
-  <string name="tab_tray_collection_button_multiselect_content_description">Ruaji te koleksioni skedat e përzgjedhura\u0032</string>
+  <string name="tab_tray_collection_button_multiselect_content_description">Ruaji te koleksioni skedat e përzgjedhura\u0020</string>
   <!--
     Home - Bookmarks
 
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s-u e spastron historikun tuaj të kërkimeve dhe shfletimit prej skedash private, kur i mbyllni ato, ose dilni nga aplikacioni. Edhe pse kjo s’ju bën anonim përballë sajteve apo furnizuesit të shërbimit tuaj internet, e bën më të lehtë mbajtjen private të asaj çka bëni në internet, nga cilido tjetër që përdor këtë pajisje.</string>
-  <string name="private_browsing_common_myths">\u0032Mite të rëndomtë mbi shfletimin privat\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Mite të rëndomtë mbi shfletimin privat\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -248,7 +248,7 @@
   <!-- Browser menu description that is shown when one or more extensions are disabled due to extension errors -->
   <string name="browser_menu_extensions_disabled_description">Çaktivizuar përkohësisht</string>
   <!-- The description of the browser menu appears when the user hasn't installed any extensions. -->
-  <string name="browser_menu_no_extensions_installed_description">S’ka zgjerime të aktivizuara\u0032</string>
+  <string name="browser_menu_no_extensions_installed_description">S’ka zgjerime të aktivizuara\u0020</string>
   <!-- Browser menu button that opens account settings -->
   <string name="browser_menu_account_settings">Hollësi llogarie</string>
   <!-- Browser menu button that sends a user to help articles -->
@@ -645,7 +645,7 @@
   <!-- Marketing onboarding page title. 'Firefox' is intentionally hardcoded. -->
   <string name="onboarding_marketing_title" tools:ignore="BrandUsage,UnusedResources">Ndihmonani të fuqizojmë Firefox-in</string>
   <!-- Marketing onboarding page body. 'Firefox' is intentionally hardcoded. -->
-  <string name="onboarding_marketing_body" tools:ignore="BrandUsage,UnusedResources">Kur na tregoni se si e zbuluat Firefox-in dhe se e përdorni, na ndihmoni ta paraqesim shfletuesin tonë te më tepër njerëz.\u0032</string>
+  <string name="onboarding_marketing_body" tools:ignore="BrandUsage,UnusedResources">Kur na tregoni se si e zbuluat Firefox-in dhe se e përdorni, na ndihmoni ta paraqesim shfletuesin tonë te më tepër njerëz.\u0020</string>
   <!-- Marketing onboarding page opt-in checkbox. 'Mozilla' is intentionally hardcoded. -->
   <string name="onboarding_marketing_opt_in_checkbox" tools:ignore="UnusedResources">Ndani me partnerë teknologjish marketingu të Mozilla-s të dhëna minimale. Këto të dhëna nuk shiten kurrë, apo të përdoren për t’ju shfaqur reklama.</string>
   <!-- Marketing onboarding page clickable link text to "learn more" on how data is used. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-su/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-su/strings.xml
@@ -321,7 +321,7 @@
   -->
   <string name="browser_menu_save">Teundeun</string>
   <!-- Browser menu description that describes the various save related menu items inside of the save sub-menu -->
-  <string name="browser_menu_save_description">Tambahan tetengger, Panarabas, Imah, Koléksi, PDF\u0032</string>
+  <string name="browser_menu_save_description">Tambahan tetengger, Panarabas, Imah, Koléksi, PDF\u0020</string>
   <!-- Browser menu label that bookmarks the currently visited page -->
   <string name="browser_menu_bookmark_this_page">Markahkeun ieu kaca</string>
   <!-- Browser menu label that navigates to the edit bookmark screen for the current bookmarked page -->
@@ -345,7 +345,7 @@
     Browser menu label for the Delete browsing data on quit feature.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="browser_menu_delete_browsing_data_on_quit">Eureun %1$s\u0032</string>
+  <string name="browser_menu_delete_browsing_data_on_quit">Eureun %1$s\u0020</string>
   <!--
     Menu "contextual feature recommendation" (CFR)
 
@@ -353,7 +353,7 @@
   -->
   <string name="menu_cfr_title">Anyar: ménu nu diutamakeun</string>
   <!-- Text for the message in the contextual feature recommendation popup promoting the menu feature. -->
-  <string name="menu_cfr_body">Manggihkeun kabutuhan anjeun leuwih ganjang, ti panyungsian privat nepi ka nyimpen.\u0032</string>
+  <string name="menu_cfr_body">Manggihkeun kabutuhan anjeun leuwih ganjang, ti panyungsian privat nepi ka nyimpen.\u0020</string>
   <!--
     Extensions management fragment
 
@@ -378,7 +378,7 @@
     %1$s is the name of the language that is displayed in the original page. (For example: English)
     %2$s is the name of the language which the page was translated to. (For example: French)
   -->
-  <string name="browser_toolbar_translated_successfully">Kaca ditarjamahkeun ti %1$s ka %2$s.\u0032</string>
+  <string name="browser_toolbar_translated_successfully">Kaca ditarjamahkeun ti %1$s ka %2$s.\u0020</string>
   <!--
     Locale Settings Fragment
 
@@ -445,9 +445,9 @@
   -->
   <string name="juno_onboarding_default_browser_title_nimbus_3" tools:ignore="BrandUsage,UnusedResources">Téang iber naha mangyuta jalma resep Firefox</string>
   <!-- Title for set firefox as default browser screen used by Nimbus experiments. -->
-  <string name="juno_onboarding_default_browser_title_nimbus_4" tools:ignore="UnusedResources">Panyungsian aman jeung réa pilihan\u0032</string>
+  <string name="juno_onboarding_default_browser_title_nimbus_4" tools:ignore="UnusedResources">Panyungsian aman jeung réa pilihan\u0020</string>
   <!-- Description for set firefox as default browser screen used by Nimbus experiments. -->
-  <string name="juno_onboarding_default_browser_description_nimbus_3">Browser anu dirojong kalawan nirlaba urang nulungan pikeun mahing pausahaan ngukuntit anjuen dina wéb.\u0032</string>
+  <string name="juno_onboarding_default_browser_description_nimbus_3">Browser anu dirojong kalawan nirlaba urang nulungan pikeun mahing pausahaan ngukuntit anjuen dina wéb.\u0020</string>
   <!-- Description for set firefox as default browser screen used by Nimbus experiments. -->
   <string name="juno_onboarding_default_browser_description_nimbus_4" tools:ignore="UnusedResources">Leuwih ti 100 juta jalma ngajaga privasina ku milih browser anu dirojong ku nirlaba.</string>
   <!-- Description for set firefox as default browser screen used by Nimbus experiments. -->
@@ -586,7 +586,7 @@
   <!-- Text for indicating that a request for unsupported site was sent to Nimbus (it's a Mozilla library for experiments), this is shown as part of the protections panel with the tracking protection toggle -->
   <string name="reduce_cookie_banner_unsupported_site_request_submitted_2">Rekés dukungan dikirim</string>
   <!-- Text for indicating cookie banner handling is currently not supported for this site, this is shown as part of the protections panel with the tracking protection toggle -->
-  <string name="reduce_cookie_banner_unsupported_site">Kiwari loka teu didukung\u0032</string>
+  <string name="reduce_cookie_banner_unsupported_site">Kiwari loka teu didukung\u0020</string>
   <!-- Title text for a detail explanation indicating cookie banner handling is on this site, this is shown as part of the cookie banner panel in the toolbar. %1$s is a shortened URL of the current site. -->
   <string name="reduce_cookie_banner_details_panel_title_on_for_site_1">Hurungkeun Pameungpeuk Spanduk Réréméh pikeun %1$s?</string>
   <!-- Title text for a detail explanation indicating cookie banner handling is off this site, this is shown as part of the cookie banner panel in the toolbar. %1$s is a shortened URL of the current site. -->
@@ -1726,7 +1726,7 @@
   <!-- Preference for enhanced tracking protection for the standard protection settings -->
   <string name="preference_enhanced_tracking_protection_standard_default_1">Baku (bawaan)</string>
   <!-- Preference description for enhanced tracking protection for the standard protection settings -->
-  <string name="preference_enhanced_tracking_protection_standard_description_5">Kaca loka bakal muka sakumaha biasa, ngan meungpeuk leuwih saeutik palacak.\u0032</string>
+  <string name="preference_enhanced_tracking_protection_standard_description_5">Kaca loka bakal muka sakumaha biasa, ngan meungpeuk leuwih saeutik palacak.\u0020</string>
   <!-- Accessibility text for the Standard protection information icon -->
   <string name="preference_enhanced_tracking_protection_standard_info_button">Naon anu dipeungpeuk ku perlindungan pelacakan baku</string>
   <!-- Preference for enhanced tracking protection for the strict protection settings -->
@@ -1822,7 +1822,7 @@
   <!-- Preference for fingerprinting protection for the custom protection settings -->
   <string name="etp_suspected_fingerprinters_title">Sidik ramo anu dicurigaan</string>
   <!-- Description of fingerprinters that can be blocked by fingerprinting protection -->
-  <string name="etp_suspected_fingerprinters_description">Hurungkeun panyalindung sidik ramo pikeun nulak sidik ramo anu dicurigaan\u0032</string>
+  <string name="etp_suspected_fingerprinters_description">Hurungkeun panyalindung sidik ramo pikeun nulak sidik ramo anu dicurigaan\u0020</string>
   <!-- Category of trackers (fingerprinters) that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_known_fingerprinters_title">Sidik ramo nu dipiwanoh</string>
   <!--
@@ -2255,7 +2255,7 @@
   <!-- Label text displayed for a sponsored top site. -->
   <string name="top_sites_sponsored_label">Disponsoran</string>
   <!-- Text for the menu item to edit a top site. -->
-  <string name="top_sites_edit_top_site">Ropéa\u0032</string>
+  <string name="top_sites_edit_top_site">Ropéa\u0020</string>
   <!-- Text for the dialog title to edit a top site. -->
   <string name="top_sites_edit_dialog_title">Ropéa panarabas</string>
   <!-- Button caption to confirm the edit of the top site. -->
@@ -2446,7 +2446,7 @@
   <!-- Toggle switch description that will appear under the "Never translate these sites" settings toggle switch to provide more information on how this setting interacts with other settings. -->
   <string name="translation_option_bottom_sheet_switch_never_translate_site_description">Timpah sakabéh setelan séjén</string>
   <!-- Toggle switch description that will appear under the "Never translate" and "Always translate" toggle switch settings to provide more information on how these  settings interacts with other settings. -->
-  <string name="translation_option_bottom_sheet_switch_description">Timpah tawaran pikeun narjamahkeun\u0032</string>
+  <string name="translation_option_bottom_sheet_switch_description">Timpah tawaran pikeun narjamahkeun\u0020</string>
   <!-- Button text for the button that will take the user to the translation settings dialog. -->
   <string name="translation_option_bottom_sheet_translation_settings">Setélan tarjamahan</string>
   <!-- Button text for the button that will take the user to a website to learn more about how translations works in the given app. %1$s is the name of the app (for example "Firefox"). -->
@@ -2701,7 +2701,7 @@
   <!-- Text shown in prompt for printing microsurvey. "sec" It's an abbreviation for "second". Note: The word "Firefox" should NOT be translated. -->
   <string name="microsurvey_prompt_printing_title" tools:ignore="BrandUsage,UnusedResources">Bantuan sangkan Firefox bisa nyitak leuwih hadé. Ngan perlu sakolépat</string>
   <!-- Text shown in prompt for search microsurvey. Note: The word "Firefox" should NOT be translated. -->
-  <string name="microsurvey_prompt_search_title" tools:ignore="BrandUsage,UnusedResources">Bantuan sangkan panyungsi Firefox leuwih hadé. Ngan perlu samenit baé.\u0032</string>
+  <string name="microsurvey_prompt_search_title" tools:ignore="BrandUsage,UnusedResources">Bantuan sangkan panyungsi Firefox leuwih hadé. Ngan perlu samenit baé.\u0020</string>
   <!-- Text shown in prompt for sync microsurvey. Note: The word "Firefox" should NOT be translated. -->
   <string name="microsurvey_prompt_sync_title" tools:ignore="BrandUsage,UnusedResources">Bantuan sangkan singkronisasi Firefox leuwih hadé. Ngan perlu samenit baé</string>
   <!-- Text shown in the survey title for printing microsurvey. Note: The word "Firefox" should NOT be translated. -->
@@ -2741,7 +2741,7 @@
 
     The title of the CFR Tools feature in the Debug Drawer
   -->
-  <string name="debug_drawer_cfr_tools_title">Pakakas CFR\u0032</string>
+  <string name="debug_drawer_cfr_tools_title">Pakakas CFR\u0020</string>
   <!-- The title of the reset CFR section in CFR Tools -->
   <string name="debug_drawer_cfr_tools_reset_cfr_title">Atur deui CFRs</string>
   <!--

--- a/mozilla-mobile/fenix/app/src/main/res/values-sv-rSE/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-sv-rSE/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s rensar din sök- och surfhistorik när du stänger appen eller stänger alla privata flikar. Även om detta inte gör dig anonym för webbplatser eller din internetleverantör, gör det det lättare att hålla vad du gör online privat från alla andra som använder den här enheten.</string>
-  <string name="private_browsing_common_myths">\u0032Vanliga myter om privat surfning\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Vanliga myter om privat surfning\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2511,7 +2511,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Sparade lösenord</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">Lösenorden du sparar eller synkroniserar till %s kommer att listas här. Alla lösenord du sparar är krypterade.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">Lösenorden du sparar eller synkroniserar till %s kommer att listas här. Alla lösenord du sparar är krypterade.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Läs mer om synkronisering</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->
@@ -2772,7 +2772,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Verifierad av: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Verifierad av: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Ta bort</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-szl/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-szl/strings.xml
@@ -50,8 +50,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s ôprōżnio historyjo wyszukowanio i przeglōndanio ze prywatnych kart, jak zawrzisz je abo aplikacyjo. Skuli tego niy je sie anonimowym do strōn ani dostowcōw necowych usug. Snadnij ale możesz skryć swoja aktywność w internecie przed inkszymi, co używajōm tyj masziny.</string>
-  <string name="private_browsing_common_myths">\u0032Czynste mity ô prywatnym przeglōndaniu\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s ôprōżnio historyjo wyszukowanio i przeglōndanio ze prywatnych kart, jak zawrzisz je abo aplikacyjo. Skuli tego niy je sie anonimowym do strōn ani dostowcōw necowych usug. Snadnij ale możesz skryć swoja aktywność w internecie przed inkszymi, co używajōm tyj masziny.</string>
+  <string name="private_browsing_common_myths">\u0020Czynste mity ô prywatnym przeglōndaniu\u0020</string>
   <!--
     Private mode shortcut "contextual feature recommendation" (CFR)
 
@@ -67,7 +67,7 @@
 
     Text for the info message. %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="open_in_app_cfr_info_message_2">Możesz nastawić aplikacyjo %1$s, coby autōmatycznie ôtwiyrała linki w aplikacyjach.\u0032</string>
+  <string name="open_in_app_cfr_info_message_2">Możesz nastawić aplikacyjo %1$s, coby autōmatycznie ôtwiyrała linki w aplikacyjach.\u0020</string>
   <!-- Text for the positive action button -->
   <string name="open_in_app_cfr_positive_button_text">Idź do sztalōnkōw</string>
   <!-- Text for the negative action button -->
@@ -79,7 +79,7 @@
   <!-- Text for the negative action button to dismiss the dialog. -->
   <string name="camera_permissions_needed_negative_button_text">Ôdkoż</string>
   <!-- Text for the banner message to tell users about our auto close feature. -->
-  <string name="tab_tray_close_tabs_banner_message">Nastow, coby ôtwarte karty autōmatycznie sie zawiyrały, jak bez ôstatni dziyń, tydziyń abo rok niy były nawiedzōne.\u0032</string>
+  <string name="tab_tray_close_tabs_banner_message">Nastow, coby ôtwarte karty autōmatycznie sie zawiyrały, jak bez ôstatni dziyń, tydziyń abo rok niy były nawiedzōne.\u0020</string>
   <!-- Text for the positive action button to go to Settings for auto close tabs. -->
   <string name="tab_tray_close_tabs_banner_positive_button_text">Pokoż ôpcyje</string>
   <!-- Text for the negative action button to dismiss the Close Tabs Banner. -->
@@ -373,7 +373,7 @@
   <!-- Message shown in the error page for when trying to access a http website while https only mode is enabled. The message has two paragraphs. This is the first. -->
   <string name="errorpage_httpsonly_message_title">Zdowo sie, że to strōna niy ôbsuguje HTTPS.</string>
   <!-- Message shown in the error page for when trying to access a http website while https only mode is enabled. The message has two paragraphs. This is the second. -->
-  <string name="errorpage_httpsonly_message_summary">Może ale tyż sie rozchodzić ô jaki atak. Jak przyńdziesz na strōna, to niy ôstawiej na nij żodnych prywatnych informacyji. Jak na nia pudziesz, tryb \"Ino HTTPS\" czasowo sie wyłōnczy do tyj strōny.\u0032</string>
+  <string name="errorpage_httpsonly_message_summary">Może ale tyż sie rozchodzić ô jaki atak. Jak przyńdziesz na strōna, to niy ôstawiej na nij żodnych prywatnych informacyji. Jak na nia pudziesz, tryb \"Ino HTTPS\" czasowo sie wyłōnczy do tyj strōny.\u0020</string>
   <!-- Preference for accessibility -->
   <string name="preferences_accessibility">Dostympność</string>
   <!-- Preference to override the Sync token server -->
@@ -1361,7 +1361,7 @@
   <!-- Category of trackers (cryptominers) that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_cryptominers_title">Elymynty, co fedrujōm kryptopiniōndze</string>
   <!-- Description of cryptominers that can be blocked by Enhanced Tracking Protection -->
-  <string name="etp_cryptominers_description">Niy dowo ôszydnym skryptōm fedrować cyfrowych piniyndzy na twojij maszinie.\u0032</string>
+  <string name="etp_cryptominers_description">Niy dowo ôszydnym skryptōm fedrować cyfrowych piniyndzy na twojij maszinie.\u0020</string>
   <!-- Category of trackers (tracking content) that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_tracking_content_title">Śledzōnco zawartość</string>
   <!-- Text displayed that links to website about enhanced tracking protection SmartBlock -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-tg/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-tg/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032%1$s таърихи тамошобинӣ ва ҷустуҷӯи шуморо аз варақаҳои хусусие, ки шумо мепӯшед ё вақте ки шумо барномаро хомӯш мекунед, пок мекунад. Ин амал шуморо аз сомонаҳо ё провайдери хизматрасонии интернет пинҳон намекунад, аммо аз корбарони дигаре, ки ин дастгоҳро истифода мебаранд, фаъолияти онлайни шуморо ба осонӣ шахсӣ карда, нигоҳ медорад.</string>
-  <string name="private_browsing_common_myths">\u0032Асотири маълум дар бораи тамошобинии хусусӣ\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020%1$s таърихи тамошобинӣ ва ҷустуҷӯи шуморо аз варақаҳои хусусие, ки шумо мепӯшед ё вақте ки шумо барномаро хомӯш мекунед, пок мекунад. Ин амал шуморо аз сомонаҳо ё провайдери хизматрасонии интернет пинҳон намекунад, аммо аз корбарони дигаре, ки ин дастгоҳро истифода мебаранд, фаъолияти онлайни шуморо ба осонӣ шахсӣ карда, нигоҳ медорад.</string>
+  <string name="private_browsing_common_myths">\u0020Асотири маълум дар бораи тамошобинии хусусӣ\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -1808,7 +1808,7 @@
   <!-- Text for the button to navigate to sync authentication -->
   <string name="bookmark_empty_list_guest_cta">Барои ҳамоҳангсозӣ ворид шавед</string>
   <!-- Description for the bookmark list empty state when you're signed into sync. -->
-  <string name="bookmark_empty_list_authenticated_description">Сомонаҳоро ҳангоми тамошо нигоҳ доред. Мо, инчунин, аз дастгоҳҳои ҳамоҳангшудаи дигар хатбаракҳоро ба даст меорем.\u0032</string>
+  <string name="bookmark_empty_list_authenticated_description">Сомонаҳоро ҳангоми тамошо нигоҳ доред. Мо, инчунин, аз дастгоҳҳои ҳамоҳангшудаи дигар хатбаракҳоро ба даст меорем.\u0020</string>
   <!-- Description for the bookmark list empty state when you're in an empty folder. -->
   <string name="bookmark_empty_list_folder_description">Ҳангоми тамошо, хатбаракҳоро илова кунед, то тавонед сомонаҳои дӯстдоштаи худро дар оянда пайдо кунед.</string>
   <!-- Description for the add new folder button when selecting a folder. -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-tl/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-tl/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032Inaalis ng %1$s ang iyong bakas sa paghahanap at pag-browse sa mga pribadong tab kapag isinara mo sila o umalis sa app. Bagaman makikilala ka pa rin ng mga website o internet service provider mo, nakatutulong pa rin ito para mapanatiling pribado ang mga gawain mo online mula sa ibang gagamit ng device na ito.</string>
-  <string name="private_browsing_common_myths">\u0032Mga karaniwang pamahiin tungkol sa pribadong pag-browse\u0032</string>
+  <string name="private_browsing_placeholder_description_2">\u0020Inaalis ng %1$s ang iyong bakas sa paghahanap at pag-browse sa mga pribadong tab kapag isinara mo sila o umalis sa app. Bagaman makikilala ka pa rin ng mga website o internet service provider mo, nakatutulong pa rin ito para mapanatiling pribado ang mga gawain mo online mula sa ibang gagamit ng device na ito.</string>
+  <string name="private_browsing_common_myths">\u0020Mga karaniwang pamahiin tungkol sa pribadong pag-browse\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -1531,7 +1531,7 @@
     %2$s is the total size of the downloaded file.
     %3$s is the amount of time remaining to complete the download.
   -->
-  <string name="download_item_in_progress_description" tools:ignore="UnusedResources">%1$s / %2$s • natitirang %3$s\u0032</string>
+  <string name="download_item_in_progress_description" tools:ignore="UnusedResources">%1$s / %2$s • natitirang %3$s\u0020</string>
   <!-- Text to indicate that an in progress download is paused. -->
   <string name="download_item_status_paused" tools:ignore="UnusedResources">nakatigil</string>
   <!-- Text to indicate that the download speed of an in progress download is being calculated. -->
@@ -2707,7 +2707,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Naberipika ng: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Naberipika ng: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Burahin</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-tr/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-tr/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s, gizli sekmeleri kapattığınızda veya uygulamadan çıktığınızda gizli sekmelerdeki arama ve gezinti geçmişinizi temizler. Bu işlem, web sitelerinin ve internet servis sağlayıcınızın sizi tanımamasını sağlamaz ama bu cihazı kullanan başkaları varsa internette yaptıklarınızı onlardan gizlemenizi sağlar.</string>
-  <string name="private_browsing_common_myths">\u0032Gizli gezinti ile ilgili yaygın efsaneler\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Gizli gezinti ile ilgili yaygın efsaneler\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -1162,7 +1162,7 @@
     open on this device from another device that's signed in to the same Mozilla account.
     %1$s is a placeholder for the app name; %2$d is the number of tabs closed.
   -->
-  <string name="fxa_tabs_closed_notification_title">%2$d %1$s sekmesi kapatıldı\u0032</string>
+  <string name="fxa_tabs_closed_notification_title">%2$d %1$s sekmesi kapatıldı\u0020</string>
   <!-- The body for a "closed synced tabs" notification. -->
   <string name="fxa_tabs_closed_text">Son kapatılan sekmeleri göster</string>
   <!--
@@ -2770,7 +2770,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Doğrulayan: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Doğrulayan: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Sil</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-trs/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-trs/strings.xml
@@ -650,7 +650,7 @@
   -->
   <string name="open_all_warning_message">Si nā’nï̄nt gā’ì nej rakïj ñanj nī gā’hue nāhuin nāj %s. Gān’ānjt ne’ ñāan aj.</string>
   <!-- Dialog button text for confirming open all tabs -->
-  <string name="open_all_warning_confirm">Na\'nïn nej rakïj ñanj\u0032</string>
+  <string name="open_all_warning_confirm">Na\'nïn nej rakïj ñanj\u0020</string>
   <!-- Dialog button text for canceling open all tabs -->
   <string name="open_all_warning_cancel">Dūyichin\'</string>
   <!--
@@ -1161,7 +1161,7 @@
   -->
   <string name="notification_re_engagement_A_text">Riña aché nun huìt riña %1$s nitāj si na’nḯn sà’aj nej nuguan’ huā rayi’ît.</string>
   <!-- Title B shown in the notification that pops up to re-engage the user -->
-  <string name="notification_re_engagement_B_title">Gāyi’ì nānà’huì’t\u0032</string>
+  <string name="notification_re_engagement_B_title">Gāyi’ì nānà’huì’t\u0020</string>
   <!-- Text B shown in the notification that pops up to re-engage the user -->
   <string name="notification_re_engagement_B_text">Narì’ ‘ngō sa huin nīchrù’un. Asi nārì’ ‘ngō sa gī’hiaj nāhuin nīhià’ ruhuât.</string>
   <!--
@@ -1376,7 +1376,7 @@
   <!-- Option for enhanced tracking protection for the custom protection settings for cookies -->
   <string name="preference_enhanced_tracking_protection_custom_cookies_4">Daran\' nej kokî (ga\'ue dūre\'ej dā\'āj sîtio)</string>
   <!-- Option for enhanced tracking protection for the custom protection settings for cookies -->
-  <string name="preference_enhanced_tracking_protection_custom_cookies_5">Gi’hiaj anêj nej kôki riña nej sitio\u0032</string>
+  <string name="preference_enhanced_tracking_protection_custom_cookies_5">Gi’hiaj anêj nej kôki riña nej sitio\u0020</string>
   <!-- Preference for enhanced tracking protection for the custom protection settings for tracking content -->
   <string name="preference_enhanced_tracking_protection_custom_tracking_content">Sa nīkāj sa naga\'nāj a</string>
   <!-- Option for enhanced tracking protection for the custom protection settings for tracking content -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-tt/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-tt/strings.xml
@@ -56,7 +56,7 @@
   <string name="home_bookmarks_menu_item_remove">Бетерү</string>
   <!-- About content. %1$s is the name of the app (for example "Firefox"). -->
   <string name="about_content">%1$s Mozilla тарафыннан җитештерелә.</string>
-  <string name="private_browsing_common_myths">\u0032Хосусый гизү турында киң таралган мифлар\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Хосусый гизү турында киң таралган мифлар\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -90,7 +90,7 @@
   <!-- Text for the negative action button to dismiss the dialog. -->
   <string name="camera_permissions_needed_negative_button_text">Яшерү</string>
   <!-- Text for the positive action button to go to Settings for auto close tabs. -->
-  <string name="tab_tray_close_tabs_banner_positive_button_text">Опцияләрне карау\u0032</string>
+  <string name="tab_tray_close_tabs_banner_positive_button_text">Опцияләрне карау\u0020</string>
   <!-- Text for the negative action button to dismiss the Close Tabs Banner. -->
   <string name="tab_tray_close_tabs_banner_negative_button_text">Яшерү</string>
   <!-- Text for the banner message to tell users about our inactive tabs feature. -->
@@ -338,7 +338,7 @@
 
     Content description for tick mark on selected language
   -->
-  <string name="a11y_selected_locale_content_description">Сайланган тел\u0032</string>
+  <string name="a11y_selected_locale_content_description">Сайланган тел\u0020</string>
   <!-- Text for default locale item -->
   <string name="default_locale_text">Җиһаз теленә иярү</string>
   <!-- Placeholder text shown in the search bar before a user enters text -->
@@ -934,7 +934,7 @@
   <!-- Option in library for Recently Closed Tabs -->
   <string name="library_recently_closed_tabs">Күптән түгел ябылган таблар</string>
   <!-- Option in library to open Recently Closed Tabs page -->
-  <string name="recently_closed_show_full_history">Тулы тарихны күрсәтү\u0032</string>
+  <string name="recently_closed_show_full_history">Тулы тарихны күрсәтү\u0020</string>
   <!--
     Text to show users they have multiple tabs saved in the Recently Closed Tabs section of history.
     %d is a placeholder for the number of tabs selected.
@@ -1016,7 +1016,7 @@
   <!-- Content description (not visible, for screen readers etc.): Add tab button. Adds a news tab when pressed -->
   <string name="add_tab">Таб өстәү</string>
   <!-- Content description (not visible, for screen readers etc.): Add tab button. Adds a news tab when pressed -->
-  <string name="add_private_tab">Хосусый таб өстәү\u0032</string>
+  <string name="add_private_tab">Хосусый таб өстәү\u0020</string>
   <!-- Text for the new tab button to indicate adding a new private tab in the tab -->
   <string name="tab_drawer_fab_content">Хосусый</string>
   <!-- Text for the new tab button to indicate syncing command on the synced tabs page -->
@@ -1809,7 +1809,7 @@
   <!-- Content Description (for screenreaders etc) read for the button to copy a password in logins -->
   <string name="saved_logins_copy_password">Серсүзне күчереп алу</string>
   <!-- Content Description (for screenreaders etc) read for the button to clear a password while editing a login -->
-  <string name="saved_logins_clear_password">Серсүзне чистарту\u0032</string>
+  <string name="saved_logins_clear_password">Серсүзне чистарту\u0020</string>
   <!-- Content Description (for screenreaders etc) read for the button to copy a username in logins -->
   <string name="saved_login_copy_username">Кулланучы исемен күчереп алу</string>
   <!-- Content Description (for screenreaders etc) read for the button to clear a username while editing a login -->
@@ -1817,7 +1817,7 @@
   <!-- Content Description (for screenreaders etc) read for the button to clear the hostname field while creating a login -->
   <string name="saved_login_clear_hostname">Сервер исемен чистарту</string>
   <!-- Content Description (for screenreaders etc) read for the button to open a site in logins -->
-  <string name="saved_login_open_site">Сайтны браузерда ачу\u0032</string>
+  <string name="saved_login_open_site">Сайтны браузерда ачу\u0020</string>
   <!-- Content Description (for screenreaders etc) read for the button to reveal a password in logins -->
   <string name="saved_login_reveal_password">Серсүзне күрсәтү</string>
   <!-- Content Description (for screenreaders etc) read for the button to hide a password in logins -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-tzm/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-tzm/strings.xml
@@ -211,7 +211,7 @@
 
     Text for the snackbar to confirm that multiple downloads items have been removed
   -->
-  <string name="download_delete_multiple_items_snackbar_1" moz:removedIn="138" tools:ignore="UnusedResources">ttwakksen wagamen\u0032</string>
+  <string name="download_delete_multiple_items_snackbar_1" moz:removedIn="138" tools:ignore="UnusedResources">ttwakksen wagamen\u0020</string>
   <!-- Text for the button to remove a single download item -->
   <string name="download_delete_item_1" moz:removedIn="138" tools:ignore="UnusedResources">Kkes</string>
   <!-- Close tab button text on the tab crash page -->
@@ -330,7 +330,7 @@
   <!-- The header for the expiration date of a credit card -->
   <string name="credit_cards_expiration_date">Azemz n taggara</string>
   <!-- The label for the expiration date month of a credit card to be used by a11y services -->
-  <string name="credit_cards_expiration_date_month">Ayyur n uzemz n taggar\u0032</string>
+  <string name="credit_cards_expiration_date_month">Ayyur n uzemz n taggar\u0020</string>
   <!-- The label for the expiration date year of a credit card to be used by a11y services -->
   <string name="credit_cards_expiration_date_year">Azemz n taggar n useggas</string>
   <!-- The header for the name on the credit card -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-ug/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ug/strings.xml
@@ -62,8 +62,8 @@
     Explanation for private browsing displayed to users on home view when they first enable private mode.
     %1$s is the name of the app (for example "Firefox").
   -->
-  <string name="private_browsing_placeholder_description_2">\u0032ئەپنى تاقىغان تياكى چېكىنگەندە %1$s شەخسىي بەتكۈچلەردىن ئىزدەش ۋە زىيارەت تارىخىڭىزنى تازىلايدۇ. گەرچە بۇ سىزنى تور بېكەت ياكى ئىنتېرنېت مۇلازىمەت تەمىنلىگۈچىڭىزگە نىسبەتەن ئاتسىز قىلمىسىمۇ ئەمما توردا نېمە ئىش قىلغانلىقىڭىزنى مەزكۇر ئۈسكۈنىنى ئىشلىتىدىغان باشقا كىشىلەردىن سىر تۇرۇشنى ئاسانلاشتۇرىدۇ.</string>
-  <string name="private_browsing_common_myths">\u0032شەخسىيەت زىيارىتى ھەققىدە كۆپ ئۇچرايدىغان قاراشلار</string>
+  <string name="private_browsing_placeholder_description_2">\u0020ئەپنى تاقىغان تياكى چېكىنگەندە %1$s شەخسىي بەتكۈچلەردىن ئىزدەش ۋە زىيارەت تارىخىڭىزنى تازىلايدۇ. گەرچە بۇ سىزنى تور بېكەت ياكى ئىنتېرنېت مۇلازىمەت تەمىنلىگۈچىڭىزگە نىسبەتەن ئاتسىز قىلمىسىمۇ ئەمما توردا نېمە ئىش قىلغانلىقىڭىزنى مەزكۇر ئۈسكۈنىنى ئىشلىتىدىغان باشقا كىشىلەردىن سىر تۇرۇشنى ئاسانلاشتۇرىدۇ.</string>
+  <string name="private_browsing_common_myths">\u0020شەخسىيەت زىيارىتى ھەققىدە كۆپ ئۇچرايدىغان قاراشلار</string>
   <!--
     True Private Browsing Mode
 
@@ -116,7 +116,7 @@
   -->
   <string name="navbar_cfr_title" moz:removedIn="140" tools:ignore="UnusedResources">يېڭى يولباشچى ئىشلىتىلسە، تور كۆرگۈ تېزلىشىدۇ</string>
   <!-- Text for the message displayed in the contextual feature recommendation popup promoting the navigation bar. -->
-  <string name="navbar_cfr_message_2" moz:removedIn="140" tools:ignore="UnusedResources">تور بېكەتتە بەتنى دومىلاتقىنىڭىزدا بۇ بالداق ئۆزلۈكىدىن يوشۇرۇلۇپ كۆز يۈگۈرتۈشكە تېخىمۇ كۆپ بوشلۇق ئاجرىتىدۇ.\u0032</string>
+  <string name="navbar_cfr_message_2" moz:removedIn="140" tools:ignore="UnusedResources">تور بېكەتتە بەتنى دومىلاتقىنىڭىزدا بۇ بالداق ئۆزلۈكىدىن يوشۇرۇلۇپ كۆز يۈگۈرتۈشكە تېخىمۇ كۆپ بوشلۇق ئاجرىتىدۇ.\u0020</string>
   <!-- Text for the message displayed for the popup promoting the long press of navigation in the navigation bar. -->
   <string name="navbar_navigation_buttons_cfr_message" moz:removedIn="140" tools:ignore="UnusedResources">يا ئوقنى چېكىپ بېسىپ تۇرۇلسا بۇ بەتكۈچنىڭ تارىخىدىكى بەتلىرى ئارىسىدا ئاتلايدۇ.</string>
   <!--
@@ -1473,7 +1473,7 @@
   <!-- Text for the snackbar to confirm that multiple browsing history items has been deleted -->
   <string name="history_delete_multiple_items_snackbar">تارىخ ئۆچۈرۈلدى</string>
   <!-- Text for the snackbar to confirm that a single browsing history item has been deleted. %1$s is the shortened URL of the deleted history item. -->
-  <string name="history_delete_single_item_snackbar">\u0032%1$s ئۆچۈرۈلدى</string>
+  <string name="history_delete_single_item_snackbar">\u0020%1$s ئۆچۈرۈلدى</string>
   <!-- Context description text for the button to delete a single history item -->
   <string name="history_delete_item">ئۆچۈر</string>
   <!--
@@ -1776,7 +1776,7 @@
     Bookmark snackbar message on deletion
     %1$s is the host part of the URL of the bookmark deleted, if any
   -->
-  <string name="bookmark_deletion_snackbar_message">\u0032%1$s ئۆچۈرۈلدى</string>
+  <string name="bookmark_deletion_snackbar_message">\u0020%1$s ئۆچۈرۈلدى</string>
   <!-- Bookmark snackbar message on deleting multiple bookmarks not including folders -->
   <string name="bookmark_deletion_multiple_snackbar_message_2">خەتكۈچ ئۆچۈرۈلدى</string>
   <!-- Bookmark snackbar message on deleting multiple bookmarks including folders -->
@@ -1991,7 +1991,7 @@
   <!-- An option from the share dialog to sign into sync -->
   <string name="sync_sign_in">قەدەمداشلاشتا تىزىمغا كىرىڭ</string>
   <!-- An option from the three dot menu to sync and save data -->
-  <string name="sync_menu_sync_and_save_data">\u0032سانلىق مەلۇمات قەدەمداش ۋە ساقلاش</string>
+  <string name="sync_menu_sync_and_save_data">\u0020سانلىق مەلۇمات قەدەمداش ۋە ساقلاش</string>
   <!-- An option from the share dialog to send link to all other sync devices -->
   <string name="sync_send_to_all">ھەممە ئۈسكۈنىگە يوللا</string>
   <!-- An option from the share dialog to reconnect to sync -->
@@ -2772,7 +2772,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">دەلىللىگۈچى: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">دەلىللىگۈچى: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">ئۆچۈر</string>
   <!-- Login overflow menu edit button -->
@@ -3019,7 +3019,7 @@
   <!-- Button text on the translations dialog to restore the translated website back to the original untranslated version. -->
   <string name="translations_bottom_sheet_negative_button_restore">ئەسلىنى كۆرسەت</string>
   <!-- Accessibility announcement (not visible, for screen readers etc.) for the translations dialog after restore button was pressed that indicates the original untranslated page was loaded. -->
-  <string name="translations_bottom_sheet_restore_accessibility_announcement">\u0032تەرجىمە قىلىنمىغان ئەسلى بەت يۈكلەندى</string>
+  <string name="translations_bottom_sheet_restore_accessibility_announcement">\u0020تەرجىمە قىلىنمىغان ئەسلى بەت يۈكلەندى</string>
   <!-- Button text on the translations dialog when a translation error appears, used to dismiss the dialog and return to the browser. -->
   <string name="translations_bottom_sheet_negative_button_error">تامام</string>
   <!-- Button text on the translations dialog to begin a translation of the website. -->
@@ -3136,7 +3136,7 @@
     The Delete site dialogue title will appear when the user clicks on a list item.
     %1$s is web site url (for example:"wikipedia.com")
   -->
-  <string name="never_translate_site_dialog_title_preference">\u0032%1$s نى ئۆچۈرەمدۇ؟</string>
+  <string name="never_translate_site_dialog_title_preference">\u0020%1$s نى ئۆچۈرەمدۇ؟</string>
   <!-- The Delete site dialogue positive button will appear when the user clicks on a list item. The site will be deleted. -->
   <string name="never_translate_site_dialog_confirm_delete_preference">ئۆچۈر</string>
   <!-- The Delete site dialogue negative button will appear when the user clicks on a list item. The dialog will be dismissed. -->
@@ -3196,7 +3196,7 @@
     The dialog will be presented when the user requests deletion of a language.
     %1$s is the name of the language, for example, "Spanish" and %2$s is the size in kilobytes or megabytes of the language file.
   -->
-  <string name="delete_language_file_dialog_title">\u0032%1$s (%2$s) نى ئۆچۈرەمدۇ؟</string>
+  <string name="delete_language_file_dialog_title">\u0020%1$s (%2$s) نى ئۆچۈرەمدۇ؟</string>
   <!-- Additional information for the dialog used by the translations feature to confirm deleting a language. %1$s is the name of the app (for example "Firefox"). -->
   <string name="delete_language_file_dialog_message">ئەگەر بۇ تىلنى ئۆچۈرسىڭىز، %1$s تەرجىمە قىلغاندا تىلنى قىسمەن ھالدا غەملەككە چۈشۈرىدۇ.</string>
   <!--

--- a/mozilla-mobile/fenix/app/src/main/res/values-uk/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-uk/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s стирає вашу історію пошуку та перегляду для приватних вкладок, коли ви закриваєте їх чи виходите з програми. Це не робить вас анонімними для вебсайтів чи вашого провайдера, але дозволяє приховати вашу діяльність в інтернеті від будь-кого іншого, хто використовує цей пристрій.</string>
-  <string name="private_browsing_common_myths">\u0032Поширені міфи про приватний перегляд\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Поширені міфи про приватний перегляд\u0020</string>
   <!--
     True Private Browsing Mode
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-ur/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-ur/strings.xml
@@ -265,7 +265,7 @@
   <!-- Preference for account settings -->
   <string name="preferences_account_settings">اکاؤنٹ کی سیٹنگز</string>
   <!-- Preference for enabling url autocomplete -->
-  <string name="preferences_enable_autocomplete_urls">خودکار تکميلURLs\u0032</string>
+  <string name="preferences_enable_autocomplete_urls">خودکار تکميلURLs\u0020</string>
   <!-- Preference for open links in third party apps -->
   <string name="preferences_open_links_in_apps">ایپس میں ربط کھولیں</string>
   <!-- Preference for open download with an external download manager app -->
@@ -1100,7 +1100,7 @@
   <!-- Content Description (for screenreaders etc) read for the button to copy a password in logins -->
   <string name="saved_logins_copy_password">پاس ورڈ نقل کریں</string>
   <!-- Content Description (for screenreaders etc) read for the button to clear a password while editing a login -->
-  <string name="saved_logins_clear_password">پاس ورڈ صاف کریں\u0032</string>
+  <string name="saved_logins_clear_password">پاس ورڈ صاف کریں\u0020</string>
   <!-- Content Description (for screenreaders etc) read for the button to copy a username in logins -->
   <string name="saved_login_copy_username">صارف نام نقل کریں</string>
   <!-- Content Description (for screenreaders etc) read for the button to clear a username while editing a login -->
@@ -1128,7 +1128,7 @@
   <!-- Preference option for syncing credit cards across devices. This is displayed when the user is not signed into sync -->
   <string name="preferences_credit_cards_sync_cards_across_devices">اپنے آلات کے مابین کارڈز سنک کریں</string>
   <!-- Preference option for syncing credit cards across devices. This is displayed when the user is signed into sync -->
-  <string name="preferences_credit_cards_sync_cards">کارڈ سنک کریں\u0032</string>
+  <string name="preferences_credit_cards_sync_cards">کارڈ سنک کریں\u0020</string>
   <!-- Title of the "Add card" screen -->
   <string name="credit_cards_add_card">کارڈ شامل کریں</string>
   <!-- Title of the "Edit card" screen -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-vi/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-vi/strings.xml
@@ -63,7 +63,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s xóa lịch sử tìm kiếm và duyệt web của bạn khỏi các thẻ riêng tư khi bạn đóng chúng hoặc thoát khỏi ứng dụng. Mặc dù điều này không làm cho bạn ẩn danh với các trang web hoặc nhà cung cấp dịch vụ internet của bạn, nhưng nó giúp bạn dễ dàng giữ những gì bạn làm trực tuyến riêng tư với bất kỳ ai khác sử dụng thiết bị này.</string>
-  <string name="private_browsing_common_myths">\u0032Những lầm tưởng phổ biến về duyệt web riêng tư\u0032</string>
+  <string name="private_browsing_common_myths">\u0020Những lầm tưởng phổ biến về duyệt web riêng tư\u0020</string>
   <!--
     True Private Browsing Mode
 
@@ -2461,7 +2461,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">Mật khẩu đã lưu</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">Mật khẩu bạn lưu hoặc đồng bộ hóa với %s sẽ được liệt kê ở đây. Tất cả mật khẩu bạn lưu đều được mã hóa.\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">Mật khẩu bạn lưu hoặc đồng bộ hóa với %s sẽ được liệt kê ở đây. Tất cả mật khẩu bạn lưu đều được mã hóa.\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">Tìm hiểu thêm về đồng bộ hoá</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->
@@ -2720,7 +2720,7 @@
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
   -->
-  <string name="certificate_info_verified_by">Được xác minh bởi: %1$s\u0032</string>
+  <string name="certificate_info_verified_by">Được xác minh bởi: %1$s\u0020</string>
   <!-- Login overflow menu delete button -->
   <string name="login_menu_delete_button">Xóa</string>
   <!-- Login overflow menu edit button -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-yo/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-yo/strings.xml
@@ -15,7 +15,7 @@
   <!-- Content description (not visible, for screen readers etc.): "Private Browsing" menu button. -->
   <string name="content_description_disable_private_browsing_button">Má ṣe ìgbàláyè fún bíráwúsìnnì ìkọ̀kọ̀</string>
   <!-- Placeholder text shown in the search bar before a user enters text for the default engine -->
-  <string name="search_hint">Ṣàwárí tàbí fi àdìrẹ́sì si\u0032</string>
+  <string name="search_hint">Ṣàwárí tàbí fi àdìrẹ́sì si\u0020</string>
   <!-- Placeholder text shown in the search bar when using application search engines -->
   <string name="application_search_hint">Tẹ àwọn òfin wíwá si</string>
   <!-- No Open Tabs Message Description -->
@@ -43,7 +43,7 @@
     %1$s is the name of the app (for example "Firefox").
   -->
   <string name="private_browsing_placeholder_description_2">%1$s pa ìwádìí àti ìtàn ìlọkiri rẹ̀ lórí àwọn táàbù ìkọ̀kọ̀ nígbà tí o bá tì wọ́n tàbí nígbà tí o kò lo áàpù náà mọ́. Ní àkó́kò tí èyí kò sọ ẹ́ di aláìnídáánimọ̀ sí àwọn wẹ́íbusaìtì yí tàbí olùpèsè ìlò íntánẹ́ẹ̀tì rẹ, ó jẹ́ kó rọrùn láti tọ́jú gbogbo ohun tí ò ń ṣe lórí ayélujára sí ìkọ̀kọ̀ fún ẹnikẹ́ni tó bá lo èrọ yìí.</string>
-  <string name="private_browsing_common_myths">Àwọn àròsọ tó wọ́pọ̀ nípa ìlọkiri-oníwẹ́ẹ̀bù ìkọ̀kọ̀\u0032</string>
+  <string name="private_browsing_common_myths">Àwọn àròsọ tó wọ́pọ̀ nípa ìlọkiri-oníwẹ́ẹ̀bù ìkọ̀kọ̀\u0020</string>
   <!-- Text for the negative button to decline adding a Private Browsing shortcut to the Home screen -->
   <string name="cfr_neg_button_text" moz:removedIn="138" tools:ignore="UnusedResources">Rárá o ṣeun</string>
   <!--
@@ -131,7 +131,7 @@
 
     Content description (not visible, for screen readers etc.): Navigate backward (browsing history)
   -->
-  <string name="browser_menu_back">Padà\u0032</string>
+  <string name="browser_menu_back">Padà\u0020</string>
   <!-- Content description (not visible, for screen readers etc.): Navigate forward (browsing history) -->
   <string name="browser_menu_forward">Síwájú</string>
   <!-- Content description (not visible, for screen readers etc.): Refresh current website -->
@@ -232,7 +232,7 @@
   <!-- Text for the button to skip the onboarding on the home onboarding dialog. -->
   <string name="onboarding_home_skip_button">Fò</string>
   <!-- Onboarding home screen sync popup dialog message, shown on top of Recent Synced Tabs in the Jump back in section. -->
-  <string name="sync_cfr_message">Àwọn táàbù rẹ ti ń ṣiṣẹ́ pọ̀! Mú u sókè níbi tí o ti kúrò lóri ẹ̀rọ rẹ mìíràn.\u0032</string>
+  <string name="sync_cfr_message">Àwọn táàbù rẹ ti ń ṣiṣẹ́ pọ̀! Mú u sókè níbi tí o ti kúrò lóri ẹ̀rọ rẹ mìíràn.\u0020</string>
   <!--
     Search Widget
 
@@ -315,7 +315,7 @@
   <!-- Preference for settings related to visual options -->
   <string name="preferences_customize">Ìsọditaraẹni</string>
   <!-- Preference description for banner about signing in -->
-  <string name="preferences_sign_in_description_2">Wọlé láti so táàbù pọ̀, àwọn búkúmaakì, àwọn ọ̀rọ̀ ìpamọ́, àti díẹ̀ si.\u0032</string>
+  <string name="preferences_sign_in_description_2">Wọlé láti so táàbù pọ̀, àwọn búkúmaakì, àwọn ọ̀rọ̀ ìpamọ́, àti díẹ̀ si.\u0020</string>
   <!-- Preference text for account title when there was an error syncing FxA -->
   <string name="preferences_account_sync_error">Tún darapọ̀ láti tún bẹ̀rẹ̀ ìṣiṣẹ́pọ̀ padà</string>
   <!-- Preference for language -->
@@ -604,7 +604,7 @@
   <!-- Text for the new tab button to indicate syncing command on the synced tabs page -->
   <string name="tab_drawer_fab_sync">Ìṣepọ̀</string>
   <!-- Text shown in the menu for sharing all tabs -->
-  <string name="tab_tray_menu_item_share">Pín gbogbo àwọn táàbù\u0032</string>
+  <string name="tab_tray_menu_item_share">Pín gbogbo àwọn táàbù\u0020</string>
   <!-- Text shown in the menu to view recently closed tabs -->
   <string name="tab_tray_menu_recently_closed">Àwọn táàbù tí a ṣẹ̀ṣẹ̀ padé</string>
   <!-- Text shown in the tabs tray inactive tabs section -->
@@ -812,11 +812,11 @@
   <!-- Preference for altering the microphone access for all websites -->
   <string name="preference_phone_feature_microphone">Ẹ̀rọ ìgbóhùnsáfẹ́fẹ́</string>
   <!-- Preference for altering the location access for all websites -->
-  <string name="preference_phone_feature_location">Ibi\u0032</string>
+  <string name="preference_phone_feature_location">Ibi\u0020</string>
   <!-- Preference for altering the notification access for all websites -->
   <string name="preference_phone_feature_notification">Ìfitónilétí</string>
   <!-- Preference for altering the persistent storage access for all websites -->
-  <string name="preference_phone_feature_persistent_storage">Ibi-ìpamọ́ Ìgbàgbogbo\u0032</string>
+  <string name="preference_phone_feature_persistent_storage">Ibi-ìpamọ́ Ìgbàgbogbo\u0020</string>
   <!-- Preference for altering the storage access setting for all websites -->
   <string name="preference_phone_feature_cross_origin_storage_access">Kúkììsì irúfẹ́ ààbò nínú àwọn áàpù wẹ́ẹ̀bù</string>
   <!-- Preference for altering the EME access for all websites -->
@@ -834,7 +834,7 @@
   <!-- Summary of tracking protection preference if tracking protection is set to off -->
   <string name="tracking_protection_off">Pa á</string>
   <!-- Label for global setting that indicates that all video and audio autoplay is allowed -->
-  <string name="preference_option_autoplay_allowed2">Fàyègba ọ́díò àti fídíò\u0032</string>
+  <string name="preference_option_autoplay_allowed2">Fàyègba ọ́díò àti fídíò\u0020</string>
   <!-- Label for site specific setting that indicates that all video and audio autoplay is allowed -->
   <string name="quick_setting_option_autoplay_allowed">Gba ọ́díò àti fídíò lááyè</string>
   <!-- Label that indicates that video and audio autoplay is only allowed over Wi-Fi -->
@@ -1037,7 +1037,7 @@
   <!-- Text for the button to delete browsing data -->
   <string name="preferences_delete_browsing_data_button">Pa dátà bíráwúsìnnì rẹ́</string>
   <!-- Title for the Delete browsing data on quit preference -->
-  <string name="preferences_delete_browsing_data_on_quit">Pa dátà bíráwúsínnì rẹ́ lóri kíkúrò\u0032</string>
+  <string name="preferences_delete_browsing_data_on_quit">Pa dátà bíráwúsínnì rẹ́ lóri kíkúrò\u0020</string>
   <!-- Summary for the Delete browsing data on quit preference. "Quit" translation should match delete_browsing_data_on_quit_action translation. -->
   <string name="preference_summary_delete_browsing_data_on_quit_2">Pa dátà bíráwúsínnì rẹ́ ní aláìfọwọkàn nígbà tí o bá yàn-án \"Jáde\" láti inú àkójọpọ̀ àṣàyàn</string>
   <!-- Action item in menu for the Delete browsing data on quit feature -->
@@ -1073,7 +1073,7 @@
 
     text to display in the snackbar once account is signed-in
   -->
-  <string name="onboarding_firefox_account_sync_is_on">Ìṣepọ̀ wà ní títàn\u0032</string>
+  <string name="onboarding_firefox_account_sync_is_on">Ìṣepọ̀ wà ní títàn\u0020</string>
   <!--
     Onboarding theme
 
@@ -1115,7 +1115,7 @@
   <!-- Preference title for enhanced tracking protection settings -->
   <string name="preference_enhanced_tracking_protection">Ètò ìdáàbòbò tó múnádóko</string>
   <!-- Text displayed that links to website about enhanced tracking protection -->
-  <string name="preference_enhanced_tracking_protection_explanation_learn_more">Kọ́ si\u0032</string>
+  <string name="preference_enhanced_tracking_protection_explanation_learn_more">Kọ́ si\u0020</string>
   <!-- Preference for enhanced tracking protection for the standard protection settings -->
   <string name="preference_enhanced_tracking_protection_standard_default_1">Ìdúródéédé (àìyípadà)</string>
   <!-- Accessibility text for the Standard protection information icon -->
@@ -1137,7 +1137,7 @@
   -->
   <string name="preference_enhanced_tracking_protection_custom_cookies">Àwọn kúkì</string>
   <!-- Option for enhanced tracking protection for the custom protection settings for cookies -->
-  <string name="preference_enhanced_tracking_protection_custom_cookies_1">Kírọ́sì-sáìtì àti olùtọpasẹ̀ ayélujára\u0032</string>
+  <string name="preference_enhanced_tracking_protection_custom_cookies_1">Kírọ́sì-sáìtì àti olùtọpasẹ̀ ayélujára\u0020</string>
   <!-- Option for enhanced tracking protection for the custom protection settings for cookies -->
   <string name="preference_enhanced_tracking_protection_custom_cookies_2">Kúkíìsì láti sáìtì tí a kò ṣàbẹ̀wò sí</string>
   <!-- Option for enhanced tracking protection for the custom protection settings for cookies -->
@@ -1155,7 +1155,7 @@
   <!-- Preference for enhanced tracking protection for the custom protection settings -->
   <string name="preference_enhanced_tracking_protection_custom_cryptominers">Àwọn kíríputomínà</string>
   <!-- Button label for navigating to the Enhanced Tracking Protection details -->
-  <string name="enhanced_tracking_protection_details">Ẹ̀kúnrẹ́rẹ́\u0032</string>
+  <string name="enhanced_tracking_protection_details">Ẹ̀kúnrẹ́rẹ́\u0020</string>
   <!-- Header for categories that are being being blocked by current Enhanced Tracking Protection settings -->
   <string name="enhanced_tracking_protection_blocked">Ti dènà</string>
   <!-- Header for categories that are being not being blocked by current Enhanced Tracking Protection settings -->
@@ -1167,11 +1167,11 @@
   <!-- Category of trackers (cross-site tracking cookies) that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_cookies_title">Ìtọpasẹ̀ Kúkíìsì Kírọ́sí-Sáìtì</string>
   <!-- Category of trackers (cross-site tracking cookies) that can be blocked by Enhanced Tracking Protection -->
-  <string name="etp_cookies_title_2">\u0032Kúkíìsì Kírọ́sí-Sáìtì</string>
+  <string name="etp_cookies_title_2">\u0020Kúkíìsì Kírọ́sí-Sáìtì</string>
   <!-- Description of cross-site tracking cookies that can be blocked by Enhanced Tracking Protection -->
-  <string name="etp_cookies_description">Ṣe ìdínnàmọ́ kúkíìsì tí àwọn nẹ́tíwọọ̀kì ìpolówó àti àwọn ilé-iṣẹ́ àwọn ìṣètúpalẹ̀ ń lò láti ṣe àkójọ àwọn dátà bíráwúsínnì rẹ kárí ọ̀pọ̀ àwọn sáìtì.\u0032</string>
+  <string name="etp_cookies_description">Ṣe ìdínnàmọ́ kúkíìsì tí àwọn nẹ́tíwọọ̀kì ìpolówó àti àwọn ilé-iṣẹ́ àwọn ìṣètúpalẹ̀ ń lò láti ṣe àkójọ àwọn dátà bíráwúsínnì rẹ kárí ọ̀pọ̀ àwọn sáìtì.\u0020</string>
   <!-- Description of cross-site tracking cookies that can be blocked by Enhanced Tracking Protection -->
-  <string name="etp_cookies_description_2">Àpapọ̀ ìdáábòbò Kúkì ṣe ìyàsọ́tọ̀ kúkíìsì sí sáìtì tí o wà lóri rẹ̀ kí àwọn olùtọpasẹ̀ bí i àwọn nẹ́tíwọọ̀kì ìpolówó lé è máá rìi lò láti tẹ̀lé ọ kiri gbogbo àwọn sáìtì.\u0032</string>
+  <string name="etp_cookies_description_2">Àpapọ̀ ìdáábòbò Kúkì ṣe ìyàsọ́tọ̀ kúkíìsì sí sáìtì tí o wà lóri rẹ̀ kí àwọn olùtọpasẹ̀ bí i àwọn nẹ́tíwọọ̀kì ìpolówó lé è máá rìi lò láti tẹ̀lé ọ kiri gbogbo àwọn sáìtì.\u0020</string>
   <!-- Category of trackers (cryptominers) that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_cryptominers_title">Àwọn kíríputomínà</string>
   <!-- Description of cryptominers that can be blocked by Enhanced Tracking Protection -->
@@ -1183,7 +1183,7 @@
   <!-- Enhanced Tracking Protection message that protection is currently on for this site -->
   <string name="etp_panel_on">Àwọn ìdáàbòbò wà ní TÍTÀN fún sáìtì yìí</string>
   <!-- Enhanced Tracking Protection message that protection is currently off for this site -->
-  <string name="etp_panel_off">Àwọn ìdáábòbò wà ní PÍPA fún sáìtì yìí\u0032</string>
+  <string name="etp_panel_off">Àwọn ìdáábòbò wà ní PÍPA fún sáìtì yìí\u0020</string>
   <!-- Header for exceptions list for which sites enhanced tracking protection is always off -->
   <string name="enhanced_tracking_protection_exceptions">Ètò ìdáàbòbò tó múná ti wà ní pípa fún àwọn ojú òpó wẹ́ẹ̀bù yìí</string>
   <!--
@@ -1201,16 +1201,16 @@
   <!-- Category of trackers (redirect trackers) that can be blocked by Enhanced Tracking Protection -->
   <string name="etp_redirect_trackers_title">Àtúnjúwe Àwọn ohun ìtọpasè</string>
   <!-- Description of redirect tracker cookies that can be blocked by Enhanced Tracking Protection -->
-  <string name="etp_redirect_trackers_description">Pa kúkíìsì rẹ́ ètò tí àwọn aṣàtúnjúwe ṣe sí ìtọpasẹ̀ àwọn ojú ọ̀pọ́ wẹ́ẹ̀bù tí a mọ̀.\u0032</string>
+  <string name="etp_redirect_trackers_description">Pa kúkíìsì rẹ́ ètò tí àwọn aṣàtúnjúwe ṣe sí ìtọpasẹ̀ àwọn ojú ọ̀pọ́ wẹ́ẹ̀bù tí a mọ̀.\u0020</string>
   <!--
     Description of the SmartBlock Enhanced Tracking Protection feature. The * symbol is intentionally hardcoded here,
     as we use it on the UI to indicate which trackers have been partially unblocked.
   -->
   <string name="preference_etp_smartblock_description">Nínú àwọn olùtọpasẹ̀ tí o ṣàmìsí ní ìsàlẹ̀ ti jẹ́ ṣíṣí sílẹ̀ lóri ojú-ìwé yìí nítorí pé o ní àjọṣepọ̀ pẹ̀lú wọn *.</string>
   <!-- Text displayed that links to website about enhanced tracking protection SmartBlock -->
-  <string name="preference_etp_smartblock_learn_more">Kọ́ si\u0032</string>
+  <string name="preference_etp_smartblock_learn_more">Kọ́ si\u0020</string>
   <!-- About page link text to open support link -->
-  <string name="about_support">Àtìlẹ́yìn\u0032</string>
+  <string name="about_support">Àtìlẹ́yìn\u0020</string>
   <!-- About page link text to list of past crashes (like about:crashes on desktop) -->
   <string name="about_crashes">Àwọn ìjàmbá</string>
   <!-- About page link text to open privacy notice link -->
@@ -1286,7 +1286,7 @@
   <!-- Content Description (for screenreaders etc) read for the button to clear a username while editing a login -->
   <string name="saved_login_clear_username">Pa orúkọ aṣàmúlò rẹ́</string>
   <!-- Content Description (for screenreaders etc) read for the button to clear the hostname field while creating a login -->
-  <string name="saved_login_clear_hostname">Pa orúkọ nẹ́tíwọọ̀kì kọ̀m̀pútà rẹ́\u0032</string>
+  <string name="saved_login_clear_hostname">Pa orúkọ nẹ́tíwọọ̀kì kọ̀m̀pútà rẹ́\u0020</string>
   <!-- Content Description (for screenreaders etc) read for the button to open a site in logins -->
   <string name="saved_login_open_site">Ṣí sáìtì nínu bíráwúsà</string>
   <!-- Content Description (for screenreaders etc) read for the button to reveal a password in logins -->
@@ -1300,7 +1300,7 @@
   <!-- Title of PIN verification dialog to direct users to re-enter their device credentials to access their logins -->
   <string name="logins_biometric_prompt_message_pin">Ṣí ẹ̀rọ rẹ</string>
   <!-- Title for Accessibility Force Enable Zoom Preference -->
-  <string name="preference_accessibility_force_enable_zoom">Sún-un mọ́ra lóri gbogbo àwọn ojú òpó wẹ́ẹ̀bù\u0032</string>
+  <string name="preference_accessibility_force_enable_zoom">Sún-un mọ́ra lóri gbogbo àwọn ojú òpó wẹ́ẹ̀bù\u0020</string>
   <!-- Summary for Accessibility Force Enable Zoom Preference -->
   <string name="preference_accessibility_force_enable_zoom_summary">Láti jẹ́ kí ó fàyè gba ìfúnpọ̀ àti fífẹ̀, àti lórí wẹ́íbusaìtì tí kò gba ìrúfẹ́ ìfihàn yìí.</string>
   <!-- Saved logins sorting strategy menu item -by name- (if selected, it will sort saved logins alphabetically) -->
@@ -1450,7 +1450,7 @@
   <!-- Browser menu button that adds a shortcut to the home fragment -->
   <string name="browser_menu_add_to_shortcuts">Ṣàfikún àwọn ọ̀nà-àbùjá</string>
   <!-- Browser menu button that removes a shortcut from the home fragment -->
-  <string name="browser_menu_remove_from_shortcuts">Yọọ́ kúrò nínú àwọn ọ̀nà-àbùjá\u0032</string>
+  <string name="browser_menu_remove_from_shortcuts">Yọọ́ kúrò nínú àwọn ọ̀nà-àbùjá\u0020</string>
   <!--
     text shown before the issuer name to indicate who its verified by, %1$s is the name of
     the certificate authority that verified the ticket
@@ -1477,7 +1477,7 @@
   <!-- This is an error message shown below the hostname field of the add login page when a hostname does not contain http or https. -->
   <string name="add_login_hostname_invalid_text_3">Àdírẹ́sì wẹ́ẹ̀bù gbọ́dọ̀ ní \"https://\" tàbí \"http://\"</string>
   <!-- This is an error message shown below the hostname field of the add login page when a hostname is invalid. -->
-  <string name="add_login_hostname_invalid_text_2">A nílò orúkọ nẹ́tíwọọ̀kì kọ̀m̀pútà tó tẹ̀wọ̀n\u0032</string>
+  <string name="add_login_hostname_invalid_text_2">A nílò orúkọ nẹ́tíwọọ̀kì kọ̀m̀pútà tó tẹ̀wọ̀n\u0020</string>
   <!--
     Synced Tabs
 

--- a/mozilla-mobile/fenix/app/src/main/res/values-zh-rCN/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-zh-rCN/strings.xml
@@ -2461,7 +2461,7 @@
   <!-- Preference to access list of saved passwords -->
   <string name="preferences_passwords_saved_logins_2">保存的密码</string>
   <!-- Description of empty list of saved passwords. %s is the name of the app (for example "Firefox"). -->
-  <string name="preferences_passwords_saved_logins_description_empty_text_2">保存和同步到 %s 的密码会显示在这里，所有密码均已加密保存。\u0032</string>
+  <string name="preferences_passwords_saved_logins_description_empty_text_2">保存和同步到 %s 的密码会显示在这里，所有密码均已加密保存。\u0020</string>
   <!-- Clickable text for opening an external link for more information about Sync. -->
   <string name="preferences_passwords_saved_logins_description_empty_learn_more_link_2">详细了解同步功能</string>
   <!-- Preference to access list of login exceptions that we never save logins for -->

--- a/mozilla-mobile/fenix/app/src/main/res/values-zh-rTW/strings.xml
+++ b/mozilla-mobile/fenix/app/src/main/res/values-zh-rTW/strings.xml
@@ -2116,7 +2116,7 @@
   <!-- Message for copying the URL via long press on the toolbar -->
   <string name="url_copied">已複製網址</string>
   <!-- Sample text for accessibility font size -->
-  <string name="accessibility_text_size_sample_text_1">This is sample text. It is here to show how text will appear when you increase or decrease the size with this setting.\n中文字型測試：「老闆，來一杯大杯珍奶，半糖去冰！」\u0032</string>
+  <string name="accessibility_text_size_sample_text_1">This is sample text. It is here to show how text will appear when you increase or decrease the size with this setting.\n中文字型測試：「老闆，來一杯大杯珍奶，半糖去冰！」\u0020</string>
   <!-- Summary for Accessibility Text Size Scaling Preference -->
   <string name="preference_accessibility_text_size_summary">放大或縮小網站上的文字</string>
   <!-- Title for Accessibility Text Size Scaling Preference -->


### PR DESCRIPTION
This is fixing the fallout from mozilla/moz-l10n#78. Merging this should be coordinated together with a Pontoon production update.